### PR TITLE
Allow for multiple kube-state-metrics series

### DIFF
--- a/contrib/kube-prometheus/assets/grafana/deployment-dashboard.json
+++ b/contrib/kube-prometheus/assets/grafana/deployment-dashboard.json
@@ -302,7 +302,7 @@
           "targets": [
             {
               "refId": "A",
-              "expr": "kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+              "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
               "intervalFactor": 2,
               "step": 600,
               "metric": "kube_deployment_spec_replicas"
@@ -381,7 +381,7 @@
           "targets": [
             {
               "refId": "A",
-              "expr": "kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+              "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
               "intervalFactor": 2,
               "step": 600
             }
@@ -505,7 +505,7 @@
           },
           "targets": [
             {
-              "expr": "kube_deployment_status_observed_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+              "expr": "max(kube_deployment_status_observed_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
               "intervalFactor": 2,
               "legendFormat": "",
               "refId": "A",
@@ -583,7 +583,7 @@
           },
           "targets": [
             {
-              "expr": "kube_deployment_metadata_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+              "expr": "max(kube_deployment_metadata_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
               "intervalFactor": 2,
               "legendFormat": "",
               "refId": "A",
@@ -649,35 +649,35 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "kube_deployment_status_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+              "expr": "max(kube_deployment_status_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
               "intervalFactor": 2,
               "legendFormat": "current replicas",
               "refId": "A",
               "step": 30
             },
             {
-              "expr": "kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+              "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
               "intervalFactor": 2,
               "legendFormat": "available",
               "refId": "B",
               "step": 30
             },
             {
-              "expr": "kube_deployment_status_replicas_unavailable{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+              "expr": "max(kube_deployment_status_replicas_unavailable{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
               "intervalFactor": 2,
               "legendFormat": "unavailable",
               "refId": "C",
               "step": 30
             },
             {
-              "expr": "kube_deployment_status_replicas_updated{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+              "expr": "min(kube_deployment_status_replicas_updated{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
               "intervalFactor": 2,
               "legendFormat": "updated",
               "refId": "D",
               "step": 30
             },
             {
-              "expr": "kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+              "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
               "intervalFactor": 2,
               "legendFormat": "desired",
               "refId": "E",

--- a/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: kube-state-metrics
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
@@ -1166,7 +1166,7 @@ data:
               "targets": [
                 {
                   "refId": "A",
-                  "expr": "kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
                   "intervalFactor": 2,
                   "step": 600,
                   "metric": "kube_deployment_spec_replicas"
@@ -1245,7 +1245,7 @@ data:
               "targets": [
                 {
                   "refId": "A",
-                  "expr": "kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
                   "intervalFactor": 2,
                   "step": 600
                 }
@@ -1369,7 +1369,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "kube_deployment_status_observed_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "expr": "max(kube_deployment_status_observed_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
                   "intervalFactor": 2,
                   "legendFormat": "",
                   "refId": "A",
@@ -1447,7 +1447,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "kube_deployment_metadata_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "expr": "max(kube_deployment_metadata_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
                   "intervalFactor": 2,
                   "legendFormat": "",
                   "refId": "A",
@@ -1513,35 +1513,35 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "kube_deployment_status_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "expr": "max(kube_deployment_status_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
                   "intervalFactor": 2,
                   "legendFormat": "current replicas",
                   "refId": "A",
                   "step": 30
                 },
                 {
-                  "expr": "kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
                   "intervalFactor": 2,
                   "legendFormat": "available",
                   "refId": "B",
                   "step": 30
                 },
                 {
-                  "expr": "kube_deployment_status_replicas_unavailable{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "expr": "max(kube_deployment_status_replicas_unavailable{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
                   "intervalFactor": 2,
                   "legendFormat": "unavailable",
                   "refId": "C",
                   "step": 30
                 },
                 {
-                  "expr": "kube_deployment_status_replicas_updated{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "expr": "min(kube_deployment_status_replicas_updated{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
                   "intervalFactor": 2,
                   "legendFormat": "updated",
                   "refId": "D",
                   "step": 30
                 },
                 {
-                  "expr": "kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance)",
                   "intervalFactor": 2,
                   "legendFormat": "desired",
                   "refId": "E",


### PR DESCRIPTION
This can happen if you run multiple replicas, or if you redeploy kube-state-metrics.
In either case, prometheus records multiple metrics with the instance ip in, and the dashboard fails.

This uses aggregation functions to get sensible output in either case

I've switched between max and min to try and be pessimistic where appropriate (e.g. max for generations and total replicas, min for available replicas etc.)
Shouldn't really matter given multiple copies should report the same data anyway