### PR TITLE
External url

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -117,6 +117,11 @@ func makeStatefulSetSpec(a *spec.Alertmanager) v1beta1.StatefulSetSpec {
 		fmt.Sprintf("-mesh.listen-address=:%d", 6783),
 		fmt.Sprintf("-storage.path=%s", "/etc/alertmanager/data"),
 	}
+
+	if a.Spec.ExternalURL != "" {
+		commands = append(commands, "-web.external-url="+a.Spec.ExternalURL)
+	}
+
 	for i := int32(0); i < a.Spec.Replicas; i++ {
 		commands = append(commands, fmt.Sprintf("-mesh.peer=%s-%d.%s.%s.svc", a.Name, i, "alertmanager", a.Namespace))
 	}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -16,6 +16,8 @@ package prometheus
 
 import (
 	"fmt"
+	"net/url"
+	"path"
 
 	"k8s.io/client-go/pkg/api/resource"
 	"k8s.io/client-go/pkg/api/v1"
@@ -146,6 +148,23 @@ func makeStatefulSetSpec(p spec.Prometheus) v1beta1.StatefulSetSpec {
 	// generally has a very high time series churn.
 	memChunks := reqMem.Value() / 1024 / 5
 
+	promArgs := []string{
+		"-storage.local.retention=" + p.Spec.Retention,
+		"-storage.local.memory-chunks=" + fmt.Sprintf("%d", memChunks),
+		"-storage.local.max-chunks-to-persist=" + fmt.Sprintf("%d", memChunks/2),
+		"-storage.local.num-fingerprint-mutexes=4096",
+		"-storage.local.path=/var/prometheus/data",
+		"-config.file=/etc/prometheus/config/prometheus.yaml",
+	}
+	webRoutePrefix := ""
+	if p.Spec.ExternalURL != "" {
+		promArgs = append(promArgs, "-web.external-url="+p.Spec.ExternalURL)
+		extUrl, err := url.Parse(p.Spec.ExternalURL)
+		if err == nil {
+			webRoutePrefix = extUrl.Path
+		}
+	}
+
 	return v1beta1.StatefulSetSpec{
 		ServiceName: "prometheus",
 		Replicas:    &p.Spec.Replicas,
@@ -168,14 +187,7 @@ func makeStatefulSetSpec(p spec.Prometheus) v1beta1.StatefulSetSpec {
 								Protocol:      v1.ProtocolTCP,
 							},
 						},
-						Args: []string{
-							"-storage.local.retention=" + p.Spec.Retention,
-							"-storage.local.memory-chunks=" + fmt.Sprintf("%d", memChunks),
-							"-storage.local.max-chunks-to-persist=" + fmt.Sprintf("%d", memChunks/2),
-							"-storage.local.num-fingerprint-mutexes=4096",
-							"-storage.local.path=/var/prometheus/data",
-							"-config.file=/etc/prometheus/config/prometheus.yaml",
-						},
+						Args: promArgs,
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -196,7 +208,7 @@ func makeStatefulSetSpec(p spec.Prometheus) v1beta1.StatefulSetSpec {
 						ReadinessProbe: &v1.Probe{
 							Handler: v1.Handler{
 								HTTPGet: &v1.HTTPGetAction{
-									Path: "/status",
+									Path: path.Clean(webRoutePrefix + "/status"),
 									Port: intstr.FromString("web"),
 								},
 							},

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -144,6 +144,13 @@ type AlertmanagerSpec struct {
 	// Storage is the definition of how storage will be used by the Alertmanager
 	// instances.
 	Storage *StorageSpec `json:"storage"`
+	// ExternalURL is the URL under which Alertmanager is externally reachable
+	// (for example, if Alertmanager is served via a reverse proxy). Used for
+	// generating relative and absolute links back to Alertmanager itself. If the
+	// URL has a path portion, it will be used to prefix all HTTP endpoints
+	// served by Alertmanager. If omitted, relevant URL components will be
+	// derived automatically.
+	ExternalURL string `json:"externalUrl,omitempty"`
 }
 
 type AlertmanagerList struct {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -44,6 +44,7 @@ type PrometheusSpec struct {
 	BaseImage              string                  `json:"baseImage"`
 	Replicas               int32                   `json:"replicas"`
 	Retention              string                  `json:"retention"`
+	ExternalURL            string                  `json:"externalUrl"`
 	Storage                *StorageSpec            `json:"storage"`
 	Alerting               AlertingSpec            `json:"alerting"`
 	Resources              v1.ResourceRequirements `json:"resources"`


### PR DESCRIPTION
@alexsomesan @fabxc 

Tested with minikube. And the following manifests (replacing the manifests from `kube-prometheus`).

Prometheus:

```
apiVersion: monitoring.coreos.com/v1alpha1
kind: Prometheus
metadata:
  name: prometheus-k8s
  labels:
    prometheus: k8s
spec:
  version: v1.4.1
  externalUrl: http://192.168.99.100:30900/prometheus
  resources:
    requests:
      memory: 400Mi
```

Alertmanager:

```
apiVersion: "monitoring.coreos.com/v1alpha1"
kind: "Alertmanager"
metadata:
  name: "alertmanager-main"
  labels:
    alertmanager: "main"
spec:
  replicas: 3
  version: v0.5.1
  externalUrl: http://192.168.99.100:30903/alertmanager
```

Fixes #26 