### PR TITLE
grafana-watcher: revert to import endpoint

### DIFF
--- a/contrib/grafana-watcher/Makefile
+++ b/contrib/grafana-watcher/Makefile
@@ -3,7 +3,7 @@ all: build
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 REGISTRY = quay.io/coreos
-TAG = v0.0.1
+TAG = v0.0.2
 NAME = grafana-watcher
 
 build:

--- a/contrib/grafana-watcher/examples/grafana-bundle.yaml
+++ b/contrib/grafana-watcher/examples/grafana-bundle.yaml
@@ -61,7 +61,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.1
+        image: quay.io/coreos/grafana-watcher:v0.0.2
         imagePullPolicy: Never
         args:
           - '--watch-dir=/var/grafana-dashboards'

--- a/contrib/grafana-watcher/grafana/dashboard.go
+++ b/contrib/grafana-watcher/grafana/dashboard.go
@@ -84,7 +84,7 @@ func (c *DashboardsClient) Delete(slug string) error {
 }
 
 func (c *DashboardsClient) Create(dashboardJson io.Reader) error {
-	importDashboardUrl := c.BaseUrl + "/api/dashboards/db"
+	importDashboardUrl := c.BaseUrl + "/api/dashboards/import"
 	_, err := c.HTTPClient.Post(importDashboardUrl, "application/json", dashboardJson)
 	if err != nil {
 		return err

--- a/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             memory: 300Mi
             cpu: 300m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.1
+        image: quay.io/coreos/grafana-watcher:v0.0.2
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://admin:admin@localhost:3000'


### PR DESCRIPTION
The dashboard create endpoint behaves slightly different when templating
is used. The import API works exactly the same as the front-end import
functionality.

@fabxc @mxinden 

/cc @nirdothan