### PR TITLE
RBAC: update RBAC requirements for Prometheus

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -80,6 +80,8 @@ The Prometheus server itself accesses the Kubernetes API to discover targets and
 
 As Prometheus does not modify any Objects in the Kubernetes API, but just reads them it simply requires the `get`, `list`, and `watch` actions.
 
+In addition to the resources Prometheus itself needs to access, the Prometheus side-car needs to be able to `get` configmaps to be able to pull in rule files from configmap objects.
+
 [embedmd]:# (../example/rbac/prometheus-cluster-role.yaml)
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1alpha1
@@ -94,6 +96,10 @@ rules:
   - endpoints
   - pods
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
 ```
 
 > Note: A cluster admin is required to create this `ClusterRole` and create a `ClusterRoleBinding` or `RoleBinding` to the `ServiceAccount` used by the Prometheus `Pod`s.  The `ServiceAccount` used by the Prometheus `Pod`s can be specified in the `Prometheus` object.

--- a/cmd/apidocgen/main.go
+++ b/cmd/apidocgen/main.go
@@ -1,3 +1,17 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/example/rbac/prometheus-cluster-role.yaml
+++ b/example/rbac/prometheus-cluster-role.yaml
@@ -10,3 +10,7 @@ rules:
   - endpoints
   - pods
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]


### PR DESCRIPTION
Due to the recently developed Prometheus side-car the RBAC requirements
for Prometheus Pods has changed slightly.

@fabxc @mxinden 