### PR TITLE
pkg/operator: fix flag typo

### DIFF
--- a/example/node-exporter-bundle.yaml
+++ b/example/node-exporter-bundle.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+  labels:
+    app: node-exporter
+    name: node-exporter
+  name: node-exporter
+spec:
+  clusterIP: None
+  ports:
+  - name: scrape
+    port: 9100
+    protocol: TCP
+  selector:
+    app: node-exporter
+  type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+spec:
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+      name: node-exporter
+    spec:
+      containers:
+      - image: prom/node-exporter
+        name: node-exporter
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: metrics
+      hostNetwork: true
+      hostPID: true

--- a/example/node-exporter-monitor.yaml
+++ b/example/node-exporter-monitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: "monitoring.coreos.com/v1"
+apiVersion: "monitoring.coreos.com/v1alpha1"
 kind: "ServiceMonitor"
 metadata:
   name: "node-exporter"

--- a/pkg/operator/petset.go
+++ b/pkg/operator/petset.go
@@ -174,7 +174,7 @@ func makePetSetSpec(p spec.Prometheus, alertmanagers []string) v1alpha1.PetSetSp
 						Args: []string{
 							"-storage.local.retention=" + p.Spec.Retention,
 							"-storage.local.memory-chunks=" + fmt.Sprintf("%d", memChunks),
-							"-storage.local.max-chunks-to-persist" + fmt.Sprintf("%d", memChunks/2),
+							"-storage.local.max-chunks-to-persist=" + fmt.Sprintf("%d", memChunks/2),
 							"-storage.local.num-fingerprint-mutexes=4096",
 							"-storage.local.path=/var/prometheus/data",
 							"-config.file=/etc/prometheus/config/prometheus.yaml",


### PR DESCRIPTION
Added the node exporter manifests here for testing purposes and so they won't pollute the Alertmanager PR. Let me know if you think that's ok. The actual fix is in `pkg/operator/petset.go`.

@fabxc 