### PR TITLE
test: Add master job to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,88 +1,4 @@
-job('prometheus-operator-unit-tests') {
-    concurrentBuild()
-
-    parameters {
-        stringParam('sha1')
-    }
-
-    scm {
-        git {
-            remote {
-                github('coreos/prometheus-operator')
-                refspec('+refs/pull/*:refs/remotes/origin/pr/*')
-            }
-            branch('${sha1}')
-        }
-    }
-
-    triggers {
-        githubPullRequest {
-            useGitHubHooks()
-            orgWhitelist(['coreos-inc'])
-            allowMembersOfWhitelistedOrgsAsAdmin()
-            triggerPhrase('test this please|please test this')
-            extensions {
-                commitStatus {
-                    context('prometheus-operator-unit-tests')
-                    triggeredStatus('Tests triggered')
-                    startedStatus('Tests started')
-                    completedStatus('SUCCESS', 'Success')
-                    completedStatus('FAILURE', 'Failure')
-                    completedStatus('PENDING', 'Pending')
-                    completedStatus('ERROR', 'Error')
-                }
-            }
-        }
-    }
-
-    steps {
-        shell('docker run --rm -v $PWD:/go/src/github.com/coreos/prometheus-operator -w /go/src/github.com/coreos/prometheus-operator golang make test')
-    }
-}
-job('prometheus-operator-generate-content') {
-    concurrentBuild()
-
-    parameters {
-        stringParam('sha1')
-    }
-
-
-    scm {
-        git {
-            remote {
-                github('coreos/prometheus-operator')
-                refspec('+refs/pull/*:refs/remotes/origin/pr/*')
-            }
-            branch('${sha1}')
-        }
-    }
-
-    triggers {
-        githubPullRequest {
-            useGitHubHooks()
-            orgWhitelist(['coreos-inc'])
-            allowMembersOfWhitelistedOrgsAsAdmin()
-            triggerPhrase('test this please|please test this')
-            extensions {
-                commitStatus {
-                    context('prometheus-operator-docs')
-                    triggeredStatus('Tests triggered')
-                    startedStatus('Tests started')
-                    completedStatus('SUCCESS', 'Success')
-                    completedStatus('FAILURE', 'Failure')
-                    completedStatus('PENDING', 'Pending')
-                    completedStatus('ERROR', 'Error')
-                }
-            }
-        }
-    }
-
-    steps {
-        shell('docker run -v $PWD:/go/src/github.com/coreos/prometheus-operator -w /go/src/github.com/coreos/prometheus-operator/ golang make generate')
-        shell('git diff --exit-code')
-    }
-}
-job('prometheus-operator-e2e-tests') {
+job('po-tests-pr') {
     concurrentBuild()
 
     parameters {
@@ -118,7 +34,7 @@ job('prometheus-operator-e2e-tests') {
             triggerPhrase('test this please|please test this')
             extensions {
                 commitStatus {
-                    context('prometheus-operator-e2e-tests')
+                    context('prometheus-operator-tests')
                     triggeredStatus('Tests triggered')
                     startedStatus('Tests started')
                     completedStatus('SUCCESS', 'Success')
@@ -131,10 +47,80 @@ job('prometheus-operator-e2e-tests') {
     }
 
     steps {
+        shell('docker run -v $PWD:/go/src/github.com/coreos/prometheus-operator -w /go/src/github.com/coreos/prometheus-operator/ golang make generate')
+        shell('git diff --exit-code')
+    }
+
+    steps {
+        shell('docker run --rm -v $PWD:/go/src/github.com/coreos/prometheus-operator -w /go/src/github.com/coreos/prometheus-operator golang make test')
+    }
+
+    steps {
         shell('./scripts/jenkins/run-e2e-tests.sh')
     }
 
     publishers {
+        postBuildScripts {
+            steps {
+                shell('./scripts/jenkins/post-e2e-tests.sh')
+            }
+            onlyIfBuildSucceeds(false)
+            onlyIfBuildFails(false)
+        }
+    }
+}
+
+job('po-tests-master') {
+    concurrentBuild()
+
+    scm {
+        git {
+            remote {
+                github('coreos/prometheus-operator')
+            }
+            branch('master')
+        }
+    }
+
+    wrappers {
+        credentialsBinding {
+            amazonWebServicesCredentialsBinding{
+                accessKeyVariable('AWS_ACCESS_KEY_ID')
+                secretKeyVariable('AWS_SECRET_ACCESS_KEY')
+                credentialsId('Jenkins-Monitoring-AWS-User')
+            }
+            usernamePassword('QUAY_ROBOT_USERNAME', 'QUAY_ROBOT_SECRET', 'quay_robot')
+        }
+    }
+
+    triggers {
+        githubPush()
+        gitHubPushTrigger()
+        cron('@daily')
+        pollSCM{scmpoll_spec('')}
+    }
+
+    steps {
+        shell('docker run -v $PWD:/go/src/github.com/coreos/prometheus-operator -w /go/src/github.com/coreos/prometheus-operator/ golang make generate')
+        shell('git diff --exit-code')
+    }
+
+    steps {
+        shell('docker run --rm -v $PWD:/go/src/github.com/coreos/prometheus-operator -w /go/src/github.com/coreos/prometheus-operator golang make test')
+    }
+
+    steps {
+        shell('./scripts/jenkins/run-e2e-tests.sh')
+    }
+
+    publishers {
+        postBuildScripts {
+            steps {
+                shell('docker tag quay.io/coreos/prometheus-operator-dev:$BUILD_ID quay.io/coreos/prometheus-operator:master')
+                shell('docker push quay.io/coreos/prometheus-operator:master')
+            }
+            onlyIfBuildSucceeds(true)
+        }
         postBuildScripts {
             steps {
                 shell('./scripts/jenkins/post-e2e-tests.sh')

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Prometheus Operator
+[![Build Status](https://jenkins-monitoring-public.prod.coreos.systems/buildStatus/icon?job=po-tests-master&build=1)](https://jenkins-monitoring-public.prod.coreos.systems/job/po-tests-master/1/)
 
 **Project status: *alpha*** Not all planned features are completed. The API, spec, status 
 and other user facing objects are subject to change. We do not support backward-compatibility


### PR DESCRIPTION
* Moves e2e, unit and generation tests into one job.
* GitHub triggers Jenkins on every push event.
* Jenkins triggers the po-tests-master job on master pushes. 
* It runs the unit, generation and e2e tests and updates the :master image on quay.
* It runs daily to ensure PO operates with external dependencies.
* Adds build status to README.md.