### PR TITLE
cmd/operator: rename kubelet-object flag to kubelet-service

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -24,7 +24,7 @@ Once you complete this guide you will monitor the following:
 
 ## Preparing Kubernetes Components
 
-The manifests used here use the [Prometheus Operator](https://github.com/coreos/prometheus-operator), which manages Prometheus servers and their configuration in a cluster. Prometheus discovers targets through `Endpoints` objects, which means all targets that are running as `Pod`s in the Kubernetes cluster are easily monitored. Many Kubernetes components can be [self-hosted](https://coreos.com/blog/self-hosted-kubernetes.html) today. The kubelet, however, is not. Therefore the Prometheus Operator implements a functionality to synchronize the kubelets into an `Endpoints` object. To make use of that functionality the `--kubelet-object` argument must be passed to the Prometheus Operator when running it.
+The manifests used here use the [Prometheus Operator](https://github.com/coreos/prometheus-operator), which manages Prometheus servers and their configuration in a cluster. Prometheus discovers targets through `Endpoints` objects, which means all targets that are running as `Pod`s in the Kubernetes cluster are easily monitored. Many Kubernetes components can be [self-hosted](https://coreos.com/blog/self-hosted-kubernetes.html) today. The kubelet, however, is not. Therefore the Prometheus Operator implements a functionality to synchronize the kubelets into an `Endpoints` object. To make use of that functionality the `--kubelet-service` argument must be passed to the Prometheus Operator when running it.
 
 [embedmd]:# (../../contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator.yaml)
 ```yaml
@@ -46,7 +46,7 @@ spec:
        - name: prometheus-operator
          image: quay.io/coreos/prometheus-operator:v0.8.2
          args:
-         - "--kubelet-object=kube-system/kubelet"
+         - "--kubelet-service=kube-system/kubelet"
          - "--config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1"
          resources:
            requests:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -45,7 +45,7 @@ func init() {
 	flagset.StringVar(&cfg.TLSConfig.CertFile, "cert-file", "", " - NOT RECOMMENDED FOR PRODUCTION - Path to public TLS certificate file.")
 	flagset.StringVar(&cfg.TLSConfig.KeyFile, "key-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to private TLS certificate file.")
 	flagset.StringVar(&cfg.TLSConfig.CAFile, "ca-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to TLS CA file.")
-	flagset.StringVar(&cfg.KubeletObject, "kubelet-object", "", "Endpoints object to write kubelets into in format \"namespace/name\"")
+	flagset.StringVar(&cfg.KubeletObject, "kubelet-service", "", "Service/Endpoints object to write kubelets into in format \"namespace/name\"")
 	flagset.BoolVar(&cfg.TLSInsecure, "tls-insecure", false, "- NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate.")
 	flagset.BoolVar(&analyticsEnabled, "analytics", true, "Send analytical event (Cluster Created/Deleted etc.) to Google Analytics")
 	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", "quay.io/coreos/prometheus-config-reloader:v0.0.1", "Config and rule reload image")

--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator.yaml
@@ -16,7 +16,7 @@ spec:
        - name: prometheus-operator
          image: quay.io/coreos/prometheus-operator:v0.8.2
          args:
-         - "--kubelet-object=kube-system/kubelet"
+         - "--kubelet-service=kube-system/kubelet"
          - "--config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1"
          resources:
            requests:


### PR DESCRIPTION
As @mgoodness in #354 `kubelet-service` describes much better what the flag is supposed to represent than `kubelet-object`, therefore the renaming here.

@mgoodness @fabxc @mxinden 