### PR TITLE
grafana-watcher: use official documented API

### DIFF
--- a/contrib/grafana-watcher/Makefile
+++ b/contrib/grafana-watcher/Makefile
@@ -3,18 +3,19 @@ all: build
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 REGISTRY = quay.io/coreos
-TAG = latest
+TAG = v0.0.1
+NAME = grafana-watcher
 
 build:
-	$(ENVVAR) go build -o grafana-watcher main.go
+	$(ENVVAR) go build -o ${NAME} main.go
 
 image: build
-	docker build -t ${REGISTRY}/grafana-watcher:$(TAG) .
+	docker build -t ${REGISTRY}/${NAME}:$(TAG) .
 
 push: image
-	docker push ${REGISTRY}/grafana-watcher:$(TAG)
+	docker push ${REGISTRY}/${NAME}:$(TAG)
 
 clean:
-	rm -f grafana-watcher
+	rm -f ${NAME}
 
 .PHONY: all build image push clean

--- a/contrib/grafana-watcher/examples/grafana-bundle.yaml
+++ b/contrib/grafana-watcher/examples/grafana-bundle.yaml
@@ -61,7 +61,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:latest
+        image: quay.io/coreos/grafana-watcher:v0.0.1
         imagePullPolicy: Never
         args:
           - '--watch-dir=/var/grafana-dashboards'

--- a/contrib/grafana-watcher/grafana/dashboard.go
+++ b/contrib/grafana-watcher/grafana/dashboard.go
@@ -84,7 +84,7 @@ func (c *DashboardsClient) Delete(slug string) error {
 }
 
 func (c *DashboardsClient) Create(dashboardJson io.Reader) error {
-	importDashboardUrl := c.BaseUrl + "/api/dashboards/import"
+	importDashboardUrl := c.BaseUrl + "/api/dashboards/db"
 	_, err := c.HTTPClient.Post(importDashboardUrl, "application/json", dashboardJson)
 	if err != nil {
 		return err

--- a/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             memory: 300Mi
             cpu: 300m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:latest
+        image: quay.io/coreos/grafana-watcher:v0.0.1
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://admin:admin@localhost:3000'


### PR DESCRIPTION
Fixes #224 

@fabxc @mxinden 

Will push the new version (`v0.0.1`) to quay once this we merge this change.