### PR TITLE
Correct metric for container requested memory in grafana dashboard

### DIFF
--- a/contrib/kube-prometheus/assets/grafana/kubernetes-pods-dashboard.json
+++ b/contrib/kube-prometheus/assets/grafana/kubernetes-pods-dashboard.json
@@ -92,11 +92,11 @@
                             "step": 10
                         },
                         {
-                            "expr": "kube_pod_container_requested_memory_bytes{pod=\"$pod\", container=~\"$container\"}",
+                            "expr": "kube_pod_container_resource_requests_memory_bytes{pod=\"$pod\", container=~\"$container\"}",
                             "interval": "10s",
                             "intervalFactor": 2,
                             "legendFormat": "Requested: {{ container }}",
-                            "metric": "kube_pod_container_requested_memory_bytes",
+                            "metric": "kube_pod_container_resource_requests_memory_bytes",
                             "refId": "B",
                             "step": 20
                         }

--- a/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
@@ -1782,11 +1782,11 @@ data:
                                 "step": 10
                             },
                             {
-                                "expr": "kube_pod_container_requested_memory_bytes{pod=\"$pod\", container=~\"$container\"}",
+                                "expr": "kube_pod_container_resource_requests_memory_bytes{pod=\"$pod\", container=~\"$container\"}",
                                 "interval": "10s",
                                 "intervalFactor": 2,
                                 "legendFormat": "Requested: {{ container }}",
-                                "metric": "kube_pod_container_requested_memory_bytes",
+                                "metric": "kube_pod_container_resource_requests_memory_bytes",
                                 "refId": "B",
                                 "step": 20
                             }


### PR DESCRIPTION
Rename kube_pod_container_requested_memory_bytes -> kube_pod_container_resource_requests_memory_bytes in grafana dashboard

Based on https://github.com/coreos/prometheus-operator/issues/356#issuecomment-300090929