### PR TITLE
*: complete comments for types

### DIFF
--- a/Documentation/service-monitor.md
+++ b/Documentation/service-monitor.md
@@ -42,6 +42,7 @@ of the service endpoints. This is also made possible by the Prometheus Operator.
 | scheme | HTTP scheme to use for scraping | false | string | http |
 | interval | Interval at which metrics should be scraped | false | duration | 30s |
 | tlsConfig | TLS configuration to use when scraping the endpoint | false | TLSConfig | |
+| bearerTokenFile | File to read bearer token for scraping targets. | false | string | |
 
 ### `TLSConfig`
 


### PR DESCRIPTION
Just so we keep a habit of having all of our API objects documented, I completed it for everything we have now and whenever we add something. And this is potentially interesting for #110. Once we should revisit the docs we have in place and the current comments and take the best of both as they are sometimes more detailed in one then the other.

@alexsomesan @fabxc 