### PR TITLE
Namespace selection and service label set matching

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -15,111 +15,150 @@
 package prometheus
 
 import (
-	"html/template"
+	"fmt"
+
+	yaml "gopkg.in/yaml.v1"
 
 	"github.com/coreos/prometheus-operator/pkg/spec"
 )
 
-type templateConfig struct {
-	Prometheus      spec.PrometheusSpec
-	ServiceMonitors map[string]*spec.ServiceMonitor
+func generateConfig(p *spec.Prometheus, mons map[string]*spec.ServiceMonitor) ([]byte, error) {
+	cfg := map[string]interface{}{}
+
+	global := map[string]string{
+		"evaluation_interval": "30s",
+	}
+	if p.Spec.EvaluationInterval != "" {
+		global["evaluation_interval"] = p.Spec.EvaluationInterval
+	}
+
+	cfg["global"] = global
+	cfg["rule_files"] = []string{"/etc/prometheus/rules/*.rules"}
+
+	var scrapeConfigs []interface{}
+	for _, mon := range mons {
+		for i, ep := range mon.Spec.Endpoints {
+			scrapeConfigs = append(scrapeConfigs, generateServiceMonitorConfig(mon, ep, i))
+		}
+	}
+
+	cfg["scrape_configs"] = scrapeConfigs
+
+	return yaml.Marshal(cfg)
 }
 
-var configTmpl = template.Must(template.New("config").Parse(`
-{{- block "globals" . }}
-global:
-  {{- if ne .Prometheus.EvaluationInterval "" }}
-  evaluation_interval: {{ .Prometheus.EvaluationInterval }}
-  {{- else }}
-  evaluation_interval: 30s
-  {{- end }}
-{{- end}}
+func generateServiceMonitorConfig(m *spec.ServiceMonitor, ep spec.Endpoint, i int) interface{} {
+	cfg := map[string]interface{}{
+		"job_name": fmt.Sprintf("%s/%s/%d", m.Namespace, m.Name, i),
+		"kubernetes_sd_configs": []map[string]interface{}{
+			{
+				"role": "endpoints",
+			},
+		},
+	}
 
-rule_files:
-- /etc/prometheus/rules/*.rules
+	if ep.Interval != "" {
+		cfg["scrape_interval"] = ep.Interval
+	}
+	if ep.Path != "" {
+		cfg["metrics_path"] = ep.Path
+	}
+	if ep.Scheme != "" {
+		cfg["scheme"] = ep.Scheme
+	}
 
-{{ block "scrapeConfigs" . }}
-scrape_configs:
-{{- range $mon := .ServiceMonitors }}
-{{- range $i, $ep := $mon.Spec.Endpoints }}
-- job_name: "{{ $mon.Namespace }}/{{ $mon.Name }}/{{ $i }}"
+	var relabelings []interface{}
 
-  {{- if ne $ep.Interval "" }}
-  scrape_interval: "{{ $ep.Interval }}"
-  {{- end }}
-  {{- if ne $ep.Path "" }}
-  metrics_path: "{{ $ep.Path }}"
-  {{- end }}
-  {{- if ne $ep.Scheme "" }}
-  scheme: "{{ $ep.Scheme }}"
-  {{- end }}
+	// Filter targets by services selected by the monitor.
+	for k, v := range m.Spec.Selector.MatchLabels {
+		relabelings = append(relabelings, map[string]interface{}{
+			"action":        "keep",
+			"source_labels": []string{"__meta_kubernetes_service_label_" + k},
+			"regex":         v,
+		})
+	}
 
-  kubernetes_sd_configs:
-  - role: endpoints
+	// Filter targets based on correct port for the endpoint.
+	if ep.Port != "" {
+		relabelings = append(relabelings, map[string]interface{}{
+			"action":        "keep",
+			"source_labels": []string{"__meta_kubernetes_endpoint_port_name"},
+			"regex":         ep.Port,
+		})
+	} else if ep.TargetPort.StrVal != "" {
+		relabelings = append(relabelings, map[string]interface{}{
+			"action":        "keep",
+			"source_labels": []string{"__meta_kubernetes_container_port_name"},
+			"regex":         ep.TargetPort.String(),
+		})
+	} else if ep.TargetPort.IntVal != 0 {
+		relabelings = append(relabelings, map[string]interface{}{
+			"action":        "keep",
+			"source_labels": []string{"__meta_kubernetes_container_port_number"},
+			"regex":         ep.TargetPort.String(),
+		})
+	}
 
-  relabel_configs:
-  # 
-  # FILTERING
-  #
-  {{- range $k, $v := $mon.Spec.Selector.MatchLabels }}
-  - action: "keep"
-    source_labels: ["__meta_kubernetes_service_label_{{ $k }}"]
-    regex: "{{ $v }}"
-  {{- end }}
-  {{- if ne $ep.Port "" }}
-  - action: "keep"
-    source_labels: ["__meta_kubernetes_endpoint_port_name"]
-    regex: "{{ $ep.Port }}"
-  {{- else if ne $ep.TargetPort.StrVal "" }}
-  - action: "keep"
-    source_labels: ["__meta_kubernetes_pod_container_port_name"]
-    regex: "{{ $ep.TargetPort.String }}"
-  {{- else if ne $ep.TargetPort.IntVal 0 }}
-  - action: "keep"
-    source_labels: ["__meta_kubernetes_pod_container_port_number"]
-    regex: "{{ $ep.TargetPort.String }}"
-  {{- end }}
-  # 
-  # TARGET LABELS
-  #
-  - source_labels: ["__meta_kubernetes_namespace"]
-    target_label: "namespace"
-  - action: "labelmap"
-    regex: "__meta_kubernetes_service_label_(.+)"
-    replacement: "svc_$1"
-  - # Drop 'pod_template_hash' label that's set by deployment controller.
-    action: replace
-    target_label: "__meta_kubernetes_pod_label_pod_template_hash"
-    replacement: ""
-  - action: "labelmap"
-    regex: "__meta_kubernetes_pod_label_(.+)"
-    replacement: "pod_$1"
-  # 
-  # JOB LABEL
-  #
-  {{- if ne $ep.Port "" }}
-  - source_labels: ["__meta_kubernetes_service_name"]
-    target_label: "job"
-    replacement: "${1}-{{ $ep.Port }}"
-  {{- else if ne $ep.TargetPort.String "" }}
-  - source_labels: ["__meta_kubernetes_service_name"]
-    target_label: "job"
-    replacement: "${1}-{{ $ep.TargetPort.String }}"
-  {{- end}}
-  {{- if ne $mon.Spec.JobLabel "" }}
-    {{- if ne $ep.Port "" }}
-  - source_labels: ["__meta_kubernetes_service_label_{{ $mon.Spec.JobLabel }}"]
-    regex: "(.+)"
-    target_label: "job"
-    replacement: "${1}-{{ $ep.Port }}"
-    {{- else if ne $ep.TargetPort.String "" }}
-  - source_labels: ["__meta_kubernetes_service_label_{{ $mon.Spec.JobLabel }}"]
-    regex: "(.+)"
-    target_label: "job"
-    replacement: "${1}-{{ $ep.TargetPort.String }}"
-    {{- end}}
-  {{- end}}
-{{- end }}
-{{- end }}
-{{- end }}
-`))
+	// Relabel namespace and pod and service labels into proper labels.
+	relabelings = append(relabelings, []interface{}{
+		map[string]interface{}{
+			"source_labels": []string{"__meta_kubernetes_namespace"},
+			"target_label":  "namespace",
+		},
+		map[string]interface{}{
+			"action":      "labelmap",
+			"regex":       "__meta_kubernetes_service_label_(.+)",
+			"replacement": "svc_$1",
+		},
+		map[string]interface{}{
+			"action":       "replace",
+			"target_label": "__meta_kubernetes_pod_label_pod_template_hash",
+			"replacement":  "",
+		},
+		map[string]interface{}{
+			"action":      "labelmap",
+			"regex":       "__meta_kubernetes_pod_label_(.+)",
+			"replacement": "pod_$1",
+		},
+	}...)
+
+	// By default, generate a safe job name from the service name and scraped port.
+	// We also keep this around if a jobLabel is set in case the targets don't actually
+	// have a value for it.
+	if ep.Port != "" {
+		relabelings = append(relabelings, map[string]interface{}{
+			"source_labels": []string{"__meta_kubernetes_service_name"},
+			"target_label":  "job",
+			"replacement":   "${1}-" + ep.Port,
+		})
+	} else if ep.TargetPort.String() != "" {
+		relabelings = append(relabelings, map[string]interface{}{
+			"source_labels": []string{"__meta_kubernetes_service_name"},
+			"target_label":  "job",
+			"replacement":   "${1}-" + ep.TargetPort.String(),
+		})
+	}
+	// Generate a job name with a base label. Same as above, just that we
+	// get the base from the label, if present.
+	if m.Spec.JobLabel != "" {
+		if ep.Port != "" {
+			relabelings = append(relabelings, map[string]interface{}{
+				"source_labels": []string{"__meta_kubernetes_service_label_" + m.Spec.JobLabel},
+				"target_label":  "job",
+				"regex":         "(.+)",
+				"replacement":   "${1}-" + ep.Port,
+			})
+		} else if ep.TargetPort.String() != "" {
+			relabelings = append(relabelings, map[string]interface{}{
+				"source_labels": []string{"__meta_kubernetes_service_label_" + m.Spec.JobLabel},
+				"target_label":  "job",
+				"regex":         "(.+)",
+				"replacement":   "${1}-" + ep.TargetPort.String(),
+			})
+		}
+	}
+
+	cfg["relabel_configs"] = relabelings
+
+	return cfg
+}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -25,14 +25,11 @@ import (
 func generateConfig(p *spec.Prometheus, mons map[string]*spec.ServiceMonitor) ([]byte, error) {
 	cfg := map[string]interface{}{}
 
-	global := map[string]string{
+	cfg["global"] = map[string]string{
 		"evaluation_interval": "30s",
-	}
-	if p.Spec.EvaluationInterval != "" {
-		global["evaluation_interval"] = p.Spec.EvaluationInterval
+		"scrape_interval":     "30s",
 	}
 
-	cfg["global"] = global
 	cfg["rule_files"] = []string{"/etc/prometheus/rules/*.rules"}
 
 	var scrapeConfigs []interface{}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -86,7 +86,7 @@ type ServiceMonitorSpec struct {
 	JobLabel          string                    `json:"jobLabel"`
 	Endpoints         []Endpoint                `json:"endpoints"`
 	Selector          unversioned.LabelSelector `json:"selector"`
-	NamespaceSelector *Selector                 `json:"namespaceSelector"`
+	NamespaceSelector Selector                  `json:"namespaceSelector"`
 	// AllNamespaces     bool                      `json:"allNamespaces"`
 	// Namespaces        []string                  `json:"namespaces"`
 	// NamespaceSelector unversioned.LabelSelector `json:"namespaceSelector"`
@@ -139,7 +139,10 @@ type AlertmanagerList struct {
 }
 
 type Selector struct {
-	unversioned.LabelSelector `json:",inline"`
-	Any                       bool     `json:"any,omitempty"`
-	MatchNames                []string `json:"matchNames,omitempty"`
+	Any        bool     `json:"any,omitempty"`
+	MatchNames []string `json:"matchNames,omitempty"`
+
+	// TODO(fabxc): this should embed unversioned.LabelSelector eventually.
+	// Currently the selector is only used for namespaces which require more complex
+	// implementation to support label selections.
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -37,18 +37,16 @@ type PrometheusList struct {
 
 // PrometheusSpec holds specification parameters of a Prometheus deployment.
 type PrometheusSpec struct {
-	ServiceMonitors    []ServiceMonitorSelection `json:"serviceMonitors"`
-	EvaluationInterval string                    `json:"evaluationInterval"`
-	Version            string                    `json:"version"`
-	BaseImage          string                    `json:"baseImage"`
-	Replicas           int32                     `json:"replicas"`
-	Retention          string                    `json:"retention"`
-	Storage            *StorageSpec              `json:"storage"`
-	Alerting           AlertingSpec              `json:"alerting"`
-	Resources          v1.ResourceRequirements   `json:"resources"`
-	// Alerting        AlertingSpec               `json:"alerting"`
+	ServiceMonitors []ServiceMonitorSelection `json:"serviceMonitors"`
+	Version         string                    `json:"version"`
+	BaseImage       string                    `json:"baseImage"`
+	Replicas        int32                     `json:"replicas"`
+	Retention       string                    `json:"retention"`
+	Storage         *StorageSpec              `json:"storage"`
+	Alerting        AlertingSpec              `json:"alerting"`
+	Resources       v1.ResourceRequirements   `json:"resources"`
+	// EvaluationInterval string                    `json:"evaluationInterval"`
 	// Remote          RemoteSpec                 `json:"remote"`
-	// Persistence...
 	// Sharding...
 }
 

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -85,9 +85,10 @@ type ServiceMonitor struct {
 
 // ServiceMonitorSpec contains specification parameters for a ServiceMonitor.
 type ServiceMonitorSpec struct {
-	JobLabel  string                    `json:"jobLabel"`
-	Endpoints []Endpoint                `json:"endpoints"`
-	Selector  unversioned.LabelSelector `json:"selector"`
+	JobLabel          string                    `json:"jobLabel"`
+	Endpoints         []Endpoint                `json:"endpoints"`
+	Selector          unversioned.LabelSelector `json:"selector"`
+	NamespaceSelector *Selector                 `json:"namespaceSelector"`
 	// AllNamespaces     bool                      `json:"allNamespaces"`
 	// Namespaces        []string                  `json:"namespaces"`
 	// NamespaceSelector unversioned.LabelSelector `json:"namespaceSelector"`
@@ -137,4 +138,10 @@ type AlertmanagerList struct {
 	unversioned.ListMeta `json:"metadata,omitempty"`
 	// Items is a list of third party objects
 	Items []Alertmanager `json:"items"`
+}
+
+type Selector struct {
+	unversioned.LabelSelector `json:",inline"`
+	Any                       bool     `json:"any,omitempty"`
+	MatchNames                []string `json:"matchNames,omitempty"`
 }


### PR DESCRIPTION
@brancz 

This implements selection by "any" and a list of names for namespaces. By default it only includes the namespace of the specified ServiceMonitor. (As discussed in #39)
This is just based on my idea on this issue – there was not opinions stated towards either of the options.

Configuration is now generated without templates. Still not using config types but notably safer and saner nonetheless.

Also added mapping of the label selections via set operations to the appropriate relabeling configs.