### PR TITLE
test: Introduce a context and a namespace per test and run save tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO?=quay.io/coreos/prometheus-operator
 TAG?=$(shell git rev-parse --short HEAD)
-NAMESPACE?=prometheus-operator-e2e-tests-$(shell LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 13 ; echo '')
+NAMESPACE?=po-e2e-$(shell LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 13 ; echo '')
 
 PROMU := $(GOPATH)/bin/promu
 PREFIX ?= $(shell pwd)

--- a/scripts/jenkins/Dockerfile
+++ b/scripts/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.5-wheezy
+FROM golang:1.8.1-stretch
 
 ENV TERRAFORM_VERSION 0.8.7
 ENV KOPS_VERSION 1.5.1
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     wget \
     unzip \
-    python python-pip jq \
+    python python-pip jq python-setuptools \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar -xvz && \

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -28,78 +28,84 @@ import (
 )
 
 func TestAlertmanagerCreateDeleteCluster(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, framework.MakeBasicAlertmanager(name, 3)); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, framework.MakeBasicAlertmanager(name, 3)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx.Id, name); err != nil {
+	if err := framework.DeleteAlertmanagerAndWaitUntilGone(ns, name); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestAlertmanagerScaling(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, framework.MakeBasicAlertmanager(name, 3)); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, framework.MakeBasicAlertmanager(name, 3)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx.Id, framework.MakeBasicAlertmanager(name, 5)); err != nil {
+	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, framework.MakeBasicAlertmanager(name, 5)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx.Id, framework.MakeBasicAlertmanager(name, 3)); err != nil {
+	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, framework.MakeBasicAlertmanager(name, 3)); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestAlertmanagerVersionMigration(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
 
 	am := framework.MakeBasicAlertmanager(name, 1)
 	am.Spec.Version = "v0.6.0"
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, am); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
 		t.Fatal(err)
 	}
 
 	am.Spec.Version = "v0.6.1"
-	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx.Id, am); err != nil {
+	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
 		t.Fatal(err)
 	}
 
 	am.Spec.Version = "v0.6.0"
-	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx.Id, am); err != nil {
+	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestExposingAlertmanagerWithNodePort(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", 1)
 	alertmanagerService := framework.MakeAlertmanagerNodePortService(alertmanager.Name, "nodeport-service", 30903)
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, alertmanagerService); err != nil {
+	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	} else {
 		ctx.AddFinalizerFn(finalizerFn)
@@ -114,22 +120,24 @@ func TestExposingAlertmanagerWithNodePort(t *testing.T) {
 }
 
 func TestExposingAlertmanagerWithKubernetesAPI(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", 1)
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, alertmanagerService); err != nil {
+	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
-	proxyGet := framework.KubeClient.CoreV1().Services(ctx.Id).ProxyGet
+	proxyGet := framework.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := proxyGet("", alertmanagerService.Name, "web", "/", make(map[string]string))
 	_, err := request.DoRaw()
 	if err != nil {
@@ -138,31 +146,33 @@ func TestExposingAlertmanagerWithKubernetesAPI(t *testing.T) {
 }
 
 func TestExposingAlertmanagerWithIngress(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	alertmanager := framework.MakeBasicAlertmanager("main", 1)
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "test-group", v1.ServiceTypeClusterIP)
 	ingress := testFramework.MakeBasicIngress(alertmanagerService.Name, 9093)
 
-	if err := testFramework.SetupNginxIngressControllerIncDefaultBackend(framework.KubeClient, ctx.Id); err != nil {
+	if err := testFramework.SetupNginxIngressControllerIncDefaultBackend(framework.KubeClient, ns); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, alertmanagerService); err != nil {
+	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := testFramework.CreateIngress(framework.KubeClient, ctx.Id, ingress); err != nil {
+	if err := testFramework.CreateIngress(framework.KubeClient, ns, ingress); err != nil {
 		t.Fatal(err)
 	}
 
-	ip, err := testFramework.GetIngressIP(framework.KubeClient, ctx.Id, ingress.Name)
+	ip, err := testFramework.GetIngressIP(framework.KubeClient, ns, ingress.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,9 +184,11 @@ func TestExposingAlertmanagerWithIngress(t *testing.T) {
 }
 
 func TestMeshInitialization(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	var amountAlertmanagers int32 = 3
 	alertmanager := &v1alpha1.Alertmanager{
@@ -191,26 +203,28 @@ func TestMeshInitialization(t *testing.T) {
 
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, alertmanagerService); err != nil {
+	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < int(amountAlertmanagers); i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitializedMesh(ctx.Id, name, int(amountAlertmanagers)); err != nil {
+		if err := framework.WaitForAlertmanagerInitializedMesh(ns, name, int(amountAlertmanagers)); err != nil {
 			t.Fatal(err)
 		}
 	}
 }
 
 func TestAlertmanagerReloadConfig(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	alertmanager := framework.MakeBasicAlertmanager("reload-config", 1)
 
@@ -252,25 +266,25 @@ receivers:
 		},
 	}
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ctx.Id).Update(cfg); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(cfg); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForSpecificAlertmanagerConfig(ctx.Id, alertmanager.Name, firstConfig); err != nil {
+	if err := framework.WaitForSpecificAlertmanagerConfig(ns, alertmanager.Name, firstConfig); err != nil {
 		t.Fatal(err)
 	}
 
 	cfg.Data["alertmanager.yaml"] = []byte(secondConfig)
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ctx.Id).Update(cfg); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(cfg); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForSpecificAlertmanagerConfig(ctx.Id, alertmanager.Name, secondConfig); err != nil {
+	if err := framework.WaitForSpecificAlertmanagerConfig(ns, alertmanager.Name, secondConfig); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -28,85 +28,101 @@ import (
 )
 
 func TestAlertmanagerCreateDeleteCluster(t *testing.T) {
+	ctx := testFramework.NewTestCtx(t)
+	defer ctx.CleanUp(t)
+	ctx.BasicSetup(t, framework.KubeClient)
+
 	name := "test"
 
 	defer func() {
-		if err := framework.DeleteAlertmanagerAndWaitUntilGone(name); err != nil {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx.Id, name); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(framework.MakeBasicAlertmanager(name, 3)); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, framework.MakeBasicAlertmanager(name, 3)); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestAlertmanagerScaling(t *testing.T) {
+	ctx := testFramework.NewTestCtx(t)
+	defer ctx.CleanUp(t)
+	ctx.BasicSetup(t, framework.KubeClient)
+
 	name := "test"
 
 	defer func() {
-		if err := framework.DeleteAlertmanagerAndWaitUntilGone(name); err != nil {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx.Id, name); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(framework.MakeBasicAlertmanager(name, 3)); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, framework.MakeBasicAlertmanager(name, 3)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.UpdateAlertmanagerAndWaitUntilReady(framework.MakeBasicAlertmanager(name, 5)); err != nil {
+	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx.Id, framework.MakeBasicAlertmanager(name, 5)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.UpdateAlertmanagerAndWaitUntilReady(framework.MakeBasicAlertmanager(name, 3)); err != nil {
+	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx.Id, framework.MakeBasicAlertmanager(name, 3)); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestAlertmanagerVersionMigration(t *testing.T) {
+	ctx := testFramework.NewTestCtx(t)
+	defer ctx.CleanUp(t)
+	ctx.BasicSetup(t, framework.KubeClient)
+
 	name := "test"
 
 	defer func() {
-		if err := framework.DeleteAlertmanagerAndWaitUntilGone(name); err != nil {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx.Id, name); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
 	am := framework.MakeBasicAlertmanager(name, 3)
 	am.Spec.Version = "v0.6.0"
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(am); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, am); err != nil {
 		t.Fatal(err)
 	}
 
 	am.Spec.Version = "v0.6.1"
-	if err := framework.UpdateAlertmanagerAndWaitUntilReady(am); err != nil {
+	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx.Id, am); err != nil {
 		t.Fatal(err)
 	}
 
 	am.Spec.Version = "v0.6.0"
-	if err := framework.UpdateAlertmanagerAndWaitUntilReady(am); err != nil {
+	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx.Id, am); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestExposingAlertmanagerWithNodePort(t *testing.T) {
+	ctx := testFramework.NewTestCtx(t)
+	defer ctx.CleanUp(t)
+	ctx.BasicSetup(t, framework.KubeClient)
+
 	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", 1)
 	alertmanagerService := framework.MakeAlertmanagerNodePortService(alertmanager.Name, "nodeport-service", 30903)
 
 	defer func() {
-		if err := framework.DeleteAlertmanagerAndWaitUntilGone(alertmanager.Name); err != nil {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx.Id, alertmanager.Name); err != nil {
 			t.Fatal(err)
 		}
-		if err := testFramework.DeleteService(framework.KubeClient, framework.Namespace.Name, alertmanagerService.Name); err != nil {
+		if err := testFramework.DeleteService(framework.KubeClient, ctx.Id, alertmanagerService.Name); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, framework.Namespace.Name, alertmanagerService); err != nil {
+	if err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
@@ -119,27 +135,31 @@ func TestExposingAlertmanagerWithNodePort(t *testing.T) {
 }
 
 func TestExposingAlertmanagerWithKubernetesAPI(t *testing.T) {
+	ctx := testFramework.NewTestCtx(t)
+	defer ctx.CleanUp(t)
+	ctx.BasicSetup(t, framework.KubeClient)
+
 	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", 1)
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
 
 	defer func() {
-		if err := framework.DeleteAlertmanagerAndWaitUntilGone(alertmanager.Name); err != nil {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx.Id, alertmanager.Name); err != nil {
 			t.Fatal(err)
 		}
-		if err := testFramework.DeleteService(framework.KubeClient, framework.Namespace.Name, alertmanagerService.Name); err != nil {
+		if err := testFramework.DeleteService(framework.KubeClient, ctx.Id, alertmanagerService.Name); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, framework.Namespace.Name, alertmanagerService); err != nil {
+	if err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
-	proxyGet := framework.KubeClient.CoreV1().Services(framework.Namespace.Name).ProxyGet
+	proxyGet := framework.KubeClient.CoreV1().Services(ctx.Id).ProxyGet
 	request := proxyGet("", alertmanagerService.Name, "web", "/", make(map[string]string))
 	_, err := request.DoRaw()
 	if err != nil {
@@ -148,42 +168,46 @@ func TestExposingAlertmanagerWithKubernetesAPI(t *testing.T) {
 }
 
 func TestExposingAlertmanagerWithIngress(t *testing.T) {
+	ctx := testFramework.NewTestCtx(t)
+	defer ctx.CleanUp(t)
+	ctx.BasicSetup(t, framework.KubeClient)
+
 	alertmanager := framework.MakeBasicAlertmanager("main", 1)
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "test-group", v1.ServiceTypeClusterIP)
 	ingress := testFramework.MakeBasicIngress(alertmanagerService.Name, 9093)
 
 	defer func() {
-		if err := framework.DeleteAlertmanagerAndWaitUntilGone(alertmanager.Name); err != nil {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx.Id, alertmanager.Name); err != nil {
 			t.Fatal(err)
 		}
-		if err := testFramework.DeleteService(framework.KubeClient, framework.Namespace.Name, alertmanagerService.Name); err != nil {
+		if err := testFramework.DeleteService(framework.KubeClient, ctx.Id, alertmanagerService.Name); err != nil {
 			t.Fatal(err)
 		}
-		if err := framework.KubeClient.Extensions().Ingresses(framework.Namespace.Name).Delete(ingress.Name, nil); err != nil {
+		if err := framework.KubeClient.Extensions().Ingresses(ctx.Id).Delete(ingress.Name, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := testFramework.DeleteNginxIngressControllerIncDefaultBackend(framework.KubeClient, framework.Namespace.Name); err != nil {
+		if err := testFramework.DeleteNginxIngressControllerIncDefaultBackend(framework.KubeClient, ctx.Id); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	if err := testFramework.SetupNginxIngressControllerIncDefaultBackend(framework.KubeClient, framework.Namespace.Name); err != nil {
+	if err := testFramework.SetupNginxIngressControllerIncDefaultBackend(framework.KubeClient, ctx.Id); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, framework.Namespace.Name, alertmanagerService); err != nil {
+	if err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := testFramework.CreateIngress(framework.KubeClient, framework.Namespace.Name, ingress); err != nil {
+	if err := testFramework.CreateIngress(framework.KubeClient, ctx.Id, ingress); err != nil {
 		t.Fatal(err)
 	}
 
-	ip, err := testFramework.GetIngressIP(framework.KubeClient, framework.Namespace.Name, ingress.Name)
+	ip, err := testFramework.GetIngressIP(framework.KubeClient, ctx.Id, ingress.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,6 +219,10 @@ func TestExposingAlertmanagerWithIngress(t *testing.T) {
 }
 
 func TestMeshInitialization(t *testing.T) {
+	ctx := testFramework.NewTestCtx(t)
+	defer ctx.CleanUp(t)
+	ctx.BasicSetup(t, framework.KubeClient)
+
 	var amountAlertmanagers int32 = 3
 	alertmanager := &v1alpha1.Alertmanager{
 		ObjectMeta: v1.ObjectMeta{
@@ -209,31 +237,35 @@ func TestMeshInitialization(t *testing.T) {
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
 
 	defer func() {
-		if err := framework.DeleteAlertmanagerAndWaitUntilGone(alertmanager.Name); err != nil {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx.Id, alertmanager.Name); err != nil {
 			t.Fatal(err)
 		}
-		if err := testFramework.DeleteService(framework.KubeClient, framework.Namespace.Name, alertmanagerService.Name); err != nil {
+		if err := testFramework.DeleteService(framework.KubeClient, ctx.Id, alertmanagerService.Name); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, framework.Namespace.Name, alertmanagerService); err != nil {
+	if err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < int(amountAlertmanagers); i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitializedMesh(name, int(amountAlertmanagers)); err != nil {
+		if err := framework.WaitForAlertmanagerInitializedMesh(ctx.Id, name, int(amountAlertmanagers)); err != nil {
 			t.Fatal(err)
 		}
 	}
 }
 
 func TestAlertmanagerReloadConfig(t *testing.T) {
+	ctx := testFramework.NewTestCtx(t)
+	defer ctx.CleanUp(t)
+	ctx.BasicSetup(t, framework.KubeClient)
+
 	alertmanager := framework.MakeBasicAlertmanager("reload-config", 1)
 
 	firstConfig := `
@@ -275,30 +307,30 @@ receivers:
 	}
 
 	defer func() {
-		if err := framework.DeleteAlertmanagerAndWaitUntilGone(alertmanager.Name); err != nil {
+		if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx.Id, alertmanager.Name); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(alertmanager); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(framework.Namespace.Name).Update(cfg); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ctx.Id).Update(cfg); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForSpecificAlertmanagerConfig(alertmanager.Name, firstConfig); err != nil {
+	if err := framework.WaitForSpecificAlertmanagerConfig(ctx.Id, alertmanager.Name, firstConfig); err != nil {
 		t.Fatal(err)
 	}
 
 	cfg.Data["alertmanager.yaml"] = []byte(secondConfig)
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(framework.Namespace.Name).Update(cfg); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ctx.Id).Update(cfg); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForSpecificAlertmanagerConfig(alertmanager.Name, secondConfig); err != nil {
+	if err := framework.WaitForSpecificAlertmanagerConfig(ctx.Id, alertmanager.Name, secondConfig); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/e2e/framework/alertmanager.go
+++ b/test/e2e/framework/alertmanager.go
@@ -131,7 +131,7 @@ func (f *Framework) CreateAlertmanagerAndWaitUntilReady(ns string, a *v1alpha1.A
 	err = WaitForPodsReady(
 		f.KubeClient,
 		ns,
-		3*time.Minute,
+		5*time.Minute,
 		int(*a.Spec.Replicas),
 		alertmanager.ListOptions(a.Name),
 	)
@@ -150,7 +150,7 @@ func (f *Framework) UpdateAlertmanagerAndWaitUntilReady(ns string, a *v1alpha1.A
 	err = WaitForPodsReady(
 		f.KubeClient,
 		ns,
-		f.DefaultTimeout,
+		5*time.Minute,
 		int(*a.Spec.Replicas),
 		alertmanager.ListOptions(a.Name),
 	)

--- a/test/e2e/framework/alertmanager.go
+++ b/test/e2e/framework/alertmanager.go
@@ -131,7 +131,7 @@ func (f *Framework) CreateAlertmanagerAndWaitUntilReady(ns string, a *v1alpha1.A
 	err = WaitForPodsReady(
 		f.KubeClient,
 		ns,
-		f.DefaultTimeout,
+		3*time.Minute,
 		int(*a.Spec.Replicas),
 		alertmanager.ListOptions(a.Name),
 	)

--- a/test/e2e/framework/context.go
+++ b/test/e2e/framework/context.go
@@ -1,0 +1,53 @@
+package framework
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/kubernetes"
+)
+
+type TestCtx struct {
+	Id         string
+	cleanUpFns []finalizerFn
+}
+
+type finalizerFn func() error
+
+func NewTestCtx(t *testing.T) TestCtx {
+	prefix := strings.TrimPrefix(strings.ToLower(t.Name()), "test")
+
+	id := prefix + "-" + strconv.FormatInt(time.Now().Unix(), 10)
+	return TestCtx{
+		Id: id,
+	}
+}
+
+func (ctx *TestCtx) BasicSetup(t *testing.T, kubeClient kubernetes.Interface) {
+	if _, err := CreateNamespace(kubeClient, ctx.Id); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx.cleanUpFns = append(ctx.cleanUpFns, func() error {
+		if err := DeleteNamespace(kubeClient, ctx.Id); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (ctx *TestCtx) CleanUp(t *testing.T) {
+	var eg errgroup.Group
+
+	// TODO: Should be a stack not a list
+	for _, f := range ctx.cleanUpFns {
+		eg.Go(f)
+	}
+
+	if err := eg.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -90,7 +90,11 @@ func WaitForHTTPSuccessStatusCode(timeout time.Duration, url string) error {
 		return false, nil
 	})
 
-	return errors.Wrap(err, fmt.Sprintf("waiting for %v to return a successfull status code timed out. Last response from server was: %v", url, resp))
+	return errors.Wrap(err, fmt.Sprintf(
+		"waiting for %v to return a successfull status code timed out. Last response from server was: %v",
+		url,
+		resp,
+	))
 }
 
 func podRunsImage(p v1.Pod, image string) bool {

--- a/test/e2e/framework/ingress.go
+++ b/test/e2e/framework/ingress.go
@@ -58,7 +58,7 @@ func MakeBasicIngress(serviceName string, servicePort int) *v1beta1.Ingress {
 
 func CreateIngress(kubeClient kubernetes.Interface, namespace string, i *v1beta1.Ingress) error {
 	_, err := kubeClient.Extensions().Ingresses(namespace).Create(i)
-	return errors.Wrap(err, fmt.Sprintf("creating the ingress %v failed", i.Name))
+	return errors.Wrap(err, fmt.Sprintf("creating ingress %v failed", i.Name))
 }
 
 func SetupNginxIngressControllerIncDefaultBackend(kubeClient kubernetes.Interface, namespace string) error {

--- a/test/e2e/framework/namespace.go
+++ b/test/e2e/framework/namespace.go
@@ -1,0 +1,26 @@
+package framework
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/pkg/errors"
+)
+
+func CreateNamespace(kubeClient kubernetes.Interface, name string) (*v1.Namespace, error) {
+	namespace, err := kubeClient.Core().Namespaces().Create(&v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to create namespace with name %v", name))
+	}
+	return namespace, nil
+}
+
+func DeleteNamespace(kubeClient kubernetes.Interface, name string) error {
+	return kubeClient.Core().Namespaces().Delete(name, nil)
+}

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -17,6 +17,7 @@ package framework
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -131,7 +132,7 @@ func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Pro
 		return err
 	}
 
-	if err := f.WaitForPrometheusReady(p, time.Minute); err != nil {
+	if err := f.WaitForPrometheusReady(p, 3*time.Minute); err != nil {
 		return fmt.Errorf("failed to create %d Prometheus instances (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 
@@ -143,7 +144,7 @@ func (f *Framework) UpdatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Pro
 	if err != nil {
 		return err
 	}
-	if err := f.WaitForPrometheusReady(p, time.Minute); err != nil {
+	if err := f.WaitForPrometheusReady(p, 3*time.Minute); err != nil {
 		return fmt.Errorf("failed to update %d Prometheus instances (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 
@@ -154,6 +155,7 @@ func (f *Framework) WaitForPrometheusReady(p *v1alpha1.Prometheus, timeout time.
 	return wait.Poll(2*time.Second, timeout, func() (bool, error) {
 		st, _, err := prometheus.PrometheusStatus(f.KubeClient, p)
 		if err != nil {
+			log.Print(err)
 			return false, nil
 		}
 		return st.UpdatedReplicas == *p.Spec.Replicas, nil

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -132,7 +132,7 @@ func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Pro
 		return err
 	}
 
-	if err := f.WaitForPrometheusReady(p, 3*time.Minute); err != nil {
+	if err := f.WaitForPrometheusReady(p, 5*time.Minute); err != nil {
 		return fmt.Errorf("failed to create %d Prometheus instances (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 
@@ -144,7 +144,7 @@ func (f *Framework) UpdatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Pro
 	if err != nil {
 		return err
 	}
-	if err := f.WaitForPrometheusReady(p, 3*time.Minute); err != nil {
+	if err := f.WaitForPrometheusReady(p, 5*time.Minute); err != nil {
 		return fmt.Errorf("failed to update %d Prometheus instances (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -17,7 +17,6 @@ package framework
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"time"
 
@@ -32,11 +31,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (f *Framework) MakeBasicPrometheus(name, group string, replicas int32) *v1alpha1.Prometheus {
+func (f *Framework) MakeBasicPrometheus(ns, name, group string, replicas int32) *v1alpha1.Prometheus {
 	return &v1alpha1.Prometheus{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
-			Namespace: f.Namespace.Name,
+			Namespace: ns,
 		},
 		Spec: v1alpha1.PrometheusSpec{
 			Replicas: &replicas,
@@ -59,11 +58,11 @@ func (f *Framework) MakeBasicPrometheus(name, group string, replicas int32) *v1a
 	}
 }
 
-func (f *Framework) AddAlertingToPrometheus(p *v1alpha1.Prometheus, name string) {
+func (f *Framework) AddAlertingToPrometheus(p *v1alpha1.Prometheus, ns, name string) {
 	p.Spec.Alerting = v1alpha1.AlertingSpec{
 		Alertmanagers: []v1alpha1.AlertmanagerEndpoints{
 			v1alpha1.AlertmanagerEndpoints{
-				Namespace: f.Namespace.Name,
+				Namespace: ns,
 				Name:      fmt.Sprintf("alertmanager-%s", name),
 				Port:      intstr.FromString("web"),
 			},
@@ -126,28 +125,26 @@ func (f *Framework) MakePrometheusService(name, group string, serviceType v1.Ser
 	return service
 }
 
-func (f *Framework) CreatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) error {
-	log.Printf("Creating Prometheus (%s/%s)", f.Namespace.Name, p.Name)
-	_, err := f.MonClient.Prometheuses(f.Namespace.Name).Create(p)
+func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Prometheus) error {
+	_, err := f.MonClient.Prometheuses(ns).Create(p)
 	if err != nil {
 		return err
 	}
 
 	if err := f.WaitForPrometheusReady(p, time.Minute); err != nil {
-		return fmt.Errorf("failed to create %d Prometheus instances (%s): %v", p.Spec.Replicas, p.Name, err)
+		return fmt.Errorf("failed to create %d Prometheus instances (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 
 	return nil
 }
 
-func (f *Framework) UpdatePrometheusAndWaitUntilReady(p *v1alpha1.Prometheus) error {
-	log.Printf("Updating Prometheus (%s/%s)", f.Namespace.Name, p.Name)
-	_, err := f.MonClient.Prometheuses(f.Namespace.Name).Update(p)
+func (f *Framework) UpdatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Prometheus) error {
+	_, err := f.MonClient.Prometheuses(ns).Update(p)
 	if err != nil {
 		return err
 	}
 	if err := f.WaitForPrometheusReady(p, time.Minute); err != nil {
-		return fmt.Errorf("failed to update %d Prometheus instances (%s): %v", p.Spec.Replicas, p.Name, err)
+		return fmt.Errorf("failed to update %d Prometheus instances (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 
 	return nil
@@ -157,26 +154,25 @@ func (f *Framework) WaitForPrometheusReady(p *v1alpha1.Prometheus, timeout time.
 	return wait.Poll(2*time.Second, timeout, func() (bool, error) {
 		st, _, err := prometheus.PrometheusStatus(f.KubeClient, p)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		return st.UpdatedReplicas == *p.Spec.Replicas, nil
 	})
 }
 
-func (f *Framework) DeletePrometheusAndWaitUntilGone(name string) error {
-	log.Printf("Deleting Prometheus (%s/%s)", f.Namespace.Name, name)
-	_, err := f.MonClient.Prometheuses(f.Namespace.Name).Get(name)
+func (f *Framework) DeletePrometheusAndWaitUntilGone(ns, name string) error {
+	_, err := f.MonClient.Prometheuses(ns).Get(name)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("requesting Prometheus tpr %v failed", name))
 	}
 
-	if err := f.MonClient.Prometheuses(f.Namespace.Name).Delete(name, nil); err != nil {
+	if err := f.MonClient.Prometheuses(ns).Delete(name, nil); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("deleting Prometheus tpr %v failed", name))
 	}
 
 	if err := WaitForPodsReady(
 		f.KubeClient,
-		f.Namespace.Name,
+		ns,
 		f.DefaultTimeout,
 		0,
 		prometheus.ListOptions(name),
@@ -187,13 +183,13 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(name string) error {
 	return nil
 }
 
-func (f *Framework) WaitForPrometheusRunImageAndReady(p *v1alpha1.Prometheus) error {
-	if err := WaitForPodsRunImage(f.KubeClient, f.Namespace.Name, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name)); err != nil {
+func (f *Framework) WaitForPrometheusRunImageAndReady(ns string, p *v1alpha1.Prometheus) error {
+	if err := WaitForPodsRunImage(f.KubeClient, ns, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name)); err != nil {
 		return err
 	}
 	return WaitForPodsReady(
 		f.KubeClient,
-		f.Namespace.Name,
+		ns,
 		f.DefaultTimeout,
 		int(*p.Spec.Replicas),
 		prometheus.ListOptions(p.Name),

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -37,94 +37,102 @@ import (
 )
 
 func TestPrometheusCreateDeleteCluster(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
 
-	prometheusTPR := framework.MakeBasicPrometheus(ctx.Id, name, name, 1)
-	prometheusTPR.Namespace = ctx.Id
+	prometheusTPR := framework.MakeBasicPrometheus(ns, name, name, 1)
+	prometheusTPR.Namespace = ns
 
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, prometheusTPR); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, prometheusTPR); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.DeletePrometheusAndWaitUntilGone(ctx.Id, name); err != nil {
+	if err := framework.DeletePrometheusAndWaitUntilGone(ns, name); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPrometheusScaleUpDownCluster(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
 
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, framework.MakeBasicPrometheus(ctx.Id, name, name, 1)); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, framework.MakeBasicPrometheus(ns, name, name, 1)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.UpdatePrometheusAndWaitUntilReady(ctx.Id, framework.MakeBasicPrometheus(ctx.Id, name, name, 3)); err != nil {
+	if err := framework.UpdatePrometheusAndWaitUntilReady(ns, framework.MakeBasicPrometheus(ns, name, name, 3)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.UpdatePrometheusAndWaitUntilReady(ctx.Id, framework.MakeBasicPrometheus(ctx.Id, name, name, 2)); err != nil {
+	if err := framework.UpdatePrometheusAndWaitUntilReady(ns, framework.MakeBasicPrometheus(ns, name, name, 2)); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPrometheusVersionMigration(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
 
-	p := framework.MakeBasicPrometheus(ctx.Id, name, name, 1)
+	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 
 	p.Spec.Version = "v1.5.1"
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, p); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
 
 	p.Spec.Version = "v1.6.1"
-	if err := framework.UpdatePrometheusAndWaitUntilReady(ctx.Id, p); err != nil {
+	if err := framework.UpdatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
-	if err := framework.WaitForPrometheusRunImageAndReady(ctx.Id, p); err != nil {
+	if err := framework.WaitForPrometheusRunImageAndReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
 
 	p.Spec.Version = "v1.5.1"
-	if err := framework.UpdatePrometheusAndWaitUntilReady(ctx.Id, p); err != nil {
+	if err := framework.UpdatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
-	if err := framework.WaitForPrometheusRunImageAndReady(ctx.Id, p); err != nil {
+	if err := framework.WaitForPrometheusRunImageAndReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPrometheusResourceUpdate(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
 
-	p := framework.MakeBasicPrometheus(ctx.Id, name, name, 1)
+	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 
 	p.Spec.Resources = v1.ResourceRequirements{
 		Requests: v1.ResourceList{
 			v1.ResourceMemory: resource.MustParse("100Mi"),
 		},
 	}
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, p); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	pods, err := framework.KubeClient.Core().Pods(ctx.Id).List(prometheus.ListOptions(name))
+	pods, err := framework.KubeClient.Core().Pods(ns).List(prometheus.ListOptions(name))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,11 +147,11 @@ func TestPrometheusResourceUpdate(t *testing.T) {
 			v1.ResourceMemory: resource.MustParse("200Mi"),
 		},
 	}
-	if err := framework.UpdatePrometheusAndWaitUntilReady(ctx.Id, p); err != nil {
+	if err := framework.UpdatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	pods, err = framework.KubeClient.Core().Pods(ctx.Id).List(prometheus.ListOptions(name))
+	pods, err = framework.KubeClient.Core().Pods(ns).List(prometheus.ListOptions(name))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,16 +163,16 @@ func TestPrometheusResourceUpdate(t *testing.T) {
 }
 
 func TestPrometheusReloadConfig(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
 	replicas := int32(1)
 	p := &v1alpha1.Prometheus{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
-			Namespace: ctx.Id,
+			Namespace: ns,
 		},
 		Spec: v1alpha1.PrometheusSpec{
 			Replicas: &replicas,
@@ -199,15 +207,15 @@ scrape_configs:
 
 	svc := framework.MakeBasicPrometheusNodePortService(name, "reloadconfig-group", 30900)
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ctx.Id).Create(cfg); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(cfg); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, p); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, svc); err != nil {
+	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, svc); err != nil {
 		t.Fatal(err)
 	} else {
 		ctx.AddFinalizerFn(finalizerFn)
@@ -230,7 +238,7 @@ scrape_configs:
 `
 
 	cfg.Data["prometheus.yaml"] = []byte(secondConfig)
-	if _, err := framework.KubeClient.CoreV1().Secrets(ctx.Id).Update(cfg); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(cfg); err != nil {
 		t.Fatal(err)
 	}
 
@@ -240,9 +248,11 @@ scrape_configs:
 }
 
 func TestPrometheusReloadRules(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
 
@@ -258,24 +268,24 @@ func TestPrometheusReloadRules(t *testing.T) {
 		},
 	}
 
-	_, err := framework.KubeClient.CoreV1().ConfigMaps(ctx.Id).Create(ruleFileConfigMap)
+	_, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(ruleFileConfigMap)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, framework.MakeBasicPrometheus(ctx.Id, name, name, 1)); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, framework.MakeBasicPrometheus(ns, name, name, 1)); err != nil {
 		t.Fatal(err)
 	}
 
 	ruleFileConfigMap.Data["test.rules"] = "# comment to trigger a configmap reload"
-	_, err = framework.KubeClient.CoreV1().ConfigMaps(ctx.Id).Update(ruleFileConfigMap)
+	_, err = framework.KubeClient.CoreV1().ConfigMaps(ns).Update(ruleFileConfigMap)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// remounting a ConfigMap can take some time
 	err = wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
-		logs, err := testFramework.GetLogs(framework.KubeClient, ctx.Id, fmt.Sprintf("prometheus-%s-0", name), "prometheus-config-reloader")
+		logs, err := testFramework.GetLogs(framework.KubeClient, ns, fmt.Sprintf("prometheus-%s-0", name), "prometheus-config-reloader")
 		if err != nil {
 			return false, err
 		}
@@ -292,46 +302,46 @@ func TestPrometheusReloadRules(t *testing.T) {
 }
 
 func TestPrometheusDiscovery(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	prometheusName := "test"
 	group := "servicediscovery-test"
 	svc := framework.MakeBasicPrometheusNodePortService(prometheusName, group, 30900)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClient.ServiceMonitors(ctx.Id).Create(s); err != nil {
+	if _, err := framework.MonClient.ServiceMonitors(ns).Create(s); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
-	p := framework.MakeBasicPrometheus(ctx.Id, prometheusName, group, 1)
+	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
 	p.Spec.Version = "v1.5.0"
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, p); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, svc); err != nil {
+	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		ctx.AddFinalizerFn(finalizerFn)
 	}
 
-	_, err := framework.KubeClient.CoreV1().Secrets(ctx.Id).Get(fmt.Sprintf("prometheus-%s", prometheusName))
+	_, err := framework.KubeClient.CoreV1().Secrets(ns).Get(fmt.Sprintf("prometheus-%s", prometheusName))
 	if err != nil {
 		t.Fatal("Generated Secret could not be retrieved: ", err)
 	}
 
-	err = wait.Poll(time.Second, 18*time.Minute, isDiscoveryWorking(ctx.Id, prometheusName))
+	err = wait.Poll(time.Second, 18*time.Minute, isDiscoveryWorking(ns, prometheusName))
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
 	}
 }
 
 func TestPrometheusAlertmanagerDiscovery(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	prometheusName := "test"
 	alertmanagerName := "test"
@@ -339,56 +349,56 @@ func TestPrometheusAlertmanagerDiscovery(t *testing.T) {
 	svc := framework.MakeBasicPrometheusNodePortService(prometheusName, group, 30900)
 	amsvc := framework.MakeAlertmanagerNodePortService(alertmanagerName, group, 30903)
 
-	p := framework.MakeBasicPrometheus(ctx.Id, prometheusName, group, 1)
-	framework.AddAlertingToPrometheus(p, ctx.Id, alertmanagerName)
+	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
+	framework.AddAlertingToPrometheus(p, ns, alertmanagerName)
 	p.Spec.Version = "v1.5.0"
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, p); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, svc); err != nil {
+	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		ctx.AddFinalizerFn(finalizerFn)
 	}
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClient.ServiceMonitors(ctx.Id).Create(s); err != nil {
+	if _, err := framework.MonClient.ServiceMonitors(ns).Create(s); err != nil {
 		t.Fatalf("Creating ServiceMonitor failed: %v", err)
 	}
 
-	_, err := framework.KubeClient.CoreV1().Secrets(ctx.Id).Get(fmt.Sprintf("prometheus-%s", prometheusName))
+	_, err := framework.KubeClient.CoreV1().Secrets(ns).Get(fmt.Sprintf("prometheus-%s", prometheusName))
 	if err != nil {
 		t.Fatalf("Generated Secret could not be retrieved: %v", err)
 	}
 
-	if err := framework.CreateAlertmanagerAndWaitUntilReady(ctx.Id, framework.MakeBasicAlertmanager(alertmanagerName, 3)); err != nil {
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, framework.MakeBasicAlertmanager(alertmanagerName, 3)); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, amsvc); err != nil {
+	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, amsvc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Alertmanager service failed"))
 	}
 
-	err = wait.Poll(time.Second, 18*time.Minute, isAlertmanagerDiscoveryWorking(ctx.Id, alertmanagerName))
+	err = wait.Poll(time.Second, 18*time.Minute, isAlertmanagerDiscoveryWorking(ns, alertmanagerName))
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "validating Prometheus Alertmanager discovery failed"))
 	}
 }
 
 func TestExposingPrometheusWithNodePort(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
-	basicPrometheus := framework.MakeBasicPrometheus(ctx.Id, "test", "test", 1)
+	basicPrometheus := framework.MakeBasicPrometheus(ns, "test", "test", 1)
 	service := framework.MakeBasicPrometheusNodePortService(basicPrometheus.Name, "nodeport-service", 30900)
 
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, basicPrometheus); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, basicPrometheus); err != nil {
 		t.Fatal("Creating prometheus failed: ", err)
 	}
 
-	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, service); err != nil {
+	if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, service); err != nil {
 		t.Fatal("Creating prometheus service failed: ", err)
 	} else {
 		ctx.AddFinalizerFn(finalizerFn)
@@ -403,22 +413,24 @@ func TestExposingPrometheusWithNodePort(t *testing.T) {
 }
 
 func TestExposingPrometheusWithKubernetesAPI(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
 
-	basicPrometheus := framework.MakeBasicPrometheus(ctx.Id, "basic-prometheus", "test-group", 1)
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
+
+	basicPrometheus := framework.MakeBasicPrometheus(ns, "basic-prometheus", "test-group", 1)
 	service := framework.MakePrometheusService(basicPrometheus.Name, "test-group", v1.ServiceTypeClusterIP)
 
-	if err := framework.CreatePrometheusAndWaitUntilReady(ctx.Id, basicPrometheus); err != nil {
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, basicPrometheus); err != nil {
 		t.Fatal("Creating prometheus failed: ", err)
 	}
 
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, service); err != nil {
+	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, service); err != nil {
 		t.Fatal("Creating prometheus service failed: ", err)
 	}
 
-	ProxyGet := framework.KubeClient.CoreV1().Services(ctx.Id).ProxyGet
+	ProxyGet := framework.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := ProxyGet("", service.Name, "web", "/metrics", make(map[string]string))
 	_, err := request.DoRaw()
 	if err != nil {
@@ -427,34 +439,36 @@ func TestExposingPrometheusWithKubernetesAPI(t *testing.T) {
 }
 
 func TestExposingPrometheusWithIngress(t *testing.T) {
-	ctx := testFramework.NewTestCtx(t)
-	defer ctx.CleanUp(t)
-	ctx.BasicSetup(t, framework.KubeClient)
+	t.Parallel()
 
-	prometheus := framework.MakeBasicPrometheus(ctx.Id, "main", "test-group", 1)
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
+
+	prometheus := framework.MakeBasicPrometheus(ns, "main", "test-group", 1)
 	prometheusService := framework.MakePrometheusService(prometheus.Name, "test-group", v1.ServiceTypeClusterIP)
 	ingress := testFramework.MakeBasicIngress(prometheusService.Name, 9090)
 
-	err := testFramework.SetupNginxIngressControllerIncDefaultBackend(framework.KubeClient, ctx.Id)
+	err := testFramework.SetupNginxIngressControllerIncDefaultBackend(framework.KubeClient, ns)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = framework.CreatePrometheusAndWaitUntilReady(ctx.Id, prometheus)
+	err = framework.CreatePrometheusAndWaitUntilReady(ns, prometheus)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ctx.Id, prometheusService); err != nil {
+	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, prometheusService); err != nil {
 		t.Fatal(err)
 	}
 
-	err = testFramework.CreateIngress(framework.KubeClient, ctx.Id, ingress)
+	err = testFramework.CreateIngress(framework.KubeClient, ns, ingress)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ip, err := testFramework.GetIngressIP(framework.KubeClient, ctx.Id, ingress.Name)
+	ip, err := testFramework.GetIngressIP(framework.KubeClient, ns, ingress.Name)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
test: Introduce test context per test

test: Clean up e2e test code
* Remove unneeded delete steps
* Improve error feedback
* Cleanup main namespace properly after tests
* Wait for NodePort services to be deleted

test: Run save tests in parallel