### PR TITLE
Set SessionAfinity on the Prometheus service.

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -115,7 +115,8 @@ func makeStatefulSetService(p *v1alpha1.Prometheus) *v1.Service {
 			Name: "prometheus",
 		},
 		Spec: v1.ServiceSpec{
-			ClusterIP: "None",
+			ClusterIP:       "None",
+			SessionAffinity: "ClientIP",
 			Ports: []v1.ServicePort{
 				{
 					Name:       "web",


### PR DESCRIPTION
This configures the Kubernetes service in front of the Prometheus stateful set to use client IP based session affinity. By default, a Kubernetes service balances requests across all endpoints by doing round-robin. For Prometheus, this is not the ideal behaviour since the replicas don't store the exact same time-series data. When a user accesses the Prometheus service, this will translate in inconsistent results as identical queries land on different Prometheus pods behind the service.
Using session affinity can be a way to minimise this effect, by pinning a specific client IP to a specific Prometheus pod so results to identical queries are also consistent.