### PR TITLE
Default prom am version

### DIFF
--- a/test/e2e/framework/alertmanager.go
+++ b/test/e2e/framework/alertmanager.go
@@ -51,7 +51,6 @@ func (f *Framework) MakeBasicAlertmanager(name string, replicas int32) *v1alpha1
 		},
 		Spec: v1alpha1.AlertmanagerSpec{
 			Replicas: &replicas,
-			Version:  "v0.5.0",
 		},
 	}
 }
@@ -129,7 +128,7 @@ func (f *Framework) CreateAlertmanagerAndWaitUntilReady(a *v1alpha1.Alertmanager
 		return err
 	}
 
-	err = f.WaitForPodsReady(int(*a.Spec.Replicas), amImage(a.Spec.Version), alertmanager.ListOptions(a.Name))
+	err = f.WaitForPodsReady(int(*a.Spec.Replicas), alertmanager.ListOptions(a.Name))
 	if err != nil {
 		return fmt.Errorf("failed to create an Alertmanager cluster (%s) with %d instances: %v", a.Name, a.Spec.Replicas, err)
 	}
@@ -143,7 +142,7 @@ func (f *Framework) UpdateAlertmanagerAndWaitUntilReady(a *v1alpha1.Alertmanager
 		return err
 	}
 
-	err = f.WaitForPodsReady(int(*a.Spec.Replicas), amImage(a.Spec.Version), alertmanager.ListOptions(a.Name))
+	err = f.WaitForPodsReady(int(*a.Spec.Replicas), alertmanager.ListOptions(a.Name))
 	if err != nil {
 		return fmt.Errorf("failed to update %d Alertmanager instances (%s): %v", a.Spec.Replicas, a.Name, err)
 	}
@@ -153,7 +152,7 @@ func (f *Framework) UpdateAlertmanagerAndWaitUntilReady(a *v1alpha1.Alertmanager
 
 func (f *Framework) DeleteAlertmanagerAndWaitUntilGone(name string) error {
 	log.Printf("Deleting Alertmanager (%s/%s)", f.Namespace.Name, name)
-	a, err := f.MonClient.Alertmanagers(f.Namespace.Name).Get(name)
+	_, err := f.MonClient.Alertmanagers(f.Namespace.Name).Get(name)
 	if err != nil {
 		return err
 	}
@@ -162,11 +161,15 @@ func (f *Framework) DeleteAlertmanagerAndWaitUntilGone(name string) error {
 		return err
 	}
 
-	if err := f.WaitForPodsReady(0, amImage(a.Spec.Version), alertmanager.ListOptions(name)); err != nil {
+	if err := f.WaitForPodsReady(0, alertmanager.ListOptions(name)); err != nil {
 		return fmt.Errorf("failed to teardown Alertmanager (%s) instances: %v", name, err)
 	}
 
 	return f.KubeClient.CoreV1().Secrets(f.Namespace.Name).Delete(fmt.Sprintf("alertmanager-%s", name), nil)
+}
+
+func amImage(version string) string {
+	return fmt.Sprintf("quay.io/prometheus/alertmanager:%s", version)
 }
 
 func (f *Framework) WaitForAlertmanagerInitializedMesh(name string, amountPeers int) error {
@@ -200,8 +203,4 @@ type alertmanagerStatusData struct {
 
 type meshStatus struct {
 	Peers []interface{} `json:"peers"`
-}
-
-func amImage(version string) string {
-	return fmt.Sprintf("quay.io/prometheus/alertmanager:%s", version)
 }

--- a/test/e2e/framework/alertmanager.go
+++ b/test/e2e/framework/alertmanager.go
@@ -129,7 +129,7 @@ func (f *Framework) CreateAlertmanagerAndWaitUntilReady(a *v1alpha1.Alertmanager
 		return err
 	}
 
-	_, err = f.WaitForPodsReady(time.Minute*6, int(*a.Spec.Replicas), amImage(a.Spec.Version), alertmanager.ListOptions(a.Name))
+	err = f.WaitForPodsReady(int(*a.Spec.Replicas), amImage(a.Spec.Version), alertmanager.ListOptions(a.Name))
 	if err != nil {
 		return fmt.Errorf("failed to create an Alertmanager cluster (%s) with %d instances: %v", a.Name, a.Spec.Replicas, err)
 	}
@@ -143,7 +143,7 @@ func (f *Framework) UpdateAlertmanagerAndWaitUntilReady(a *v1alpha1.Alertmanager
 		return err
 	}
 
-	_, err = f.WaitForPodsReady(time.Minute*6, int(*a.Spec.Replicas), amImage(a.Spec.Version), alertmanager.ListOptions(a.Name))
+	err = f.WaitForPodsReady(int(*a.Spec.Replicas), amImage(a.Spec.Version), alertmanager.ListOptions(a.Name))
 	if err != nil {
 		return fmt.Errorf("failed to update %d Alertmanager instances (%s): %v", a.Spec.Replicas, a.Name, err)
 	}
@@ -162,7 +162,7 @@ func (f *Framework) DeleteAlertmanagerAndWaitUntilGone(name string) error {
 		return err
 	}
 
-	if _, err := f.WaitForPodsReady(time.Minute*6, 0, amImage(a.Spec.Version), alertmanager.ListOptions(name)); err != nil {
+	if err := f.WaitForPodsReady(0, amImage(a.Spec.Version), alertmanager.ListOptions(name)); err != nil {
 		return fmt.Errorf("failed to teardown Alertmanager (%s) instances: %v", name, err)
 	}
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
-	v1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/rest"
@@ -127,7 +126,12 @@ func (f *Framework) setupPrometheusOperator(opImage string) error {
 	}
 
 	opts := metav1.ListOptions{LabelSelector: fields.SelectorFromSet(fields.Set(deploy.Spec.Template.ObjectMeta.Labels)).String()}
-	pl, err := f.WaitForPodsReady(60*time.Second, 1, opImage, opts)
+	err = f.WaitForPodsReady(1, opImage, opts)
+	if err != nil {
+		return err
+	}
+
+	pl, err := f.KubeClient.Core().Pods(f.Namespace.Name).List(opts)
 	if err != nil {
 		return err
 	}
@@ -169,43 +173,32 @@ func (f *Framework) Teardown() error {
 
 // WaitForPodsReady waits for a selection of Pods to be running and each
 // container to pass its readiness check.
-func (f *Framework) WaitForPodsReady(timeout time.Duration, expectedReplicas int, image string, opts metav1.ListOptions) (*v1.PodList, error) {
-	return waitForPodsReady(f.KubeClient.Core(), timeout, expectedReplicas, image, f.Namespace.Name, opts)
-}
+func (f *Framework) WaitForPodsReady(expectedReplicas int, image string, opts metav1.ListOptions) error {
+	return f.Poll(time.Minute*5, time.Second, func() (bool, error) {
+		pl, err := f.KubeClient.Core().Pods(f.Namespace.Name).List(opts)
+		if err != nil {
+			return false, err
+		}
 
-func waitForPodsReady(client v1client.CoreV1Interface, timeout time.Duration, expectedRunning int, image, namespace string, opts metav1.ListOptions) (*v1.PodList, error) {
-	t := time.After(timeout)
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-t:
-			return nil, fmt.Errorf("timed out while waiting for %d pod to be running", expectedRunning)
-		case <-ticker.C:
-			pl, err := client.Pods(namespace).List(opts)
-			if err != nil {
-				return nil, err
-			}
-
-			runningAndReady := 0
-			if len(pl.Items) >= 0 {
-				for _, p := range pl.Items {
-					isRunningAndReady, err := k8sutil.PodRunningAndReady(p)
-					if err != nil {
-						return nil, err
-					}
-
-					if isRunningAndReady && podRunsImage(p, image) {
-						runningAndReady++
-					}
+		runningAndReady := 0
+		if len(pl.Items) >= 0 {
+			for _, p := range pl.Items {
+				isRunningAndReady, err := k8sutil.PodRunningAndReady(p)
+				if err != nil {
+					return false, err
 				}
-				if runningAndReady == expectedRunning {
-					return pl, nil
+
+				if isRunningAndReady && podRunsImage(p, image) {
+					runningAndReady++
 				}
 			}
 		}
-	}
+
+		if runningAndReady == expectedReplicas {
+			return true, nil
+		}
+		return false, nil
+	})
 }
 
 func (f *Framework) WaitForHTTPSuccessStatusCode(timeout time.Duration, url string) error {

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -126,7 +126,7 @@ func (f *Framework) CreatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) er
 		return err
 	}
 
-	_, err = f.WaitForPodsReady(time.Minute*6, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name))
+	err = f.WaitForPodsReady(int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name))
 	if err != nil {
 		return fmt.Errorf("failed to create %d Prometheus instances (%s): %v", p.Spec.Replicas, p.Name, err)
 	}
@@ -141,7 +141,7 @@ func (f *Framework) UpdatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) er
 		return err
 	}
 
-	_, err = f.WaitForPodsReady(time.Minute*6, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name))
+	err = f.WaitForPodsReady(int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name))
 	if err != nil {
 		return fmt.Errorf("failed to update %d Prometheus instances (%s): %v", p.Spec.Replicas, p.Name, err)
 	}
@@ -160,7 +160,7 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(name string) error {
 		return err
 	}
 
-	if _, err := f.WaitForPodsReady(time.Minute*6, 0, promImage(p.Spec.Version), prometheus.ListOptions(name)); err != nil {
+	if err := f.WaitForPodsReady(0, promImage(p.Spec.Version), prometheus.ListOptions(name)); err != nil {
 		return fmt.Errorf("failed to teardown Prometheus instances (%s): %v", name, err)
 	}
 

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -37,7 +37,6 @@ func (f *Framework) MakeBasicPrometheus(name, group string, replicas int32) *v1a
 		},
 		Spec: v1alpha1.PrometheusSpec{
 			Replicas: &replicas,
-			Version:  "v1.4.0",
 			ServiceMonitorSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"group": group,
@@ -126,7 +125,7 @@ func (f *Framework) CreatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) er
 		return err
 	}
 
-	err = f.WaitForPodsReady(int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name))
+	err = f.WaitForPodsReady(int(*p.Spec.Replicas), prometheus.ListOptions(p.Name))
 	if err != nil {
 		return fmt.Errorf("failed to create %d Prometheus instances (%s): %v", p.Spec.Replicas, p.Name, err)
 	}
@@ -141,7 +140,7 @@ func (f *Framework) UpdatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) er
 		return err
 	}
 
-	err = f.WaitForPodsReady(int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name))
+	err = f.WaitForPodsReady(int(*p.Spec.Replicas), prometheus.ListOptions(p.Name))
 	if err != nil {
 		return fmt.Errorf("failed to update %d Prometheus instances (%s): %v", p.Spec.Replicas, p.Name, err)
 	}
@@ -151,7 +150,7 @@ func (f *Framework) UpdatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) er
 
 func (f *Framework) DeletePrometheusAndWaitUntilGone(name string) error {
 	log.Printf("Deleting Prometheus (%s/%s)", f.Namespace.Name, name)
-	p, err := f.MonClient.Prometheuses(f.Namespace.Name).Get(name)
+	_, err := f.MonClient.Prometheuses(f.Namespace.Name).Get(name)
 	if err != nil {
 		return err
 	}
@@ -160,11 +159,18 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(name string) error {
 		return err
 	}
 
-	if err := f.WaitForPodsReady(0, promImage(p.Spec.Version), prometheus.ListOptions(name)); err != nil {
+	if err := f.WaitForPodsReady(0, prometheus.ListOptions(name)); err != nil {
 		return fmt.Errorf("failed to teardown Prometheus instances (%s): %v", name, err)
 	}
 
 	return nil
+}
+
+func (f *Framework) WaitForPrometheusRunImageAndReady(p *v1alpha1.Prometheus) error {
+	if err := f.WaitForPodsRunImage(int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name)); err != nil {
+		return err
+	}
+	return f.WaitForPodsReady(int(*p.Spec.Replicas), prometheus.ListOptions(p.Name))
 }
 
 func promImage(version string) string {

--- a/test/e2e/prometheus_e2e_test.go
+++ b/test/e2e/prometheus_e2e_test.go
@@ -81,18 +81,24 @@ func TestPrometheusVersionMigration(t *testing.T) {
 
 	p := framework.MakeBasicPrometheus(name, name, 1)
 
-	p.Spec.Version = "v1.4.0"
+	p.Spec.Version = "v1.5.1"
 	if err := framework.CreatePrometheusAndWaitUntilReady(p); err != nil {
 		t.Fatal(err)
 	}
 
-	p.Spec.Version = "v1.4.1"
+	p.Spec.Version = "v1.5.2"
 	if err := framework.UpdatePrometheusAndWaitUntilReady(p); err != nil {
 		t.Fatal(err)
 	}
+	if err := framework.WaitForPrometheusRunImageAndReady(p); err != nil {
+		t.Fatal(err)
+	}
 
-	p.Spec.Version = "v1.4.0"
+	p.Spec.Version = "v1.5.1"
 	if err := framework.UpdatePrometheusAndWaitUntilReady(p); err != nil {
+		t.Fatal(err)
+	}
+	if err := framework.WaitForPrometheusRunImageAndReady(p); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
### Refactor WaitForPods function

* Use framework internal Poll function instead of reimplementing it.
* Don't return pods list - only needed by one function call.
* Have one specification of how long to wait for a pod.
 	
### Introduce WaitForPodsRunImage

Instead of checking for pods running correct image in WaitForPodsReady
this functionallity is extracted into WaitForPodsRunImage function.  By
not requiring an image name when calling WaitForPodsReady we can remove
the image specification in MakeBasicPrometheus and
MakeBasicAlertmanager. Thereby basic tests are not fixed to specific am
and prom versions.