### PR TITLE
Make WaitForTPRReady more reusable by passing configured RESTClient rather than raw HTTPClient

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -39,8 +39,14 @@ import (
 )
 
 const (
-	tprServiceMonitor = "service-monitor.monitoring.coreos.com"
-	tprPrometheus     = "prometheus.monitoring.coreos.com"
+	TPRGroup   = "monitoring.coreos.com"
+	TPRVersion = "v1alpha1"
+
+	TPRPrometheusesKind    = "prometheuses"
+	TPRServiceMonitorsKind = "servicemonitors"
+
+	tprServiceMonitor = "service-monitor." + TPRGroup
+	tprPrometheus     = "prometheus." + TPRGroup
 )
 
 // Operator manages lify cycle of Prometheus deployments and
@@ -542,7 +548,7 @@ func (c *Operator) createTPRs() error {
 				Name: tprServiceMonitor,
 			},
 			Versions: []extensionsobj.APIVersion{
-				{Name: "v1alpha1"},
+				{Name: TPRVersion},
 			},
 			Description: "Prometheus monitoring for a service",
 		},
@@ -551,7 +557,7 @@ func (c *Operator) createTPRs() error {
 				Name: tprPrometheus,
 			},
 			Versions: []extensionsobj.APIVersion{
-				{Name: "v1alpha1"},
+				{Name: TPRVersion},
 			},
 			Description: "Managed Prometheus server",
 		},
@@ -566,11 +572,11 @@ func (c *Operator) createTPRs() error {
 	}
 
 	// We have to wait for the TPRs to be ready. Otherwise the initial watch may fail.
-	err := k8sutil.WaitForMonitoringTPRReady(c.kclient.CoreClient.Client, c.host, "prometheuses")
+	err := k8sutil.WaitForTPRReady(c.kclient.CoreClient.GetRESTClient(), TPRGroup, TPRVersion, TPRPrometheusesKind)
 	if err != nil {
 		return err
 	}
-	return k8sutil.WaitForMonitoringTPRReady(c.kclient.CoreClient.Client, c.host, "servicemonitors")
+	return k8sutil.WaitForTPRReady(c.kclient.CoreClient.GetRESTClient(), TPRGroup, TPRVersion, TPRServiceMonitorsKind)
 }
 
 func newClusterConfig(host string, tlsInsecure bool, tlsConfig *rest.TLSClientConfig) (*rest.Config, error) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/1.5/tools/clientcmd"
 
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
+	"github.com/coreos/prometheus-operator/pkg/prometheus"
 	"github.com/coreos/prometheus-operator/pkg/spec"
 )
 
@@ -121,17 +122,12 @@ func (f *Framework) setupPrometheusOperator(opImage string) error {
 	}
 	f.OperatorPod = &pl.Items[0]
 
-	err = k8sutil.WaitForMonitoringTPRReady(f.HTTPClient, f.MasterHost, "prometheuses")
+	err = k8sutil.WaitForTPRReady(f.KubeClient.Core().GetRESTClient(), prometheus.TPRGroup, prometheus.TPRVersion, prometheus.TPRPrometheusesKind)
 	if err != nil {
 		return err
 	}
 
-	err = k8sutil.WaitForMonitoringTPRReady(f.HTTPClient, f.MasterHost, "servicemonitors")
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return k8sutil.WaitForTPRReady(f.KubeClient.Core().GetRESTClient(), prometheus.TPRGroup, prometheus.TPRVersion, prometheus.TPRServiceMonitorsKind)
 }
 
 // Teardown tears down a previously initialized test environment.


### PR DESCRIPTION
Making this method more easily reusable could be a first step in extracting a common set of helper functions for TPR based operators.