### PR TITLE
pkg/alertmanager: don't delete Alertmanager config

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -453,16 +453,6 @@ func (c *Operator) destroyAlertmanager(key string) error {
 		return err
 	}
 
-	// Delete the auto-generate configuration.
-	// TODO(fabxc): add an ownerRef at creation so we don't delete config maps
-	// manually created for Alertmanager servers with no ServiceMonitor selectors.
-	cm := c.kclient.Core().ConfigMaps(pset.Namespace)
-	if err := cm.Delete(pset.Name, nil); err != nil {
-		return err
-	}
-	if err := cm.Delete(fmt.Sprintf("%s-rules", pset.Name), nil); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
The Alertmanager config to use is not generated by the operator, it is
entirely user created, therefore don't delete it when the Alertmanager
TPR is deleted.

@fabxc @alexsomesan 