### PR TITLE
grafana-watcher login fixes

### DIFF
--- a/contrib/grafana-watcher/grafana/datasource.go
+++ b/contrib/grafana-watcher/grafana/datasource.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"errors"
 )
 
 type DatasourcesInterface interface {
@@ -56,6 +57,10 @@ func (c *DatasourcesClient) All() ([]GrafanaDatasource, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		err := errors.New("Invalid credentials. Update and reapply the grafana-credentials manifest, then redeploy grafana.")
+		return nil, err
+	}
 	datasources := make([]GrafanaDatasource, 0)
 
 	err = json.NewDecoder(resp.Body).Decode(&datasources)

--- a/contrib/kube-prometheus/hack/cluster-monitoring/deploy
+++ b/contrib/kube-prometheus/hack/cluster-monitoring/deploy
@@ -24,6 +24,7 @@ until kctl get alertmanager > /dev/null 2>&1; do sleep 1; printf "."; done
 echo "done!"
 
 kctl apply -f manifests/exporters
+kctl apply -f manifests/grafana/grafana-credentials.yaml
 kctl apply -f manifests/grafana
 
 kctl apply -f manifests/prometheus/prometheus-k8s-rules.yaml


### PR DESCRIPTION
There is a potential race condition when the grafana manifests are applied where the credentials may not be applied prior to the deployment, which depends on them. I believe this was the cause of some issues I had with `grafana-watcher`.

There is now a helpful error message when `grafana-watcher` cannot log in, and `grafana-credentials.yaml` are applied prior to other grafana manifests to prevent weird login conditions like the one I experienced.