### PR TITLE
kube-prometheus: add RBAC resources

### DIFF
--- a/Documentation/network-policies.md
+++ b/Documentation/network-policies.md
@@ -86,18 +86,18 @@ spec:
 
 [embedmd]:# (../example/networkpolicies/grafana.yaml)
 ```yaml
-- apiVersion: extensions/v1beta1
-  kind: NetworkPolicy
-  metadata:
-    name: grafana
-  spec:
-    ingress:
-    - ports:
-      - port: 3000
-        protocol: tcp
-    podSelector:
-      matchLabels:
-        app: grafana
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: grafana
+spec:
+  ingress:
+  - ports:
+    - port: 3000
+      protocol: tcp
+  podSelector:
+    matchLabels:
+      app: grafana
 ```
 
 #### Prometheus

--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -226,6 +226,7 @@ spec:
       labels:
         app: kube-state-metrics
     spec:
+      serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
         image: gcr.io/google_containers/kube-state-metrics:v0.4.1
@@ -241,6 +242,8 @@ spec:
             cpu: 200m
 
 ```
+
+> Make sure that the `ServiceAccount` called `kube-state-metrics` exists and if using RBAC, is bound to the correct role. See the kube-state-metrics [repository for RBAC requirements](https://github.com/kubernetes/kube-state-metrics/tree/master/kubernetes).
 
 And the respective `Service` manifest:
 

--- a/contrib/kube-prometheus/hack/cluster-monitoring/deploy
+++ b/contrib/kube-prometheus/hack/cluster-monitoring/deploy
@@ -14,7 +14,7 @@ kctl() {
     kubectl --namespace "$NAMESPACE" "$@"
 }
 
-kctl apply -f manifests/prometheus-operator.yaml
+kctl apply -f manifests/prometheus-operator
 
 # Wait for TPRs to be ready.
 printf "Waiting for Operator to register third party objects..."
@@ -28,6 +28,9 @@ kctl apply -f manifests/grafana
 
 kctl apply -f manifests/prometheus/prometheus-k8s-rules.yaml
 kctl apply -f manifests/prometheus/prometheus-k8s-service.yaml
+kctl apply -f manifests/prometheus/prometheus-cluster-role-binding.yaml
+kctl apply -f manifests/prometheus/prometheus-cluster-role.yaml
+kctl apply -f manifests/prometheus/prometheus-k8s-service-account.yaml
 
 kctl apply -f manifests/alertmanager/alertmanager-config.yaml
 kctl apply -f manifests/alertmanager/alertmanager-service.yaml

--- a/contrib/kube-prometheus/hack/cluster-monitoring/teardown
+++ b/contrib/kube-prometheus/hack/cluster-monitoring/teardown
@@ -20,5 +20,5 @@ kctl delete -f manifests/alertmanager
 # Hack: wait a bit to let the controller delete the deployed Prometheus server.
 sleep 5
 
-kctl delete -f manifests/prometheus-operator.yaml
+kctl delete -f manifests/prometheus-operator
 

--- a/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-cluster-role-binding.yaml
+++ b/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: monitoring

--- a/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-cluster-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - pods
+  - resourcequotas
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]

--- a/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-deployment.yaml
@@ -9,6 +9,7 @@ spec:
       labels:
         app: kube-state-metrics
     spec:
+      serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
         image: gcr.io/google_containers/kube-state-metrics:v0.4.1

--- a/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-service-account.yaml
+++ b/contrib/kube-prometheus/manifests/exporters/kube-state-metrics-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics

--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-operator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-operator
+  namespace: default

--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRole
+metadata:
+  name: prometheus-operator
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - thirdpartyresources
+  verbs:
+  - create
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - servicemonitors
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "delete"]
+- apiGroups: [""]
+  resources:
+  - services
+  - endpoints
+  verbs: ["get", "create", "update"]
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]

--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-service-account.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-operator

--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator.yaml
@@ -11,12 +11,13 @@ spec:
       labels:
         operator: prometheus
     spec:
+      serviceAccountName: prometheus-operator
       containers:
        - name: prometheus-operator
          image: quay.io/coreos/prometheus-operator:v0.7.0
          args:
-           - "--kubelet-object=kube-system/kubelet"
-           - "--config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1"
+         - "--kubelet-object=kube-system/kubelet"
+         - "--config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1"
          resources:
            requests:
              cpu: 100m

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-cluster-role-binding.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-cluster-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-account.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-k8s

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   replicas: 2
   version: v1.5.2
+  serviceAccountName: prometheus-k8s
   serviceMonitorSelector:
     matchExpression:
     - {key: k8s-apps, operator: Exists}


### PR DESCRIPTION
With Kubernetes 1.6 RBAC is becoming a default. Therefore we should make sure that everything necessary to run end to end monitoring is RBAC aware.

Should be good to merge if you can successfully deploy this on a 1.6.x cluster.

@fabxc @mxinden 