### PR TITLE
test: build image from current tree when running e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
-REPO = quay.io/coreos/prometheus-operator
-TAG = latest
+REPO=quay.io/coreos/prometheus-operator
+TAG=$(shell git rev-parse --short HEAD)
 
 build:
 	./scripts/check_license.sh
@@ -11,8 +11,8 @@ container:
 	GOOS=linux $(MAKE) build
 	docker build -t $(REPO):$(TAG) .
 
-e2e:
-	go test -v ./test/e2e/ --kubeconfig "$(HOME)/.kube/config" --operator-image=quay.io/coreos/prometheus-operator
+e2e: container
+	go test -v ./test/e2e/ --kubeconfig "$(HOME)/.kube/config" --operator-image=quay.io/coreos/prometheus-operator:$(TAG)
 
 clean-e2e:
 	kubectl delete namespace prometheus-operator-e2e-tests

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -109,6 +109,10 @@ func (f *Framework) setupPrometheusOperator(opImage string) error {
 	if err != nil {
 		return err
 	}
+	if opImage != "" {
+		// Override operator image used, if specified when running tests.
+		deploy.Spec.Template.Spec.Containers[0].Image = opImage
+	}
 
 	err = f.createDeployment(&deploy)
 	if err != nil {


### PR DESCRIPTION
Instead of testing the current image in the repository we want to test with a container image that is built from current working tree.

Fixes #48