### PR TITLE
test: Replace own framework.Poll with client-go wait.Poll

### DIFF
--- a/test/e2e/framework/alertmanager.go
+++ b/test/e2e/framework/alertmanager.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/util/intstr"
+	"k8s.io/client-go/pkg/util/wait"
 	"k8s.io/client-go/pkg/util/yaml"
 
 	"github.com/coreos/prometheus-operator/pkg/alertmanager"
@@ -174,7 +175,7 @@ func amImage(version string) string {
 }
 
 func (f *Framework) WaitForAlertmanagerInitializedMesh(name string, amountPeers int) error {
-	return f.Poll(time.Second*20, time.Second, func() (bool, error) {
+	return wait.Poll(time.Second, time.Second*20, func() (bool, error) {
 		amStatus, err := f.GetAlertmanagerConfig(name)
 		if err != nil {
 			return false, err
@@ -203,7 +204,7 @@ func (f *Framework) GetAlertmanagerConfig(n string) (alertmanagerStatus, error) 
 }
 
 func (f *Framework) WaitForSpecificAlertmanagerConfig(amName string, expectedConfig string) error {
-	return f.Poll(time.Minute*5, time.Second, func() (bool, error) {
+	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		config, err := f.GetAlertmanagerConfig("alertmanager-" + amName + "-0")
 		if err != nil {
 			return false, err

--- a/test/e2e/framework/ingress.go
+++ b/test/e2e/framework/ingress.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/pkg/util/intstr"
+	"k8s.io/client-go/pkg/util/wait"
 	"k8s.io/client-go/pkg/util/yaml"
 	"os"
 	"time"
@@ -123,7 +124,7 @@ func (f *Framework) DeleteNginxIngressControllerIncDefaultBackend() error {
 
 func (f *Framework) GetIngressIP(ingressName string) (*string, error) {
 	var ingress *v1beta1.Ingress
-	err := f.Poll(time.Minute*5, time.Millisecond*500, func() (bool, error) {
+	err := wait.Poll(time.Millisecond*500, time.Minute*5, func() (bool, error) {
 		var err error
 		ingress, err = f.KubeClient.Extensions().Ingresses(f.Namespace.Name).Get(ingressName)
 		if err != nil {

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/util/intstr"
+	"k8s.io/client-go/pkg/util/wait"
 
 	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
 	"github.com/coreos/prometheus-operator/pkg/prometheus"
@@ -186,7 +187,7 @@ func promImage(version string) string {
 func (f *Framework) WaitForTargets(amount int) error {
 	var targets []*Target
 
-	if err := f.Poll(time.Minute*10, time.Second, func() (bool, error) {
+	if err := wait.Poll(time.Second, time.Minute*10, func() (bool, error) {
 		var err error
 		targets, err = f.GetActiveTargets()
 		if err != nil {

--- a/test/e2e/framework/replication-controller.go
+++ b/test/e2e/framework/replication-controller.go
@@ -15,10 +15,12 @@
 package framework
 
 import (
-	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/pkg/util/yaml"
 	"os"
 	"time"
+
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/util/wait"
+	"k8s.io/client-go/pkg/util/yaml"
 )
 
 func createReplicationControllerViaYml(filepath string, f *Framework) error {
@@ -73,7 +75,7 @@ func scaleDownReplicationController(f *Framework, rC v1.ReplicationController) e
 		return err
 	}
 
-	return f.Poll(time.Minute*5, time.Second, func() (bool, error) {
+	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		currentRC, err := rCAPI.Get(rC.Name)
 		if err != nil {
 			return false, err

--- a/test/e2e/framework/service.go
+++ b/test/e2e/framework/service.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/util/wait"
 	"time"
 )
 
@@ -33,7 +34,7 @@ func (f *Framework) CreateServiceAndWaitUntilReady(service *v1.Service) error {
 }
 
 func (f *Framework) WaitForServiceReady(serviceName string) error {
-	err := f.Poll(time.Minute*5, time.Second, func() (bool, error) {
+	err := wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		endpoints, err := f.KubeClient.CoreV1().Endpoints(f.Namespace.Name).Get(serviceName)
 		if err != nil {
 			return false, errors.Wrap(err, fmt.Sprintf("requesting endpoints for servce %v failed", serviceName))

--- a/test/e2e/prometheus_e2e_test.go
+++ b/test/e2e/prometheus_e2e_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/client-go/pkg/api/resource"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/util/wait"
 
 	"github.com/coreos/prometheus-operator/pkg/alertmanager"
 	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
@@ -230,7 +231,7 @@ func TestPrometheusReloadRules(t *testing.T) {
 	}
 
 	// remounting a ConfigMap can take some time
-	err = framework.Poll(time.Minute*5, time.Second, func() (bool, error) {
+	err = wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		logs, err := framework.GetLogs(fmt.Sprintf("prometheus-%s-0", name), "prometheus-config-reloader")
 		if err != nil {
 			return false, err
@@ -288,7 +289,7 @@ func TestPrometheusDiscovery(t *testing.T) {
 	}
 
 	log.Print("Validating Prometheus Targets were properly discovered")
-	err = framework.Poll(18*time.Minute, time.Second, isDiscoveryWorking(prometheusName))
+	err = wait.Poll(time.Second, 18*time.Minute, isDiscoveryWorking(prometheusName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +354,7 @@ func TestPrometheusAlertmanagerDiscovery(t *testing.T) {
 	}
 
 	log.Print("Validating Prometheus properly discovered alertmanagers")
-	err = framework.Poll(18*time.Minute, time.Second, isAlertmanagerDiscoveryWorking(alertmanagerName))
+	err = wait.Poll(time.Second, 18*time.Minute, isAlertmanagerDiscoveryWorking(alertmanagerName))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
@brancz As discussed replacing our *Poll* implementation with the client-go implementation.