### PR TITLE
test: Move e2e run logic into scripts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,28 +131,13 @@ job('prometheus-operator-e2e-tests') {
     }
 
     steps {
-        shell('docker build -t cluster-setup-env scripts/jenkins/.')
-    }
-
-    steps {
-        shell('docker run --rm -v $PWD:$PWD -v /var/run/docker.sock:/var/run/docker.sock cluster-setup-env /bin/bash -c "cd $PWD && make crossbuild"')
-    }
-
-    steps {
-        shell('docker build -t quay.io/coreos/prometheus-operator-dev:$BUILD_ID .')
-        shell('docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io')
-        shell('docker push quay.io/coreos/prometheus-operator-dev:$BUILD_ID')
-    }
-
-    steps {
-        shell('docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -v $PWD:/go/src/github.com/coreos/prometheus-operator cluster-setup-env /bin/bash -c "cd /go/src/github.com/coreos/prometheus-operator/scripts/jenkins && REPO=quay.io/coreos/prometheus-operator-dev TAG=$BUILD_ID make"')
+        shell('./scripts/jenkins/run-e2e-tests.sh')
     }
 
     publishers {
         postBuildScripts {
             steps {
-                shell('docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -v $PWD:/go/src/github.com/coreos/prometheus-operator cluster-setup-env /bin/bash -c "cd /go/src/github.com/coreos/prometheus-operator/scripts/jenkins && make clean"')
-                shell('docker rmi quay.io/coreos/prometheus-operator-dev:$BUILD_ID')
+                shell('./scripts/jenkins/post-e2e-tests.sh')
             }
             onlyIfBuildSucceeds(false)
             onlyIfBuildFails(false)

--- a/scripts/jenkins/post-e2e-tests.sh
+++ b/scripts/jenkins/post-e2e-tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# This is a cleanup script, if one command fails we still want all others to run
+# set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+# print each command before executing it
+set -x
+
+PO_GOPATH=/go/src/github.com/coreos/prometheus-operator
+
+docker run \
+       --rm \
+       -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+       -v $PWD:$PO_GOPATH \
+       -w $PO_GOPATH/scripts/jenkins \
+       cluster-setup-env \
+       /bin/bash -c "make clean"
+
+docker rmi quay.io/coreos/prometheus-operator-dev:$BUILD_ID

--- a/scripts/jenkins/run-e2e-tests.sh
+++ b/scripts/jenkins/run-e2e-tests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+# print each command before executing it
+set -x
+
+DOCKER_SOCKET=/var/run/docker.sock
+PO_QUAY_REPO=quay.io/coreos/prometheus-operator-dev
+
+docker build -t cluster-setup-env scripts/jenkins/.
+docker run \
+       --rm \
+       -v $PWD:$PWD -v $DOCKER_SOCKET:$DOCKER_SOCKET \
+       cluster-setup-env \
+       /bin/bash -c "cd $PWD && make crossbuild"
+
+docker build -t $PO_QUAY_REPO:$BUILD_ID .
+docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io
+docker push $PO_QUAY_REPO:$BUILD_ID
+
+docker run \
+       --rm \
+       -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+       -e REPO=$PO_QUAY_REPO -e TAG=$BUILD_ID \
+       -v $PWD:/go/src/github.com/coreos/prometheus-operator \
+       -w /go/src/github.com/coreos/prometheus-operator/scripts/jenkins \
+       cluster-setup-env \
+       /bin/bash -c "make"


### PR DESCRIPTION
This moves the e2e execution logic to shell scripts. 
In the long run these scripts will be reused to run tests on master.