### PR TITLE
Support both alpha & beta RBAC API

### DIFF
--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.7.0
+version: 0.7.1

--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.7.1
+version: 0.0.1

--- a/helm/prometheus-operator/templates/clusterrole.yaml
+++ b/helm/prometheus-operator/templates/clusterrole.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.rbacEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
 kind: ClusterRole
 metadata:
   labels:

--- a/helm/prometheus-operator/templates/clusterrolebinding.yaml
+++ b/helm/prometheus-operator/templates/clusterrolebinding.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.rbacEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Use `rbac.authorization.k8s.io/v1beta1` if the cluster supports it, otherwise fall back to `rbac.authorization.k8s.io/v1alpha1`.

Published as v0.7.1 and confirmed still working in K8s v1.5, but I don't yet have a K8s v1.6 cluster to test against. Recommend we wait for @peterrosell (or other) to deploy & confirm before merging.