### PR TITLE
Add warning about Grafana HA

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -82,6 +82,9 @@ This allows managing dashboards via `git` etc. and easily deploying them via CD 
 In the future, a separate Grafana operator will support gathering dashboards from multiple
 ConfigMaps based on label selection.
 
+WARNING: If you deploy multiple Grafana instances for HA, you must use session affinity.
+Otherwise if pods restart the prometheus datasource ID can get out of sync between the pods, breaking the UI
+
 ## Roadmap
 
 * Grafana Operator that dynamically discovers and deploys dashboards from ConfigMaps


### PR DESCRIPTION
We've just hit an issue where:
- if you have multiple grafana pods
- then you update the configmap to change dashboards
- then some of the grafana pods get restarted (but not all)

then the prometheus datasource ID is 0 on the new ones and N on the others, so URLs generated by one grafana instance don't work on the others.

We've fixed this by adding this to our Ingress:
```
  annotations:
    ingress.kubernetes.io/affinity: cookie
```