### PR TITLE
docs: Make getting-started guide RBAC aware

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -10,7 +10,7 @@ Here is a ready to use manifest of a `ClusterRole` that can be used to start the
 
 [embedmd]:# (../example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml)
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus-operator
@@ -84,7 +84,7 @@ In addition to the resources Prometheus itself needs to access, the Prometheus s
 
 [embedmd]:# (../example/rbac/prometheus/prometheus-cluster-role.yaml)
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -126,7 +126,7 @@ And then a `ClusterRoleBinding`:
 
 [embedmd]:# (../example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml)
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-operator
@@ -156,7 +156,7 @@ And then because the `ClusterRole` named `prometheus`, as described above, is li
 
 [embedmd]:# (../example/rbac/prometheus/prometheus-cluster-role-binding.yaml)
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-operator
@@ -11,7 +11,7 @@ subjects:
   name: prometheus-operator
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus-operator

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-operator

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus-operator

--- a/example/rbac/prometheus/prometheus-cluster-role-binding.yaml
+++ b/example/rbac/prometheus/prometheus-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/example/rbac/prometheus/prometheus-cluster-role.yaml
+++ b/example/rbac/prometheus/prometheus-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus

--- a/example/rbac/prometheus/prometheus.yaml
+++ b/example/rbac/prometheus/prometheus.yaml
@@ -1,16 +1,16 @@
 apiVersion: "monitoring.coreos.com/v1alpha1"
 kind: "Prometheus"
 metadata:
-  name: "main"
+  name: prometheus
   labels:
-    prometheus: "main"
+    prometheus: "prometheus"
 spec:
   replicas: 2
   version: v1.5.2
   serviceAccountName: prometheus
   serviceMonitorSelector:
-    matchExpressions:
-    - {key: app, operator: In, values: [node-exporter, example-app]}
+    matchLabels:
+      team: frontend
   alerting:
     alertmanagers:
     - namespace: default

--- a/example/user-guides/getting-started/prometheus-service.yaml
+++ b/example/user-guides/getting-started/prometheus-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-example
+  name: prometheus
 spec:
   type: NodePort
   ports:
@@ -11,4 +11,4 @@ spec:
     protocol: TCP
     targetPort: web
   selector:
-    prometheus: example
+    prometheus: prometheus

--- a/example/user-guides/getting-started/prometheus.yaml
+++ b/example/user-guides/getting-started/prometheus.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: Prometheus
 metadata:
-  name: example
+  name: prometheus
 spec:
   serviceMonitorSelector:
     matchLabels:


### PR DESCRIPTION
Currently the getting started guide only creates a `ClusterRole` and a `ClusterRoleBinding` for the Prometheus operator but not for the Prometheus pods. This PR adds the steps to do so for the Prometheus pods as well.

Tested with tectonic-installer and minikube cluster.

Related to #290 