### PR TITLE
Fix container build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /operator
+.build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/prometheus/busybox:latest
 
-ADD operator /bin/operator
+ADD .build/linux-amd64/operator /bin/operator
 
 ENTRYPOINT ["/bin/operator"]

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ all: check-license format build test
 build: promu
 	@$(PROMU) build --prefix $(PREFIX)
 
+crossbuild: promu
+	@$(PROMU) crossbuild
+
 test:
 	@go test -short $(pkgs)
 
@@ -24,7 +27,6 @@ check-license:
 	./scripts/check_license.sh
 
 container:
-	GOOS=linux $(MAKE) build
 	docker build -t $(REPO):$(TAG) .
 
 e2e-test:
@@ -46,4 +48,4 @@ promu:
 	GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
 	go get -u github.com/prometheus/promu
 
-.PHONY: all build test format check-license container e2e-test e2e-status e2e clean-e2e
+.PHONY: all build crossbuild test format check-license container e2e-test e2e-status e2e clean-e2e

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -31,7 +31,7 @@ import (
 const (
 	governingServiceName = "prometheus-operated"
 	defaultBaseImage     = "quay.io/prometheus/prometheus"
-	defaultVersion       = "v1.4.0"
+	defaultVersion       = "v1.5.0"
 	minReplicas          = 1
 	defaultRetention     = "24h"
 )

--- a/test/e2e/prometheus_e2e_test.go
+++ b/test/e2e/prometheus_e2e_test.go
@@ -214,7 +214,7 @@ func TestPrometheusDiscovery(t *testing.T) {
 	}
 
 	p := framework.MakeBasicPrometheus(prometheusName, group, 1)
-	p.Spec.Version = "master"
+	p.Spec.Version = "v1.5.0"
 	if err := framework.CreatePrometheusAndWaitUntilReady(p); err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func TestPrometheusAlertmanagerDiscovery(t *testing.T) {
 
 	p := framework.MakeBasicPrometheus(prometheusName, group, 1)
 	framework.AddAlertingToPrometheus(p, alertmanagerName)
-	p.Spec.Version = "master"
+	p.Spec.Version = "v1.5.0"
 	if err := framework.CreatePrometheusAndWaitUntilReady(p); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Two small things before we finish up the `0.3.0` release.

* separate building the binary from building the container image
* use `v1.5.0` of Prometheus where we used `master` before and use it as the default image

e2e tests passing :)

@alexsomesan @fabxc @mxinden 