### PR TITLE
test: Add jenkins job building the docs to check if they changed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,10 @@
 job('prometheus-operator-unit-tests') {
     concurrentBuild()
 
+    parameters {
+        stringParam('sha1')
+    }
+
     scm {
         git {
             remote {
@@ -20,6 +24,10 @@ job('prometheus-operator-unit-tests') {
                     context('prometheus-operator-unit-tests')
                     triggeredStatus('Tests triggered')
                     startedStatus('Tests started')
+                    completedStatus('SUCCESS', 'Success')
+                    completedStatus('FAILURE', 'Failure')
+                    completedStatus('PENDING', 'Pending')
+                    completedStatus('ERROR', 'Error')
                 }
             }
         }
@@ -27,6 +35,47 @@ job('prometheus-operator-unit-tests') {
 
     steps {
         shell('docker run --rm -v $PWD:/go/src/github.com/coreos/prometheus-operator -w /go/src/github.com/coreos/prometheus-operator golang make test')
+    }
+}
+job('prometheus-operator-docs') {
+    concurrentBuild()
+
+    parameters {
+        stringParam('sha1')
+    }
+
+
+    scm {
+        git {
+            remote {
+                github('coreos/prometheus-operator')
+                refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+            }
+            branch('${sha1}')
+        }
+    }
+
+    triggers {
+        githubPullRequest {
+            useGitHubHooks()
+            orgWhitelist(['coreos-inc'])
+            extensions {
+                commitStatus {
+                    context('prometheus-operator-docs')
+                    triggeredStatus('Tests triggered')
+                    startedStatus('Tests started')
+                    completedStatus('SUCCESS', 'Success')
+                    completedStatus('FAILURE', 'Failure')
+                    completedStatus('PENDING', 'Pending')
+                    completedStatus('ERROR', 'Error')
+                }
+            }
+        }
+    }
+
+    steps {
+        shell('docker run -v $PWD:/go/src/github.com/coreos/prometheus-operator -w /go/src/github.com/coreos/prometheus-operator/ golang make docs')
+        shell('git diff --exit-code')
     }
 }
 job('prometheus-operator-e2e-tests') {
@@ -66,6 +115,10 @@ job('prometheus-operator-e2e-tests') {
                     context('prometheus-operator-e2e-tests')
                     triggeredStatus('Tests triggered')
                     startedStatus('Tests started')
+                    completedStatus('SUCCESS', 'Success')
+                    completedStatus('FAILURE', 'Failure')
+                    completedStatus('PENDING', 'Pending')
+                    completedStatus('ERROR', 'Error')
                 }
             }
         }


### PR DESCRIPTION
The prometheus operator api docs are generated automatically. To ensure
the docs are not out of sync with the code we generate the docs on every
pr and check if they changed.