### PR TITLE
kube-prometheus: fix rolebinding

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-operator
-  namespace: default
+  namespace: monitoring


### PR DESCRIPTION
This entire thing is built in the monitoring namespace but the
rolebinding was on default. This caused the operator to never launch.