### PR TITLE
contrib/grafana-watcher: add license headers

### DIFF
--- a/contrib/grafana-watcher/grafana/dashboard.go
+++ b/contrib/grafana-watcher/grafana/dashboard.go
@@ -1,3 +1,17 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package grafana
 
 import (

--- a/contrib/grafana-watcher/grafana/datasource.go
+++ b/contrib/grafana-watcher/grafana/datasource.go
@@ -1,3 +1,17 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package grafana
 
 import (

--- a/contrib/grafana-watcher/grafana/grafana.go
+++ b/contrib/grafana-watcher/grafana/grafana.go
@@ -1,3 +1,17 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package grafana
 
 import (

--- a/contrib/grafana-watcher/main.go
+++ b/contrib/grafana-watcher/main.go
@@ -1,3 +1,17 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/contrib/grafana-watcher/updater/dashboard.go
+++ b/contrib/grafana-watcher/updater/dashboard.go
@@ -1,3 +1,17 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package updater
 
 import (

--- a/contrib/grafana-watcher/updater/datasource.go
+++ b/contrib/grafana-watcher/updater/datasource.go
@@ -1,3 +1,17 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package updater
 
 import (

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 licRes=$(
-for file in $(find . -type f -iname '*.go' ! -path './vendor/*'); do
+for file in $(find . -type f -iname '*.go' ! -path '*/vendor/*'); do
 	head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo -e "  ${file}"
 done;)
 if [ -n "${licRes}" ]; then


### PR DESCRIPTION
Adding license headers as I noticed that the check license script failed on the grafana-watcher source files.

@fabxc 