### PR TITLE
Add Helm chart by mgoodness

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+description: Provides easy monitoring definitions for Kubernetes services, and deployment and management of Prometheus instances.
+engine: gotpl
+maintainers:
+  - name: Michael Goodness
+    email: mgoodness@gmail.com
+name: prometheus-operator
+sources:
+  - https://github.com/coreos/prometheus-operator
+version: 0.1.0

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,66 @@
+# prometheus-operator
+
+Installs [prometheus-operator](https://github.com/coreos/prometheus-operator) to create/configure/manage Prometheus clusters atop Kubernetes.
+
+## TL;DR;
+
+```console
+$ helm install opsgoodness/prometheus-operator
+```
+
+## Introduction
+
+This chart bootstraps a [prometheus-operator](https://github.com/coreos/prometheus-operator) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+  - Kubernetes 1.4+ with Beta APIs & ThirdPartyResources enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install opsgoodness/prometheus-operator --name my-release
+```
+
+The command deploys prometheus-operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the prometheus-operator chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`global.hyperkube.repository` | Hyperkube image | `quay.io/coreos/hyperkube`
+`global.hyperkube.tag` | Hyperkube image tag | `v1.5.3_coreos.0`
+`global.hyperkube.pullPolicy` | Hyperkube image pull policy | `IfNotPresent`
+`image.repository` | Image | `quay.io/coreos/prometheus-operator`
+`image.tag` | Image tag | `v0.6.0`
+`image.pullPolicy` | Image pull policy | `IfNotPresent`
+`nodeSelector` | Node labels for pod assignment | `{}`
+`resources` | Pod resource requests & limits | `{}`
+`sendAnalytics` | Collect & send anonymous usage statistics | `true`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install opsgoodness/prometheus-operator --name my-release --set sendAnalytics=true
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install opsgoodness/prometheus-operator --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,6 @@
+The Prometheus Operator has been installed. Check its status by running:
+  kubectl --namespace {{ .Release.Namespace }} get pods \
+    -l "app={{ template "name" . }},release={{ .Release.Name }}"
+
+Visit https://github.com/coreos/prometheus-operator for instructions on how
+to create & configure Alertmanager and Prometheus instances using the Operator.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/templates/cleanup-job.yaml
+++ b/helm/templates/cleanup-job.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-delete
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-cleanup
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+      name: {{ template "fullname" . }}-cleanup
+    spec:
+      containers:
+        - name: delete-services
+          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          imagePullPolicy: "{{ .Values.global.hyperkube.pullPolicy }}"
+          command:
+            - /bin/bash
+            - -c
+            - for n in $(/kubectl get namespaces -o jsonpath={..metadata.name}); do /kubectl delete --ignore-not-found --namespace $n services prometheus-operated alertmanager-operated; done
+        - name: delete-tprs
+          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          imagePullPolicy: "{{ .Values.global.hyperkube.pullPolicy }}"
+          command:
+            - /kubectl
+            - delete
+            - --ignore-not-found
+            - thirdpartyresource
+            - alertmanager.monitoring.coreos.com
+            - prometheus.monitoring.coreos.com
+            - service-monitor.monitoring.coreos.com
+      restartPolicy: OnFailure

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    operator: prometheus
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        operator: prometheus
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          args:
+            - --analytics={{ .Values.sendAnalytics }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/helm/templates/get-tprs-job.yaml
+++ b/helm/templates/get-tprs-job.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-get-tprs
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+      name: {{ template "fullname" . }}-get-tprs
+    spec:
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          imagePullPolicy: "{{ .Values.global.hyperkube.pullPolicy }}"
+          command:
+            - ./kubectl
+            - get
+            - thirdpartyresource
+            - alertmanager.monitoring.coreos.com
+            - prometheus.monitoring.coreos.com
+            - service-monitor.monitoring.coreos.com
+      restartPolicy: OnFailure

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,34 @@
+global:
+  ## Hyperkube image to use when getting ThirdPartyResources & cleaning up
+  ##
+  hyperkube:
+    repository: quay.io/coreos/hyperkube
+    tag: v1.5.3_coreos.0
+    pullPolicy: IfNotPresent
+
+## Prometheus-operator image
+##
+image:
+  repository: quay.io/coreos/prometheus-operator
+  tag: v0.6.0
+  pullPolicy: IfNotPresent
+
+## Node labels for prometheus-operator pod assignment
+##
+nodeSelector: {}
+
+## If true, collect & send anonymous usage statistics
+## Ref: https://github.com/coreos/prometheus-operator#installation
+##
+sendAnalytics: true
+
+## Prometheus-operator resource limits & requests
+## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+  # limits:
+  #   cpu: 200m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 50Mi


### PR DESCRIPTION
@mgoodness as discussed on Slack, we'd like to maintain Helm charts along with the repo itself to make it easier to keep versions in sync.

Later on also moving the kube-prometheus packaging stuff would be great.

This just moves the prometheus-operator charts including their commit history. RBAC files should be added.

@brancz 