### PR TITLE
pkg/client/monitoring/v1alpha1: use pointer for status

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -104,11 +104,10 @@ func (api *API) prometheusStatus(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	status, _, err := prometheus.PrometheusStatus(api.kclient, p)
+	p.Status, _, err = prometheus.PrometheusStatus(api.kclient, p)
 	if err != nil {
 		api.logger.Log("error", err)
 	}
-	p.Status = *status
 
 	b, err := json.Marshal(p)
 	if err != nil {

--- a/pkg/client/monitoring/v1alpha1/types.go
+++ b/pkg/client/monitoring/v1alpha1/types.go
@@ -24,8 +24,8 @@ import (
 type Prometheus struct {
 	metav1.TypeMeta `json:",inline"`
 	v1.ObjectMeta   `json:"metadata,omitempty"`
-	Spec            PrometheusSpec   `json:"spec"`
-	Status          PrometheusStatus `json:"status,omitempty"`
+	Spec            PrometheusSpec    `json:"spec"`
+	Status          *PrometheusStatus `json:"status,omitempty"`
 }
 
 // PrometheusList is a list of Prometheuses.

--- a/pkg/client/monitoring/v1alpha1/types.go
+++ b/pkg/client/monitoring/v1alpha1/types.go
@@ -54,6 +54,10 @@ type PrometheusSpec struct {
 }
 
 type PrometheusStatus struct {
+	// Represents whether any actions on the underlaying managed objects are
+	// being performed. Only delete actions will be performed.
+	Paused bool `json:"paused"`
+
 	// Total number of non-terminated pods targeted by this Prometheus deployment
 	// (their labels match the selector).
 	Replicas int32 `json:"replicas"`

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -491,7 +491,7 @@ func (c *Operator) syncVersion(key string, p *v1alpha1.Prometheus) error {
 }
 
 func PrometheusStatus(kclient *kubernetes.Clientset, p *v1alpha1.Prometheus) (*v1alpha1.PrometheusStatus, []*v1.Pod, error) {
-	res := &v1alpha1.PrometheusStatus{}
+	res := &v1alpha1.PrometheusStatus{Paused: p.Spec.Paused}
 
 	pods, err := kclient.Core().Pods(p.Namespace).List(ListOptions(p.Name))
 	if err != nil {


### PR DESCRIPTION
I haven't added a test as a unit test would be testing the transformation of a faked http request. I would have wanted to add an end-to-end test, but as the operator is not exposed in any way it's not really possible to issue requests against it right now. Do you think it is worth exposing?

Either way, I tested this manually and have verified that this works.

@alexsomesan @fabxc 