### PR TITLE
grafana-watcher: allow credentials from env variable

### DIFF
--- a/contrib/grafana-watcher/Makefile
+++ b/contrib/grafana-watcher/Makefile
@@ -3,7 +3,7 @@ all: build
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 REGISTRY = quay.io/coreos
-TAG = v0.0.2
+TAG = v0.0.3
 NAME = grafana-watcher
 
 build:

--- a/contrib/grafana-watcher/examples/grafana-bundle.yaml
+++ b/contrib/grafana-watcher/examples/grafana-bundle.yaml
@@ -23,6 +23,15 @@ metadata:
   name: grafana-dashboards
 data:
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-credentials
+type: Opaque
+data:
+  password: c3VwZXJzZWNyZXRwYXNzd29yZA== # supersecretpassword
+  user: c3VwZXJzZWNyZXR1c2Vy             # supersecretuser
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -34,12 +43,6 @@ spec:
       labels:
         app: grafana
     spec:
-      volumes:
-      - name: grafana-storage
-        emptyDir: {}
-      - name: grafana-dashboards
-        configMap:
-          name: grafana-dashboards
       containers:
       - name: grafana
         image: grafana/grafana:4.1.1
@@ -48,11 +51,22 @@ spec:
           value: "true"
         - name: GF_AUTH_ANONYMOUS_ENABLED
           value: "true"
+        - name: GF_SECURITY_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: grafana-credentials
+              key: user
+        - name: GF_SECURITY_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: grafana-credentials
+              key: password
         volumeMounts:
         - name: grafana-storage
           mountPath: /var/grafana-storage
         ports:
-        - containerPort: 3000
+        - name: web
+          containerPort: 3000
         resources:
           requests:
             memory: 100Mi
@@ -61,11 +75,22 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.2
+        image: quay.io/coreos/grafana-watcher:v0.0.3
         imagePullPolicy: Never
         args:
           - '--watch-dir=/var/grafana-dashboards'
-          - '--grafana-url=http://admin:admin@localhost:3000'
+          - '--grafana-url=http://localhost:3000'
+        env:
+        - name: GRAFANA_USER
+          valueFrom:
+            secretKeyRef:
+              name: grafana-credentials
+              key: user
+        - name: GRAFANA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: grafana-credentials
+              key: password
         volumeMounts:
         - name: grafana-dashboards
           mountPath: /var/grafana-dashboards
@@ -79,4 +104,10 @@ spec:
         volumeMounts:
         - name: grafana-dashboards
           mountPath: /var/grafana-dashboards
+      volumes:
+      - name: grafana-storage
+        emptyDir: {}
+      - name: grafana-dashboards
+        configMap:
+          name: grafana-dashboards
 

--- a/contrib/grafana-watcher/grafana/dashboard.go
+++ b/contrib/grafana-watcher/grafana/dashboard.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -28,7 +29,7 @@ type DashboardsInterface interface {
 }
 
 type DashboardsClient struct {
-	BaseUrl    string
+	BaseUrl    *url.URL
 	HTTPClient *http.Client
 }
 
@@ -44,7 +45,7 @@ func (d *GrafanaDashboard) Slug() string {
 	return strings.TrimPrefix(d.Uri, "db/")
 }
 
-func NewDashboardsClient(baseUrl string, c *http.Client) DashboardsInterface {
+func NewDashboardsClient(baseUrl *url.URL, c *http.Client) DashboardsInterface {
 	return &DashboardsClient{
 		BaseUrl:    baseUrl,
 		HTTPClient: c,
@@ -52,7 +53,7 @@ func NewDashboardsClient(baseUrl string, c *http.Client) DashboardsInterface {
 }
 
 func (c *DashboardsClient) Search() ([]GrafanaDashboard, error) {
-	searchUrl := c.BaseUrl + "/api/search"
+	searchUrl := makeUrl(c.BaseUrl, "/api/search")
 	resp, err := c.HTTPClient.Get(searchUrl)
 	if err != nil {
 		return nil, err
@@ -69,7 +70,7 @@ func (c *DashboardsClient) Search() ([]GrafanaDashboard, error) {
 }
 
 func (c *DashboardsClient) Delete(slug string) error {
-	deleteUrl := c.BaseUrl + "/api/dashboards/db/" + slug
+	deleteUrl := makeUrl(c.BaseUrl, "/api/dashboards/db/"+slug)
 	req, err := http.NewRequest("DELETE", deleteUrl, nil)
 	if err != nil {
 		return err
@@ -84,7 +85,7 @@ func (c *DashboardsClient) Delete(slug string) error {
 }
 
 func (c *DashboardsClient) Create(dashboardJson io.Reader) error {
-	importDashboardUrl := c.BaseUrl + "/api/dashboards/import"
+	importDashboardUrl := makeUrl(c.BaseUrl, "/api/dashboards/import")
 	_, err := c.HTTPClient.Post(importDashboardUrl, "application/json", dashboardJson)
 	if err != nil {
 		return err

--- a/contrib/grafana-watcher/grafana/grafana.go
+++ b/contrib/grafana-watcher/grafana/grafana.go
@@ -16,6 +16,7 @@ package grafana
 
 import (
 	"net/http"
+	"net/url"
 )
 
 type Interface interface {
@@ -24,11 +25,11 @@ type Interface interface {
 }
 
 type Clientset struct {
-	BaseUrl    string
+	BaseUrl    *url.URL
 	HTTPClient *http.Client
 }
 
-func New(baseUrl string) Interface {
+func New(baseUrl *url.URL) Interface {
 	return &Clientset{
 		BaseUrl:    baseUrl,
 		HTTPClient: http.DefaultClient,

--- a/contrib/kube-prometheus/hack/scripts/generate-grafana-credentials-secret.sh
+++ b/contrib/kube-prometheus/hack/scripts/generate-grafana-credentials-secret.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 user password"
+    exit 1
+fi
+
+user=$1
+password=$2
+
+cat <<-EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-credentials
+data:
+  user: $(echo -n ${user} | base64 --wrap=0)
+  password: $(echo -n ${password} | base64 --wrap=0)
+EOF
+

--- a/contrib/kube-prometheus/hack/scripts/generate-manifests.sh
+++ b/contrib/kube-prometheus/hack/scripts/generate-manifests.sh
@@ -6,6 +6,9 @@ hack/scripts/generate-rules-configmap.sh > manifests/prometheus/prometheus-k8s-r
 # Generate Dashboard ConfigMap
 hack/scripts/generate-dashboards-configmap.sh > manifests/grafana/grafana-dashboards.yaml
 
+# Generate Grafana Credentials Secret
+hack/scripts/generate-grafana-credentials-secret.sh admin admin > manifests/grafana/grafana-credentials.yaml
+
 # Generate Secret for Alertmanager config
 hack/scripts/generate-alertmanager-config-secret.sh > manifests/alertmanager/alertmanager-config.yaml
 

--- a/contrib/kube-prometheus/manifests/grafana/grafana-credentials.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-credentials.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-credentials
+data:
+  user: YWRtaW4=
+  password: YWRtaW4=

--- a/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
@@ -17,6 +17,16 @@ spec:
           value: "true"
         - name: GF_AUTH_ANONYMOUS_ENABLED
           value: "true"
+        - name: GF_SECURITY_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: grafana-credentials
+              key: user
+        - name: GF_SECURITY_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: grafana-credentials
+              key: password
         volumeMounts:
         - name: grafana-storage
           mountPath: /var/grafana-storage
@@ -28,13 +38,25 @@ spec:
             memory: 100Mi
             cpu: 100m
           limits:
-            memory: 300Mi
-            cpu: 300m
+            memory: 200Mi
+            cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.2
+        image: quay.io/coreos/grafana-watcher:v0.0.3
+        imagePullPolicy: Never
         args:
           - '--watch-dir=/var/grafana-dashboards'
-          - '--grafana-url=http://admin:admin@localhost:3000'
+          - '--grafana-url=http://localhost:3000'
+        env:
+        - name: GRAFANA_USER
+          valueFrom:
+            secretKeyRef:
+              name: grafana-credentials
+              key: user
+        - name: GRAFANA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: grafana-credentials
+              key: password
         volumeMounts:
         - name: grafana-dashboards
           mountPath: /var/grafana-dashboards


### PR DESCRIPTION
This adds the ability to specify grafana credentials through environment variables. The default in kube-prometheus is still admin:admin, but now specified via a `Secret` instead of plaintext.

Closes #258

@fabxc @mxinden 