### PR TITLE
prometheus: add insecure port to kubelet endpoints object

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -238,10 +238,10 @@ spec:
           containerPort: 8080
         resources:
           requests:
-            memory: 30Mi
+            memory: 100Mi
             cpu: 100m
           limits:
-            memory: 50Mi
+            memory: 200Mi
             cpu: 200m
 
 ```

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -297,6 +297,10 @@ func (c *Operator) syncNodeEndpoints() {
 						Name: "https-metrics",
 						Port: 10250,
 					},
+					v1.EndpointPort{
+						Name: "http-metrics",
+						Port: 10255,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
As the insecure port is going to be necessary for the time being regarding metrics, we should have it on the Endpoints object we synchronize the kubelets into.

@fabxc @mxinden 