### PR TITLE
Introduce pkg/errors to ingress tests

### DIFF
--- a/test/e2e/alertmanager_e2e_test.go
+++ b/test/e2e/alertmanager_e2e_test.go
@@ -185,7 +185,7 @@ func TestExposingAlertmanagerWithIngress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = framework.WaitForHTTPSuccessStatusCode(time.Second*30, fmt.Sprintf("http://%s/metrics", *ip))
+	err = framework.WaitForHTTPSuccessStatusCode(time.Minute, fmt.Sprintf("http://%s/metrics", *ip))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
 	"github.com/coreos/prometheus-operator/pkg/prometheus"
+	"github.com/pkg/errors"
 )
 
 func (f *Framework) MakeBasicPrometheus(name, group string, replicas int32) *v1alpha1.Prometheus {
@@ -157,15 +158,15 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(name string) error {
 	log.Printf("Deleting Prometheus (%s/%s)", f.Namespace.Name, name)
 	_, err := f.MonClient.Prometheuses(f.Namespace.Name).Get(name)
 	if err != nil {
-		return err
+		return errors.Wrap(err, fmt.Sprintf("requesting Prometheus tpr %v failed", name))
 	}
 
 	if err := f.MonClient.Prometheuses(f.Namespace.Name).Delete(name, nil); err != nil {
-		return err
+		return errors.Wrap(err, fmt.Sprintf("deleting Prometheus tpr %v failed", name))
 	}
 
 	if err := f.WaitForPodsReady(0, prometheus.ListOptions(name)); err != nil {
-		return fmt.Errorf("failed to teardown Prometheus instances (%s): %v", name, err)
+		return errors.Wrap(err, fmt.Sprintf("waiting for Prometheus tpr (%s) to vanish timed out", name))
 	}
 
 	return nil

--- a/test/e2e/prometheus_e2e_test.go
+++ b/test/e2e/prometheus_e2e_test.go
@@ -461,7 +461,7 @@ func TestExposingPrometheusWithIngress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = framework.WaitForHTTPSuccessStatusCode(time.Second*30, fmt.Sprintf("http://%s:/metrics", *ip))
+	err = framework.WaitForHTTPSuccessStatusCode(time.Minute, fmt.Sprintf("http://%s:/metrics", *ip))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Adding context before passing down an error message with the library
pkg/errors is hopefully going to help us with debugging failing tests on
the Jenkins CI. This is supposed to happen with all prometheus-operator
tests in the long run.

Related to PR #234 