### PR TITLE
prometheus: syncronize nodes to enpoints object

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -45,6 +45,7 @@ func init() {
 	flagset.StringVar(&cfg.TLSConfig.CertFile, "cert-file", "", " - NOT RECOMMENDED FOR PRODUCTION - Path to public TLS certificate file.")
 	flagset.StringVar(&cfg.TLSConfig.KeyFile, "key-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to private TLS certificate file.")
 	flagset.StringVar(&cfg.TLSConfig.CAFile, "ca-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to TLS CA file.")
+	flagset.StringVar(&cfg.KubeletObject, "kubelet-object", "", "Endpoints object to write kubelets into in format \"namespace/name\"")
 	flagset.BoolVar(&cfg.TLSInsecure, "tls-insecure", false, "- NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate.")
 	flagset.BoolVar(&analyticsEnabled, "analytics", true, "Send analytical event (Cluster Created/Deleted etc.) to Google Analytics")
 


### PR DESCRIPTION
As the kubelet will not be self-hosted for the time being, we need to be able to handle it anyways. This is an implementation of a feature synchronizing nodes into an Endpoints object for discovery by Prometheus.

@fabxc 