### PR TITLE
test: Fix flaky ingress tests

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -221,11 +221,8 @@ func (f *Framework) WaitForPodsRunImage(expectedReplicas int, image string, opts
 }
 
 func (f *Framework) WaitForHTTPSuccessStatusCode(timeout time.Duration, url string) error {
-	return f.Poll(time.Minute*5, time.Second, func() (bool, error) {
+	return f.Poll(timeout, time.Second, func() (bool, error) {
 		resp, err := http.Get(url)
-		if err != nil {
-			return false, err
-		}
 		if err == nil && resp.StatusCode == 200 {
 			return true, nil
 		}


### PR DESCRIPTION
If the ingress controller is not yet, polling will result in a global
error. Before this would end the polling. Instead now we still keep on
polling to give the ingress controller more time to start.

Issue noticed in PR #219 