### PR TITLE
github: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+**What did you do?**
+
+**What did you expect to see?**
+
+**What did you see instead? Under which circumstances?**
+
+**Environment**
+
+* Kubernetes version information:
+
+	insert output of `kubectl version` here
+
+* Kubernetes cluster kind: 
+
+	insert how you created your cluster: kops, bootkube, tectonic-installer, etc.
+
+* Manifests:
+
+```
+insert manifests relevant to the issue
+```
+
+* Prometheus Operator Logs:
+
+```
+insert Prometheus Operator logs relevant to the issue here
+```


### PR DESCRIPTION
As we often ask the same questions when troubleshooting with users I thought it would be a good idea to setup an issue template so we hopefully get the data on submission of the issue.

@fabxc 