### PR TITLE
*: no subPath for emptyDir volumes

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -190,7 +190,7 @@ func makeStatefulSetSpec(p spec.Prometheus) v1beta1.StatefulSetSpec {
 							{
 								Name:      fmt.Sprintf("%s-db", p.Name),
 								MountPath: "/var/prometheus/data",
-								SubPath:   "prometheus-db",
+								SubPath:   subPathForStorage(p.Spec.Storage),
 							},
 						},
 						ReadinessProbe: &v1.Probe{
@@ -270,4 +270,12 @@ func makeStatefulSetSpec(p spec.Prometheus) v1beta1.StatefulSetSpec {
 			},
 		},
 	}
+}
+
+func subPathForStorage(s *spec.StorageSpec) string {
+	if s == nil {
+		return ""
+	}
+
+	return "prometheus-db"
 }


### PR DESCRIPTION
There is an issue with `emptyDir` volumes that does not allow them to have a `subPath` set. This should be non-disruptive for any other volume providers (I have done some tests and confirmed that the issue does not exist with `hostPath` volumes). Nonetheless I would like to ask some people to try this change with various providers.

@Rastusik you have previously introduced the `subPath` for volumes, do you happen to still have your GlusterFS available to test with a v1.5.1 cluster?

Fixes #74 

@fabxc @alexsomesan 