### PR TITLE
test: Add e2e alertmanager & prometheus exposure tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,14 @@ e2e-test:
 	go test -timeout 20m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig "$(HOME)/.kube/config" --operator-image=quay.io/coreos/prometheus-operator:$(TAG) --namespace=$(NAMESPACE) --cluster-ip=$(CLUSTER_IP)
 
 e2e-status:
-	kubectl get prometheus,alertmanager,servicemonitor,statefulsets,deploy,svc,endpoints,pods,cm --all-namespaces
+	kubectl get prometheus,alertmanager,servicemonitor,statefulsets,deploy,svc,endpoints,pods,cm,replicationcontrollers --all-namespaces
 
 e2e:
 	$(MAKE) container
 	$(MAKE) e2e-test
 
 clean-e2e:
-	kubectl -n $(NAMESPACE) delete prometheus,alertmanager,servicemonitor,statefulsets,deploy,svc,endpoints,pods,cm --all
+	kubectl -n $(NAMESPACE) delete prometheus,alertmanager,servicemonitor,statefulsets,deploy,svc,endpoints,pods,cm,replicationcontrollers --all
 	kubectl delete namespace $(NAMESPACE)
 
 promu:

--- a/test/e2e/alertmanager_e2e_test.go
+++ b/test/e2e/alertmanager_e2e_test.go
@@ -15,7 +15,11 @@
 package e2e
 
 import (
+	"fmt"
+	"k8s.io/client-go/pkg/api/v1"
+	"net/http"
 	"testing"
+	"time"
 )
 
 func TestAlertmanagerCreateDeleteCluster(t *testing.T) {
@@ -76,6 +80,106 @@ func TestAlertmanagerVersionMigration(t *testing.T) {
 
 	am.Spec.Version = "v0.5.0"
 	if err := framework.UpdateAlertmanagerAndWaitUntilReady(am); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExposingAlertmanagerWithNodePort(t *testing.T) {
+	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", 1)
+	alertmanagerService := framework.MakeAlertmanagerNodePortService(alertmanager.Name, "nodeport-service", 30903)
+
+	defer func() {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(alertmanager.Name); err != nil {
+			t.Fatal(err)
+		}
+		if err := framework.DeleteService(alertmanagerService.Name); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(alertmanager); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := framework.CreateServiceAndWaitUntilReady(alertmanagerService); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(fmt.Sprintf("http://%s:30903/", framework.ClusterIP))
+	if err != nil {
+		t.Fatal("Retrieving alertmanager landing page failed with error: ", err)
+	} else if resp.StatusCode != 200 {
+		t.Fatal("Retrieving alertmanager landing page failed with http status code: ", resp.StatusCode)
+	}
+}
+
+func TestExposingAlertmanagerWithKubernetesAPI(t *testing.T) {
+	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", 1)
+	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
+
+	defer func() {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(alertmanager.Name); err != nil {
+			t.Fatal(err)
+		}
+		if err := framework.DeleteService(alertmanagerService.Name); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(alertmanager); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := framework.CreateServiceAndWaitUntilReady(alertmanagerService); err != nil {
+		t.Fatal(err)
+	}
+
+	proxyGet := framework.KubeClient.CoreV1().Services(framework.Namespace.Name).ProxyGet
+	request := proxyGet("", alertmanagerService.Name, "web", "/", make(map[string]string))
+	_, err := request.DoRaw()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExposingAlertmanagerWithIngress(t *testing.T) {
+	alertmanager := framework.MakeBasicAlertmanager("main", 1)
+	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "test-group", v1.ServiceTypeClusterIP)
+	ingress := framework.MakeBasicIngress(alertmanagerService.Name, 9093)
+
+	defer func() {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(alertmanager.Name); err != nil {
+			t.Fatal(err)
+		}
+		if err := framework.DeleteService(alertmanagerService.Name); err != nil {
+			t.Fatal(err)
+		}
+		if err := framework.KubeClient.Extensions().Ingresses(framework.Namespace.Name).Delete(ingress.Name, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := framework.DeleteNginxIngressControllerIncDefaultBackend(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if err := framework.SetupNginxIngressControllerIncDefaultBackend(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(alertmanager); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := framework.CreateServiceAndWaitUntilReady(alertmanagerService); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := framework.CreateIngress(ingress); err != nil {
+		t.Fatal(err)
+	}
+
+	err := framework.WaitForHTTPSuccessStatusCode(time.Second*30, fmt.Sprintf("http://%s/metrics", framework.ClusterIP))
+	if err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/e2e/framework/ingress.go
+++ b/test/e2e/framework/ingress.go
@@ -1,0 +1,120 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/pkg/util/intstr"
+	"os"
+)
+
+func (f *Framework) MakeBasicIngress(serviceName string, servicePort int) *v1beta1.Ingress {
+	return &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "monitoring",
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				v1beta1.IngressRule{
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								v1beta1.HTTPIngressPath{
+									Backend: v1beta1.IngressBackend{
+										ServiceName: serviceName,
+										ServicePort: intstr.FromInt(servicePort),
+									},
+									Path: "/metrics",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (f *Framework) CreateIngress(i *v1beta1.Ingress) error {
+	_, err := f.KubeClient.Extensions().Ingresses(f.Namespace.Name).Create(i)
+	return err
+}
+
+func (f *Framework) SetupNginxIngressControllerIncDefaultBackend() error {
+	// Create Nginx Ingress Replication Controller
+	if err := createReplicationControllerViaYml("./framework/ressources/nxginx-ingress-controller.yml", f); err != nil {
+		return err
+	}
+
+	// Create Default HTTP Backend Replication Controller
+	if err := createReplicationControllerViaYml("./framework/ressources/default-http-backend.yml", f); err != nil {
+		return err
+	}
+
+	// Create Default HTTP Backend Service
+	manifest, err := os.Open("./framework/ressources/default-http-backend-service.yml")
+	if err != nil {
+		return err
+	}
+
+	service := v1.Service{}
+	err = yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&service)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.KubeClient.CoreV1().Services(f.Namespace.Name).Create(&service)
+	if err != nil {
+		return err
+	}
+	if err := f.WaitForServiceReady(service.Name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *Framework) DeleteNginxIngressControllerIncDefaultBackend() error {
+	// Delete Nginx Ingress Replication Controller
+	if err := deleteReplicationControllerViaYml("./framework/ressources/nxginx-ingress-controller.yml", f); err != nil {
+		return err
+	}
+
+	// Delete Default HTTP Backend Replication Controller
+	if err := deleteReplicationControllerViaYml("./framework/ressources/default-http-backend.yml", f); err != nil {
+		return err
+	}
+
+	// Delete Default HTTP Backend Service
+	manifest, err := os.Open("./framework/ressources/default-http-backend-service.yml")
+	if err != nil {
+		return err
+	}
+
+	service := v1.Service{}
+	err = yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&service)
+	if err != nil {
+		return err
+	}
+
+	if err := f.KubeClient.CoreV1().Services(f.Namespace.Name).Delete(service.Name, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -86,8 +86,14 @@ func (f *Framework) MakeBasicServiceMonitor(name string) *v1alpha1.ServiceMonito
 	}
 }
 
-func (f *Framework) MakePrometheusService(name, group string) *v1.Service {
-	return &v1.Service{
+func (f *Framework) MakeBasicPrometheusNodePortService(name, group string, nodePort int32) *v1.Service {
+	pService := f.MakePrometheusService(name, group, v1.ServiceTypeNodePort)
+	pService.Spec.Ports[0].NodePort = nodePort
+	return pService
+}
+
+func (f *Framework) MakePrometheusService(name, group string, serviceType v1.ServiceType) *v1.Service {
+	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("prometheus-%s", name),
 			Labels: map[string]string{
@@ -95,13 +101,12 @@ func (f *Framework) MakePrometheusService(name, group string) *v1.Service {
 			},
 		},
 		Spec: v1.ServiceSpec{
-			Type: "NodePort",
+			Type: serviceType,
 			Ports: []v1.ServicePort{
 				v1.ServicePort{
 					Name:       "web",
 					Port:       9090,
 					TargetPort: intstr.FromString("web"),
-					NodePort:   30900,
 				},
 			},
 			Selector: map[string]string{
@@ -109,6 +114,7 @@ func (f *Framework) MakePrometheusService(name, group string) *v1.Service {
 			},
 		},
 	}
+	return service
 }
 
 func (f *Framework) CreatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) error {

--- a/test/e2e/framework/replication-controller.go
+++ b/test/e2e/framework/replication-controller.go
@@ -1,0 +1,88 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/pkg/api/v1"
+	"os"
+	"time"
+)
+
+func createReplicationControllerViaYml(filepath string, f *Framework) error {
+	manifest, err := os.Open(filepath)
+	if err != nil {
+		return err
+	}
+
+	var rC v1.ReplicationController
+	err = yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&rC)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.KubeClient.CoreV1().ReplicationControllers(f.Namespace.Name).Create(&rC)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deleteReplicationControllerViaYml(filepath string, f *Framework) error {
+	manifest, err := os.Open(filepath)
+	if err != nil {
+		return err
+	}
+
+	var rC v1.ReplicationController
+	err = yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&rC)
+	if err != nil {
+		return err
+	}
+
+	if err := scaleDownReplicationController(f, rC); err != nil {
+		return err
+	}
+
+	if err := f.KubeClient.CoreV1().ReplicationControllers(f.Namespace.Name).Delete(rC.Name, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func scaleDownReplicationController(f *Framework, rC v1.ReplicationController) error {
+	*rC.Spec.Replicas = 0
+	rCAPI := f.KubeClient.CoreV1().ReplicationControllers(f.Namespace.Name)
+
+	_, err := f.KubeClient.CoreV1().ReplicationControllers(f.Namespace.Name).Update(&rC)
+	if err != nil {
+		return err
+	}
+
+	return f.Poll(time.Minute*5, time.Second, func() (bool, error) {
+		currentRC, err := rCAPI.Get(rC.Name, apimetav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if currentRC.Status.Replicas == 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+}

--- a/test/e2e/framework/ressources/default-http-backend-service.yml
+++ b/test/e2e/framework/ressources/default-http-backend-service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  labels:
+    k8s-app: default-http-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    k8s-app: default-http-backend

--- a/test/e2e/framework/ressources/default-http-backend.yml
+++ b/test/e2e/framework/ressources/default-http-backend.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: default-http-backend
+spec:
+  replicas: 1
+  selector:
+    k8s-app: default-http-backend
+  template:
+    metadata:
+      labels:
+        k8s-app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.2
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi

--- a/test/e2e/framework/ressources/nxginx-ingress-controller.yml
+++ b/test/e2e/framework/ressources/nxginx-ingress-controller.yml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx-ingress-controller
+  labels:
+    k8s-app: nginx-ingress-lb
+spec:
+  replicas: 1
+  selector:
+    k8s-app: nginx-ingress-lb
+  template:
+    metadata:
+      labels:
+        k8s-app: nginx-ingress-lb
+        name: nginx-ingress-lb
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
+        name: nginx-ingress-lb
+        imagePullPolicy: Always
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        # use downward API
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 443
+        # we expose 18080 to access nginx stats in url /nginx-status
+        # this is optional
+        - containerPort: 18080
+          hostPort: 18080
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/test/e2e/framework/service.go
+++ b/test/e2e/framework/service.go
@@ -1,0 +1,53 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+	"time"
+)
+
+func (f *Framework) CreateServiceAndWaitUntilReady(service *v1.Service) error {
+	if _, err := f.KubeClient.CoreV1().Services(f.Namespace.Name).Create(service); err != nil {
+		return err
+	}
+
+	if err := f.WaitForServiceReady(service.Name); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *Framework) WaitForServiceReady(serviceName string) error {
+	err := f.Poll(time.Minute*5, time.Second, func() (bool, error) {
+		endpoints, err := f.KubeClient.CoreV1().Endpoints(f.Namespace.Name).Get(serviceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(endpoints.Subsets) != 0 && len(endpoints.Subsets[0].Addresses) > 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+	return err
+}
+
+func (f *Framework) DeleteService(serviceName string) error {
+	if err := f.KubeClient.CoreV1().Services(f.Namespace.Name).Delete(serviceName, nil); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Ensuring functionality of the "Exposing prometheus and alertmanaer"
tutorial. Testing exposure of alertmanager and prometheus via Nodeport,
Kubernetes API and Ingress controller.

https://github.com/coreos/prometheus-operator/blob/master/Documentation/exposing-prometheus-and-alertmanager.md