### PR TITLE
add status endpoint

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -24,7 +24,8 @@ import (
 type Prometheus struct {
 	unversioned.TypeMeta `json:",inline"`
 	v1.ObjectMeta        `json:"metadata,omitempty"`
-	Spec                 PrometheusSpec `json:"spec"`
+	Spec                 PrometheusSpec   `json:"spec"`
+	Status               PrometheusStatus `json:"status,omitempty"`
 }
 
 // PrometheusList is a list of Prometheuses.
@@ -49,6 +50,23 @@ type PrometheusSpec struct {
 	// EvaluationInterval string                    `json:"evaluationInterval"`
 	// Remote          RemoteSpec                 `json:"remote"`
 	// Sharding...
+}
+
+type PrometheusStatus struct {
+	// Total number of non-terminated pods targeted by this Prometheus deployment
+	// (their labels match the selector).
+	Replicas int32 `json:"replicas"`
+
+	// Total number of non-terminated pods targeted by this Prometheus deployment
+	// that have the desired version spec.
+	UpdatedReplicas int32 `json:"updatedReplicas"`
+
+	// Total number of available pods (ready for at least minReadySeconds)
+	// targeted by this Prometheus deployment.
+	AvailableReplicas int32 `json:"availableReplicas"`
+
+	// Total number of unavailable pods targeted by this Prometheus deployment.
+	UnavailableReplicas int32 `json:"unavailableReplicas"`
 }
 
 // AlertingSpec defines paramters for alerting configuration of Prometheus servers.


### PR DESCRIPTION
So we can observe a deployment of a new version we need a current state of the Prometheus deployment. This resembles a status object similar to the some used in the `Deployment` object. Until upstream kubernetes resolves how to manage sub-resources of TPRs we will keep this independent of the actual Prometheus TPR, but depending on the upstream decisions it might go into the Prometheus TPR at some point.

@fabxc @alexsomesan 