### PR TITLE
Removed the erroneous dash beside apiVersion

### DIFF
--- a/example/networkpolicies/grafana.yaml
+++ b/example/networkpolicies/grafana.yaml
@@ -1,12 +1,12 @@
-- apiVersion: extensions/v1beta1
-  kind: NetworkPolicy
-  metadata:
-    name: grafana
-  spec:
-    ingress:
-    - ports:
-      - port: 3000
-        protocol: tcp
-    podSelector:
-      matchLabels:
-        app: grafana
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: grafana
+spec:
+  ingress:
+  - ports:
+    - port: 3000
+      protocol: tcp
+  podSelector:
+    matchLabels:
+      app: grafana


### PR DESCRIPTION
Previous version had a dash on the first line which prevent the script from being imported into k8s