### PR TITLE
pkg/operator: only set storage class annotation if given

### DIFF
--- a/pkg/operator/petset.go
+++ b/pkg/operator/petset.go
@@ -64,15 +64,17 @@ func makePetSet(p *spec.Prometheus, old *v1alpha1.PetSet, alertmanagers []string
 		pvc := v1.PersistentVolumeClaim{
 			ObjectMeta: v1.ObjectMeta{
 				Name: fmt.Sprintf("%s-db", p.Name),
-				Annotations: map[string]string{
-					"volume.beta.kubernetes.io/storage-class": vc.Class,
-				},
 			},
 			Spec: v1.PersistentVolumeClaimSpec{
 				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				Resources:   vc.Resources,
 				Selector:    vc.Selector,
 			},
+		}
+		if len(vc.Class) > 0 {
+			pvc.ObjectMeta.Annotations = map[string]string{
+				"volume.beta.kubernetes.io/storage-class": vc.Class,
+			}
 		}
 		petset.Spec.VolumeClaimTemplates = append(petset.Spec.VolumeClaimTemplates, pvc)
 	}


### PR DESCRIPTION
When the value of the annotation is empty the cluster still tries to
auto provision the PVC/PV.

This fix allows users to specify the variables for the PVC Template
without requiring auto provisioning of PVs.