### PR TITLE
prometheus: add externalLabels to PrometheusSpec API

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -136,6 +136,7 @@ Specification of the desired behavior of the Prometheus cluster. More info: http
 | imagePullSecrets | An optional list of references to secrets in the same namespace to use for pulling prometheus and alertmanager images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod | [][v1.LocalObjectReference](https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_localobjectreference) | false |
 | replicas | Number of instances to deploy for a Prometheus deployment. | *int32 | false |
 | retention | Time duration Prometheus shall retain data for. | string | false |
+| externalLabels | The labels to add to any time series or alerts when communicating with external systems (federation, remote storage, Alertmanager). | map[string]string | false |
 | externalUrl | The external URL the Prometheus instances will be available under. This is necessary to generate correct URLs. This is necessary if Prometheus is not served from root of a DNS name. | string | false |
 | routePrefix | The route prefix Prometheus registers HTTP handlers for. This is useful, if using ExternalURL and a proxy is rewriting HTTP routes of a request, and the actual ExternalURL is still true, but the server serves requests under a different route prefix. For example for use with `kubectl proxy`. | string | false |
 | storage | Storage spec to specify how storage shall be used. | *[StorageSpec](#storagespec) | false |

--- a/pkg/client/monitoring/v1alpha1/types.go
+++ b/pkg/client/monitoring/v1alpha1/types.go
@@ -66,6 +66,9 @@ type PrometheusSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Time duration Prometheus shall retain data for.
 	Retention string `json:"retention,omitempty"`
+	// The labels to add to any time series or alerts when communicating with
+	// external systems (federation, remote storage, Alertmanager).
+	ExternalLabels map[string]string `json:"externalLabels,omitempty"`
 	// The external URL the Prometheus instances will be available under. This is
 	// necessary to generate correct URLs. This is necessary if Prometheus is not
 	// served from root of a DNS name.
@@ -203,7 +206,7 @@ type Endpoint struct {
 // More info: https://prometheus.io/docs/operating/configuration/#endpoints
 type BasicAuth struct {
 	// The secret that contains the username for authenticate
-	Username v1.SecretKeySelector`json:"username,omitempty"`
+	Username v1.SecretKeySelector `json:"username,omitempty"`
 	// The secret that contains the password for authenticate
 	Password v1.SecretKeySelector `json:"password,omitempty"`
 }

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -40,9 +40,10 @@ func configMapRuleFileFolder(configMapNumber int) string {
 func generateConfig(p *v1alpha1.Prometheus, mons map[string]*v1alpha1.ServiceMonitor, ruleConfigMaps int, basicAuthSecrets map[string]BasicAuthCredentials) ([]byte, error) {
 	cfg := map[string]interface{}{}
 
-	cfg["global"] = map[string]string{
+	cfg["global"] = map[string]interface{}{
 		"evaluation_interval": "30s",
 		"scrape_interval":     "30s",
+		"external_labels":     p.Spec.ExternalLabels,
 	}
 
 	if ruleConfigMaps > 0 {


### PR DESCRIPTION
This allows the prometheus config `external_labels` to be configured via the PrometheusSpec TPR.  This is useful for adding unique identifiers for any federation or alerting.