### PR TITLE
Switched alertmanager-main from Secret to ConfigMap

### DIFF
--- a/contrib/kube-prometheus/manifests/alertmanager/alertmanager-config.yaml
+++ b/contrib/kube-prometheus/manifests/alertmanager/alertmanager-config.yaml
@@ -1,6 +1,18 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: alertmanager-main
 data:
-  alertmanager.yaml: Z2xvYmFsOgogIHJlc29sdmVfdGltZW91dDogNW0Kcm91dGU6CiAgZ3JvdXBfYnk6IFsnam9iJ10KICBncm91cF93YWl0OiAzMHMKICBncm91cF9pbnRlcnZhbDogNW0KICByZXBlYXRfaW50ZXJ2YWw6IDEyaAogIHJlY2VpdmVyOiAnd2ViaG9vaycKcmVjZWl2ZXJzOgotIG5hbWU6ICd3ZWJob29rJwogIHdlYmhvb2tfY29uZmlnczoKICAtIHVybDogJ2h0dHA6Ly9hbGVydG1hbmFnZXJ3aDozMDUwMC8nCg==
+  alertmanager.yaml: |-
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ['job']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      receiver: 'webhook'
+    receivers:
+    - name: 'webhook'
+      webhook_configs:
+      - url: 'http://alertmanagerwh:30500/'


### PR DESCRIPTION
`alertmanager` deployed using the  `contrib/kube-prometheus/hack/cluster-monitoring/self-hosted-deploy` script expects a `ConfigMap` called `alertmanager-main`. The previous version was a Secret.