### PR TITLE
prometheus: fix queue staleness and deadlock

### DIFF
--- a/example/prometheus.yaml
+++ b/example/prometheus.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     prometheus: "main"
 spec:
-  replicas: 1
-  version: v1.3.1
+  replicas: 2
+  version: v1.4.0
   serviceMonitorSelector:
     matchExpressions:
     - {key: app, operator: In, values: [node-exporter, example-app]}
@@ -14,3 +14,6 @@ spec:
     alertmanagers:
     - namespace: monitoring
       name: alertmanager-main
+  resources:
+    requests:
+      memory: 400Mi

--- a/example/prometheus.yaml
+++ b/example/prometheus.yaml
@@ -12,8 +12,9 @@ spec:
     - {key: app, operator: In, values: [node-exporter, example-app]}
   alerting:
     alertmanagers:
-    - namespace: monitoring
-      name: alertmanager-main
+    - namespace: default
+      name: alertmanager
+      port: web
   resources:
     requests:
       memory: 400Mi

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,0 +1,147 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import "sync"
+
+// New constructs a new workqueue.
+func New() *Queue {
+	return &Queue{
+		dirty:      set{},
+		processing: set{},
+		cond:       sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+// Queue is a work queue.
+type Queue struct {
+	// queue defines the order in which we will work on items. Every
+	// element of queue should be in the dirty set and not in the
+	// processing set.
+	queue []t
+
+	// dirty defines all of the items that need to be processed.
+	dirty set
+
+	// Things that are currently being processed are in the processing set.
+	// These things may be simultaneously in the dirty set. When we finish
+	// processing something and remove it from this set, we'll check if
+	// it's in the dirty set, and if so, add it to the queue.
+	processing set
+
+	cond *sync.Cond
+
+	shuttingDown bool
+}
+
+type empty struct{}
+type t interface{}
+type set map[t]empty
+
+func (s set) has(item t) bool {
+	_, exists := s[item]
+	return exists
+}
+
+func (s set) insert(item t) {
+	s[item] = empty{}
+}
+
+func (s set) delete(item t) {
+	delete(s, item)
+}
+
+// Add marks item as needing processing.
+func (q *Queue) Add(item interface{}) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	if q.shuttingDown {
+		return
+	}
+	if q.dirty.has(item) {
+		return
+	}
+
+	q.dirty.insert(item)
+	if q.processing.has(item) {
+		return
+	}
+
+	q.queue = append(q.queue, item)
+	q.cond.Signal()
+}
+
+// Len returns the current queue length, for informational purposes only. You
+// shouldn't e.g. gate a call to Add() or Get() on Len() being a particular
+// value, that can't be synchronized properly.
+func (q *Queue) Len() int {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	return len(q.queue)
+}
+
+// Get blocks until it can return an item to be processed. If shutdown = true,
+// the caller should end their goroutine. You must call Done with item when you
+// have finished processing it.
+func (q *Queue) Get() (item interface{}, shutdown bool) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	for len(q.queue) == 0 && !q.shuttingDown {
+		q.cond.Wait()
+	}
+	if len(q.queue) == 0 {
+		// We must be shutting down.
+		return nil, true
+	}
+
+	item, q.queue = q.queue[0], q.queue[1:]
+
+	q.processing.insert(item)
+	q.dirty.delete(item)
+
+	return item, false
+}
+
+// Done marks item as done processing, and if it has been marked as dirty again
+// while it was being processed, it will be re-added to the queue for
+// re-processing.
+func (q *Queue) Done(item interface{}) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	q.processing.delete(item)
+	if q.dirty.has(item) {
+		q.queue = append(q.queue, item)
+		q.cond.Signal()
+	}
+}
+
+// ShutDown will cause q to ignore all new items added to it. As soon as the
+// worker goroutines have drained the existing items in the queue, they will be
+// instructed to exit.
+func (q *Queue) ShutDown() {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	q.shuttingDown = true
+	q.cond.Broadcast()
+}
+
+func (q *Queue) ShuttingDown() bool {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	return q.shuttingDown
+}


### PR DESCRIPTION
@brancz This got a bit convoluted with other changes. Essentially, the queue used now is deduping. So if we add an item several times while it's being processed, it will only be in the queue once.

Secondly, we enqueue keys, not full objects. Instead we retrieve the object when getting the key from the queue. That avoids stale updates as in the case where we have multiple updates while the item was enqueued.

Lastly, the deadlocking if the PetSet gets stuck because a pod cannot be scheduled (that's intentional btw). We do only delete pods manually to have them be recreated if there's no ongoing work by the PetSet controller to minimize disruption. Otherwise, we just re-enqueue ourselves.
If we do delete a pod, we just delete one and don't wait for recreation and delete the next etc. but return and enqueue ourselves again and again until all pods are complete.

All those should be adopted by the Alertmanager operator as it inherited these issues.