### PR TITLE
test: Fix working dir spec and add string param for manual build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,10 @@ job('prometheus-operator-unit-tests') {
 job('prometheus-operator-e2e-tests') {
     concurrentBuild()
 
+    parameters {
+        stringParam('sha1')
+    }
+
     scm {
         git {
             remote {
@@ -58,7 +62,7 @@ job('prometheus-operator-e2e-tests') {
     }
 
     steps {
-        shell('docker run --rm -v /var/jenkins/workspace/e2e-playground:/var/jenkins/workspace/e2e-playground -v /var/run/docker.sock:/var/run/docker.sock cluster-setup-env /bin/bash -c "cd /var/jenkins/workspace/e2e-playground && make crossbuild"')
+        shell('docker run --rm -v $PWD:$PWD -v /var/run/docker.sock:/var/run/docker.sock cluster-setup-env /bin/bash -c "cd $PWD && make crossbuild"')
     }
 
     steps {


### PR DESCRIPTION
1. The current working dir was not properly specified when building the prometheus operator binary. It is now retrieved via the `$PWD` environment variable. 

2. The sha1 of the commit to be tested was previously only specified via the *GitHub Pull Request Builder* hook. This prevents the ability to trigger the job manually in Jenkins as Jenkins doesn't know which commit to test. This commit adds the sha1 string parameter to the `Jenkinsfil` job dsl for users to specify the sha1 when triggering jobs manually.