### PR TITLE
Add default timeout to test framework

### DIFF
--- a/test/e2e/framework/alertmanager.go
+++ b/test/e2e/framework/alertmanager.go
@@ -130,7 +130,13 @@ func (f *Framework) CreateAlertmanagerAndWaitUntilReady(a *v1alpha1.Alertmanager
 		return errors.Wrap(err, fmt.Sprintf("creating alertmanager %v failed", a.Name))
 	}
 
-	err = WaitForPodsReady(f.KubeClient, f.Namespace.Name, int(*a.Spec.Replicas), alertmanager.ListOptions(a.Name))
+	err = WaitForPodsReady(
+		f.KubeClient,
+		f.Namespace.Name,
+		f.DefaultTimeout,
+		int(*a.Spec.Replicas),
+		alertmanager.ListOptions(a.Name),
+	)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to create an Alertmanager cluster (%s) with %d instances", a.Name, a.Spec.Replicas))
 	}
@@ -144,7 +150,13 @@ func (f *Framework) UpdateAlertmanagerAndWaitUntilReady(a *v1alpha1.Alertmanager
 		return err
 	}
 
-	err = WaitForPodsReady(f.KubeClient, f.Namespace.Name, int(*a.Spec.Replicas), alertmanager.ListOptions(a.Name))
+	err = WaitForPodsReady(
+		f.KubeClient,
+		f.Namespace.Name,
+		f.DefaultTimeout,
+		int(*a.Spec.Replicas),
+		alertmanager.ListOptions(a.Name),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to update %d Alertmanager instances (%s): %v", a.Spec.Replicas, a.Name, err)
 	}
@@ -163,7 +175,13 @@ func (f *Framework) DeleteAlertmanagerAndWaitUntilGone(name string) error {
 		return errors.Wrap(err, fmt.Sprintf("deleting Alertmanager tpr %v failed", name))
 	}
 
-	if err := WaitForPodsReady(f.KubeClient, f.Namespace.Name, 0, alertmanager.ListOptions(name)); err != nil {
+	if err := WaitForPodsReady(
+		f.KubeClient,
+		f.Namespace.Name,
+		f.DefaultTimeout,
+		0,
+		alertmanager.ListOptions(name),
+	); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("waiting for Alertmanager tpr (%s) to vanish timed out", name))
 	}
 

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -32,8 +32,8 @@ func PathToOSFile(relativPath string) (*os.File, error) {
 
 // WaitForPodsReady waits for a selection of Pods to be running and each
 // container to pass its readiness check.
-func WaitForPodsReady(kubeClient kubernetes.Interface, namespace string, expectedReplicas int, opts v1.ListOptions) error {
-	return wait.Poll(time.Second, time.Minute, func() (bool, error) {
+func WaitForPodsReady(kubeClient kubernetes.Interface, namespace string, timeout time.Duration, expectedReplicas int, opts v1.ListOptions) error {
+	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		pl, err := kubeClient.Core().Pods(namespace).List(opts)
 		if err != nil {
 			return false, err

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -132,7 +132,13 @@ func (f *Framework) CreatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) er
 		return err
 	}
 
-	err = WaitForPodsReady(f.KubeClient, f.Namespace.Name, int(*p.Spec.Replicas), prometheus.ListOptions(p.Name))
+	err = WaitForPodsReady(
+		f.KubeClient,
+		f.Namespace.Name,
+		f.DefaultTimeout,
+		int(*p.Spec.Replicas),
+		prometheus.ListOptions(p.Name),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create %d Prometheus instances (%s): %v", p.Spec.Replicas, p.Name, err)
 	}
@@ -147,8 +153,13 @@ func (f *Framework) UpdatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) er
 		return err
 	}
 
-	err = WaitForPodsReady(f.KubeClient, f.Namespace.Name, int(*p.Spec.Replicas), prometheus.ListOptions(p.Name))
-	if err != nil {
+	if err := WaitForPodsReady(
+		f.KubeClient,
+		f.Namespace.Name,
+		f.DefaultTimeout,
+		int(*p.Spec.Replicas),
+		prometheus.ListOptions(p.Name),
+	); err != nil {
 		return fmt.Errorf("failed to update %d Prometheus instances (%s): %v", p.Spec.Replicas, p.Name, err)
 	}
 
@@ -166,7 +177,13 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(name string) error {
 		return errors.Wrap(err, fmt.Sprintf("deleting Prometheus tpr %v failed", name))
 	}
 
-	if err := WaitForPodsReady(f.KubeClient, f.Namespace.Name, 0, prometheus.ListOptions(name)); err != nil {
+	if err := WaitForPodsReady(
+		f.KubeClient,
+		f.Namespace.Name,
+		f.DefaultTimeout,
+		0,
+		prometheus.ListOptions(name),
+	); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("waiting for Prometheus tpr (%s) to vanish timed out", name))
 	}
 
@@ -177,7 +194,13 @@ func (f *Framework) WaitForPrometheusRunImageAndReady(p *v1alpha1.Prometheus) er
 	if err := WaitForPodsRunImage(f.KubeClient, f.Namespace.Name, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name)); err != nil {
 		return err
 	}
-	return WaitForPodsReady(f.KubeClient, f.Namespace.Name, int(*p.Spec.Replicas), prometheus.ListOptions(p.Name))
+	return WaitForPodsReady(
+		f.KubeClient,
+		f.Namespace.Name,
+		f.DefaultTimeout,
+		int(*p.Spec.Replicas),
+		prometheus.ListOptions(p.Name),
+	)
 }
 
 func promImage(version string) string {


### PR DESCRIPTION
This should be set via a flag in the long run. Adjust waitForPodsReady
function to take a timeout as third argument. Passing in the default
framework time out for now.