### PR TITLE
Documentation: add documentation on how to use storage

### DIFF
--- a/Documentation/storage.md
+++ b/Documentation/storage.md
@@ -1,0 +1,61 @@
+# Storage
+
+To keep data cross deployments and version upgrades the data must be persisted
+to some volume other than `emptyDir`, to be able to reuse it by `Pod`s after an
+upgrade.
+
+There are various kinds of volumes supported by Kubernetes. The Prometheus
+Operator works with `PersistentVolumeClaim`s. `PersistentVolumeClaims` are
+especially useful, because they support the underlying `PersistentVolume` to be
+provisioned when requested.
+
+This document assumes you have a basic understanding of `PersisentVolume`s,
+`PersisentVolumeClaim`s, and their
+[provisioning](https://kubernetes.io/docs/user-guide/persistent-volumes/#provisioning).
+
+# Storage Provisioning on AWS
+
+For automatic provisioning of storage a `StorageClass` is required.
+
+```yaml
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: ssd
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+```
+
+> Make sure that AWS as a cloud provider is properly configured with your
+> cluster, as otherwise storage provisioning will not work.
+
+It is recommended to use volumes that have high I/O throughput therefore we're
+using SSD EBS volumes here. Make sure to read the
+[documentation](https://kubernetes.io/docs/user-guide/persistent-volumes/#aws)
+to adapt this `StorageClass` to your needs.
+
+Having created the `StorageClass` it actually needs to be used. The
+`StorageClass` to use can be specified in the `storage` section in the
+`Prometheus` resource.
+
+```yaml
+apiVersion: "monitoring.coreos.com/v1alpha1"
+kind: "Prometheus"
+metadata:
+  name: "persisted"
+spec:
+  storage:
+    class: ssd
+    resources:
+      requests:
+        storage: 40Gi
+```
+
+> The full documentation of the `storage` field can be found in the [spec
+> documentation](prometheus.md#storagespec).
+
+When now creating the `Prometheus` object a `PersistentVolumeClaim` is used for
+each `Pod` in the `StatefulSet` and the storage should automatically be
+provisioned, mounted and used.
+

--- a/example/storage/persisted-prometheus.yaml
+++ b/example/storage/persisted-prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: "monitoring.coreos.com/v1alpha1"
+kind: "Prometheus"
+metadata:
+  name: "persisted"
+spec:
+  storage:
+    class: ssd
+    resources:
+      requests:
+        storage: 40Gi

--- a/example/storage/storageclass.yaml
+++ b/example/storage/storageclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: ssd
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2


### PR DESCRIPTION
This adds documentation on how to use storage provisioning with a concrete example for AWS. This should solve some confusion around the topic.

@fabxc 