### PR TITLE
test: Check whether alertmanager mesh network initializes correctly

### DIFF
--- a/test/e2e/alertmanager_e2e_test.go
+++ b/test/e2e/alertmanager_e2e_test.go
@@ -17,6 +17,8 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 	"net/http"
 	"testing"
@@ -192,7 +194,16 @@ func TestExposingAlertmanagerWithIngress(t *testing.T) {
 
 func TestMeshInitialization(t *testing.T) {
 	var amountAlertmanagers int32 = 3
-	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", amountAlertmanagers)
+	alertmanager := &v1alpha1.Alertmanager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-alertmanager",
+		},
+		Spec: v1alpha1.AlertmanagerSpec{
+			Replicas: &amountAlertmanagers,
+			Version:  "master",
+		},
+	}
+
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
 
 	defer func() {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -281,3 +281,7 @@ func (f *Framework) Poll(timeout, pollInterval time.Duration, pollFunc func() (b
 		}
 	}
 }
+
+func (f *Framework) ProxyGetPod(podName string, port string, path string) *rest.Request {
+	return f.KubeClient.CoreV1().RESTClient().Get().Prefix("proxy").Namespace(f.Namespace.Name).Resource("pods").Name(podName + ":" + port).Suffix(path)
+}


### PR DESCRIPTION
Spin up three alertmanagers via prometheus operator and check with the
/status API endpoint if they discover each other correctly.

❗️ ❗️ ❗️  Depends on alertmanager [PR 644](https://github.com/prometheus/alertmanager/pull/644)