### PR TITLE
test: Check whether alertmanager reloads its config

### DIFF
--- a/test/e2e/alertmanager_e2e_test.go
+++ b/test/e2e/alertmanager_e2e_test.go
@@ -233,7 +233,6 @@ func TestMeshInitialization(t *testing.T) {
 
 func TestAlertmanagerReloadConfig(t *testing.T) {
 	alertmanager := framework.MakeBasicAlertmanager("reload-config", 1)
-	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
 
 	firstConfig := `
 global:
@@ -277,16 +276,9 @@ receivers:
 		if err := framework.DeleteAlertmanagerAndWaitUntilGone(alertmanager.Name); err != nil {
 			t.Fatal(err)
 		}
-		if err := framework.DeleteService(alertmanagerService.Name); err != nil {
-			t.Fatal(err)
-		}
 	}()
 
 	if err := framework.CreateAlertmanagerAndWaitUntilReady(alertmanager); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := framework.CreateServiceAndWaitUntilReady(alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e/alertmanager_e2e_test.go
+++ b/test/e2e/alertmanager_e2e_test.go
@@ -294,7 +294,7 @@ receivers:
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerResolveTimeoutConfig(alertmanager.Name, 6*60*1000000000); err != nil {
+	if err := framework.WaitForSpecificAlertmanagerConfig(alertmanager.Name, firstConfig); err != nil {
 		t.Fatal(err)
 	}
 
@@ -304,7 +304,7 @@ receivers:
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerResolveTimeoutConfig(alertmanager.Name, 5*60*1000000000); err != nil {
+	if err := framework.WaitForSpecificAlertmanagerConfig(alertmanager.Name, secondConfig); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/e2e/framework/alertmanager.go
+++ b/test/e2e/framework/alertmanager.go
@@ -201,19 +201,18 @@ func (f *Framework) GetAlertmanagerConfig(n string) (alertmanagerStatus, error) 
 	return amStatus, nil
 }
 
-func (f *Framework) WaitForAlertmanagerResolveTimeoutConfig(amName string, resolveTimeout int) error {
+func (f *Framework) WaitForSpecificAlertmanagerConfig(amName string, expectedConfig string) error {
 	return f.Poll(time.Minute*5, time.Second, func() (bool, error) {
 		config, err := f.GetAlertmanagerConfig("alertmanager-" + amName + "-0")
 		if err != nil {
 			return false, err
 		}
 
-		if config.Data.ConfigJSON.Global.ResolveTimeout != 6*60*1000000000 {
-			fmt.Print(config.Data.ConfigJSON.Global.ResolveTimeout)
-			return false, nil
+		if config.Data.Config == expectedConfig {
+			return true, nil
 		}
 
-		return true, nil
+		return false, nil
 	})
 }
 
@@ -223,15 +222,7 @@ type alertmanagerStatus struct {
 
 type alertmanagerStatusData struct {
 	MeshStatus meshStatus `json:"meshStatus"`
-	ConfigJSON configJSON `json:"configJSON"`
-}
-
-type configJSON struct {
-	Global configJSONGlobal `json:"global"`
-}
-
-type configJSONGlobal struct {
-	ResolveTimeout int `json:"resolve_timeout"`
+	Config     string     `json:"config"`
 }
 
 type meshStatus struct {


### PR DESCRIPTION
This test first creates a config inside a kubernetes secret, checks if
alertmanager picks the config up correctly. Then it changes the config
and checks again if it is loaded by alertmanager correctly.

This is related to PR #201 