### PR TITLE
Exposing Prometheus and Alertmanager

### DIFF
--- a/Documentation/alertmanager.md
+++ b/Documentation/alertmanager.md
@@ -27,6 +27,8 @@ instances in high availability mode.
 | baseImage | The base container image (without tag) to use. | false | string | quay.io/prometheus/alertmanager |
 | replicas | Number of Alertmanager instances to deploy. | false | integer (int32) | 1 |
 | storage | Configuration of persistent storage volumes to attach to deployed Alertmanager pods. | false | [StorageSpec](prometheus.md#storagespec) |  |
+| externalUrl | External URL Alertmanager will be reachable under. Used for registering routes. | false | string |  |
+| paused | If true, the operator won't process any changes affecting the Alertmanager setup | false | bool | false |
 
 ## Current state and roadmap
 

--- a/Documentation/exposing-prometheus-and-alertmanager.md
+++ b/Documentation/exposing-prometheus-and-alertmanager.md
@@ -1,0 +1,291 @@
+# Exposing Prometheus and Alertmanager
+
+The Prometheus Operator takes care of operating Prometheus and Alertmanagers
+clusters, however, there are many ways in Kubernetes to expose these to the
+outside world. This document outlines best practices and caveats to do so in
+various ways.
+
+## NodePort
+
+The easiest way to expose Prometheus or Alertmanager is to use a `Service` of
+type `NodePort`.
+
+A simple Prometheus object's manifest could look like this:
+
+```yaml
+apiVersion: "monitoring.coreos.com/v1alpha1"
+kind: "Prometheus"
+metadata:
+  name: "main"
+spec:
+  replicas: 1
+  version: v1.5.0
+  resources:
+    requests:
+      memory: 400Mi
+```
+
+All Prometheus `Pod`s are labelled with `prometheus: <prometheus-name>`, as the
+Prometheus object's name is `main`, the selector ends up being `prometheus:
+main`. Meaning, the respective manifest for the `Service` would look like this:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-main
+spec:
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30900
+    port: 9090
+    protocol: TCP
+    targetPort: web
+  selector:
+    prometheus: main
+```
+
+After creating a `Service` with the above manifest, the web UI of Prometheus
+will be accessible by browsing to any of the worker nodes using
+`http://<node-ip>:30900/`.
+
+Exposing the Alertmanager works in the same fashion, the only difference being,
+that the selector is `alertmanager: <alertmanager-name>`. So the `Alertmanager`
+manifest would look like this:
+
+```yaml
+apiVersion: "monitoring.coreos.com/v1alpha1"
+kind: "Alertmanager"
+metadata:
+  name: "main"
+spec:
+  replicas: 3
+  version: v0.5.1
+  resources:
+    requests:
+      memory: 400Mi
+```
+
+And the `Service` manifest like this:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-main
+spec:
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30903
+    port: 9093
+    protocol: TCP
+    targetPort: web
+  selector:
+    alertmanager: main
+```
+
+And the Alertmanager web UI will be available at `http://<node-ip>:30903/`.
+
+## Kubernetes API
+
+The Kubernetes API has a feature of forwarding requests from the API to a
+cluster internal `Service`. The general URL scheme to access these is:
+
+```
+http(s)://master-host/api/v1/proxy/namespaces/<namespace>/services/<service-name>:<port-name-or-number>/
+```
+
+> Note for ease of use, you can use `kubectl proxy`, it proxies requests from a
+> local address to the Kubernetes API server and handles authentication for
+> you.
+
+To be able to do so, create a `Service` of type `ClusterIP`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-main
+spec:
+  type: ClusterIP
+  ports:
+  - name: web
+    port: 9090
+    protocol: TCP
+    targetPort: web
+  selector:
+    prometheus: main
+```
+
+A caveat about this is that Prometheus and Alertmanager need to be configured
+with the full URL they are going to be exposed at. Therefore the `Prometheus`
+manifest will need an entry for `externalUrl`:
+
+```yaml
+apiVersion: "monitoring.coreos.com/v1alpha1"
+kind: "Prometheus"
+metadata:
+  name: "main"
+spec:
+  replicas: 1
+  version: v1.5.0
+  externalUrl: http://127.0.0.1:8001/api/v1/proxy/namespaces/default/services/prometheus-main:web/
+  routePrefix: /
+  resources:
+    requests:
+      memory: 400Mi
+```
+
+> Note the `externalUrl` used there uses the host `127.0.0.1:8001`, which is
+> how `kubectl proxy` exposes the Kubernetes API by default.
+
+Once the Prometheus `Pod`s are running they are reachable under the specified
+`externalUrl`.
+
+In contrast, the Alertmanager is able to perform all requests relative to its
+root when using this approach so the manifest for the `Alertmanager` object is
+simply the following:
+
+```yaml
+apiVersion: "monitoring.coreos.com/v1alpha1"
+kind: "Alertmanager"
+metadata:
+  name: "main"
+spec:
+  replicas: 3
+  version: v0.5.1
+  resources:
+    requests:
+      memory: 400Mi
+```
+
+And the respective `Service`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-main
+spec:
+  type: ClusterIP
+  ports:
+  - name: web
+    port: 9093
+    protocol: TCP
+    targetPort: web
+  selector:
+    alertmanager: main
+```
+
+Then it will be available under
+http://127.0.0.1:8001/api/v1/proxy/namespaces/default/services/alertmanager-main:web/.
+
+> Note the URL used there uses the host `127.0.0.1:8001`, which is how `kubectl
+> proxy` exposes the Kubernetes API by default.
+
+## Ingress
+
+Exposing the Prometheus or Alertmanager web UI via an `Ingress` object is
+requires a running ingress controller. If you are unfamiliar with Ingress, have
+a look at the [documentation](https://kubernetes.io/docs/user-guide/ingress/).
+
+This example was tested with the [nginx ingress
+controller](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx).
+For a quickstart for running the nginx ingress controller run:
+
+```
+kubectl create -f https://raw.githubusercontent.com/kubernetes/contrib/master/ingress/controllers/nginx/rc.yaml
+```
+
+> It is highly recommended to compare the available ingress controllers for a
+> production environment. The nginx ingress controller may or may not be what
+> is suitable for your production environment. Also have a look at HA Proxy,
+> Træfɪk, GCE, AWS, and more.
+
+An `Ingress` object also requires a `Service` to be setup as the requests are
+simply routed from the ingress endpoint to the internal `Service`.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-main
+spec:
+  type: ClusterIP
+  ports:
+  - name: web
+    port: 9090
+    protocol: TCP
+    targetPort: web
+  selector:
+    prometheus: main
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-main
+spec:
+  type: ClusterIP
+  ports:
+  - name: web
+    port: 9090
+    protocol: TCP
+    targetPort: web
+  selector:
+    alertmanager: main
+```
+
+Then a corresponding `Ingress` object would be as follows.
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: monitoring
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: prometheus-main
+          servicePort: 9090
+        path: /prometheus
+      - backend:
+          serviceName: alertmanager-main
+          servicePort: 9093
+        path: /alertmanager
+```
+
+Lastly the `Prometheus` and `Alertmanager` objects need to be created with the
+`externalUrl` they are going to be browsed to.
+
+```yaml
+apiVersion: "monitoring.coreos.com/v1alpha1"
+kind: "Prometheus"
+metadata:
+  name: "main"
+spec:
+  replicas: 1
+  version: v1.5.0
+  externalUrl: http://monitoring.my.systems/prometheus
+  resources:
+    requests:
+      memory: 400Mi
+---
+apiVersion: "monitoring.coreos.com/v1alpha1"
+kind: "Alertmanager"
+metadata:
+  name: "main"
+spec:
+  replicas: 3
+  version: v0.5.1
+  externalUrl: http://monitoring.my.systems/alertmanager
+  resources:
+    requests:
+      memory: 400Mi
+```
+
+> Note that there is the path `/prometheus` a the end of the `externalUrl`, as
+> that is what was specified in the `Ingress` object.

--- a/Documentation/prometheus.md
+++ b/Documentation/prometheus.md
@@ -43,6 +43,8 @@ still benefiting from the Operator's capabilities of managing Prometheus setups.
 | alerting | Configuration of alerting | false | AlertingSpec |  |
 | resources | Resource requirements of single Prometheus server | false | [v1.ResourceRequirements](http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_resourcerequirements) |  | 
 | nodeSelector | [Select nodes](https://kubernetes.io/docs/tasks/administer-cluster/assign-pods-nodes/) to be used to run the Prometheus pods on | false | [object](https://kubernetes.io/docs/user-guide/node-selection/) |  |
+| externalUrl | External URL Prometheus will be reachable under. Used for generating links, and registering routes. | false | string |  |
+| routePrefix | Prefix used to register routes. Overrides `externalUrl` route. Useful for proxies, that rewrite URLs. | false | string |  |
 
 ### `StorageSpec`
 

--- a/pkg/client/monitoring/v1alpha1/types.go
+++ b/pkg/client/monitoring/v1alpha1/types.go
@@ -55,6 +55,11 @@ type PrometheusSpec struct {
 	// necessary to generate correct URLs. This is necessary if Prometheus is not
 	// served from root of a DNS name.
 	ExternalURL string `json:"externalUrl,omitempty"`
+	// The route prefix Prometheus registers HTTP handlers for. This is useful,
+	// if using ExternalURL and a proxy is rewriting HTTP routes of a request,
+	// and the actual ExternalURL is still true, but the server serves requests
+	// under a different route prefix. For example for use with `kubectl proxy`.
+	RoutePrefix string `json:"routePrefix,omitempty"`
 	// Storage spec to specify how storage shall be used.
 	Storage *StorageSpec `json:"storage,omitempty"`
 	// Define details regarding alerting.

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -177,6 +177,11 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus) v1beta1.StatefulSetSpec {
 		}
 	}
 
+	if p.Spec.RoutePrefix != "" {
+		promArgs = append(promArgs, "-web.route-prefix="+p.Spec.RoutePrefix)
+		webRoutePrefix = p.Spec.RoutePrefix
+	}
+
 	localReloadURL := &url.URL{
 		Scheme: "http",
 		Host:   "localhost:9090",


### PR DESCRIPTION
I started writing this documentation on exposing Prometheus and Alertmanager to the outside world as mentioned in #98, and realized that for Prometheus the `routePrefix` is necessary for when a proxy (`kubectl proxy` in this case) rewrites request URLs. It removes the `/api/v1/...` part from the request, which is not a problem for the Alertmanager, which does relative requests, but Prometheus does require it, and it won't go away soon as it is part of the stability guarantee of version 1.

@alexsomesan @fabxc 

@mxinden maybe we can come up with a few test cases to cover all of these in our e2e tests.