### PR TITLE
kube-prometheus: remove grafana never pull policy

### DIFF
--- a/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
@@ -42,7 +42,6 @@ spec:
             cpu: 200m
       - name: grafana-watcher
         image: quay.io/coreos/grafana-watcher:v0.0.3
-        imagePullPolicy: Never
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://localhost:3000'


### PR DESCRIPTION
This was previously used for debugging locally, but I forgot to remove it, and no error occurred because the image was present.

@fabxc @mxinden 