### PR TITLE
test: Add context to test status in pull request view

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,13 @@ job('prometheus-operator-unit-tests') {
         githubPullRequest {
             useGitHubHooks()
             orgWhitelist(['coreos-inc'])
+            extensions {
+                commitStatus {
+                    context('prometheus-operator-unit-tests')
+                    triggeredStatus('Tests triggered')
+                    startedStatus('Tests started')
+                }
+            }
         }
     }
 
@@ -54,6 +61,13 @@ job('prometheus-operator-e2e-tests') {
         githubPullRequest {
             useGitHubHooks()
             orgWhitelist(['coreos-inc'])
+            extensions {
+                commitStatus {
+                    context('prometheus-operator-e2e-tests')
+                    triggeredStatus('Tests triggered')
+                    startedStatus('Tests started')
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This instructs the Jenkins Github pull request builder plugin to add one
test status line for each e2e and unit tests in the pull request view.
In addition it updates the status when the tests are triggered and when
they are started.