### PR TITLE
Add jobLabel field

### DIFF
--- a/Documentation/service-monitor.md
+++ b/Documentation/service-monitor.md
@@ -27,6 +27,7 @@ of the service endpoints. This is also made possible by the Prometheus Operator.
 
 | Name | Description | Required | Schema | Default |
 | ---- | ----------- | -------- | ------ | ------- |
+| jobLabel | Service label of which the value is used to assemble a job name of the form `<label value>-<port>`. If no label is specified, the service name is used. | false | string |  |
 | selector | Label selector for services the `ServiceMonitor` applies to. | true | [unversioned.LabelSelector](http://kubernetes.io/docs/api-reference/v1/definitions/#_unversioned_labelselector) | |
 | endpoints | The endpoints to be monitored for endpoints of the selected services. | true | Endpoint array | |
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -106,6 +106,19 @@ scrape_configs:
     target_label: "job"
     replacement: "${1}-{{ $ep.TargetPort.String }}"
   {{- end}}
+  {{- if ne $mon.Spec.JobLabel "" }}
+    {{- if ne $ep.Port "" }}
+  - source_labels: ["__meta_kubernetes_service_label_{{ $mon.Spec.JobLabel }}"]
+    regex: "(.+)"
+    target_label: "job"
+    replacement: "${1}-{{ $ep.Port }}"
+    {{- else if ne $ep.TargetPort.String "" }}
+  - source_labels: ["__meta_kubernetes_service_label_{{ $mon.Spec.JobLabel }}"]
+    regex: "(.+)"
+    target_label: "job"
+    replacement: "${1}-{{ $ep.TargetPort.String }}"
+    {{- end}}
+  {{- end}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -85,6 +85,7 @@ type ServiceMonitor struct {
 
 // ServiceMonitorSpec contains specification parameters for a ServiceMonitor.
 type ServiceMonitorSpec struct {
+	JobLabel  string                    `json:"jobLabel"`
 	Endpoints []Endpoint                `json:"endpoints"`
 	Selector  unversioned.LabelSelector `json:"selector"`
 	// AllNamespaces     bool                      `json:"allNamespaces"`


### PR DESCRIPTION
The jobLabel field allows generating safe job names based on labels.
This is necessary for services running the same application to have the
same job name even though their direct service names are different.

The default case still falls back to the plain service name.

@brancz 