### PR TITLE
prometheus: generate config deterministically

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -178,7 +178,16 @@ func generateServiceMonitorConfig(m *v1alpha1.ServiceMonitor, ep v1alpha1.Endpoi
 	// Filter targets by services selected by the monitor.
 
 	// Exact label matches.
-	for k, v := range m.Spec.Selector.MatchLabels {
+	labelKeys := make([]string, len(m.Spec.Selector.MatchLabels))
+	i = 0
+	for k, _ := range m.Spec.Selector.MatchLabels {
+		labelKeys[i] = k
+		i++
+	}
+	sort.Strings(labelKeys)
+	for i := range labelKeys {
+		k := labelKeys[i]
+		v := m.Spec.Selector.MatchLabels[k]
 		relabelings = append(relabelings, yaml.MapSlice{
 			{Key: "action", Value: "keep"},
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_service_label_" + sanitizeLabelName(k)}},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -1,0 +1,125 @@
+package prometheus
+
+import (
+	"bytes"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+)
+
+func TestConfigGeneration(t *testing.T) {
+	cfg, err := generateTestConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		testcfg, err := generateTestConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(cfg, testcfg) {
+			t.Fatalf("Config generation is not deterministic.\n\n\nFirst generation: \n\n%s\n\nDifferent generation: \n\n%s\n\n", string(cfg), string(testcfg))
+		}
+	}
+}
+
+func generateTestConfig() ([]byte, error) {
+	replicas := int32(1)
+	return generateConfig(
+		&v1alpha1.Prometheus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.PrometheusSpec{
+				Alerting: v1alpha1.AlertingSpec{
+					Alertmanagers: []v1alpha1.AlertmanagerEndpoints{
+						{
+							Name:      "alertmanager-main",
+							Namespace: "default",
+							Port:      intstr.FromString("web"),
+						},
+					},
+				},
+				Replicas: &replicas,
+				ServiceMonitorSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"group": "group1",
+					},
+				},
+				RuleSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"role": "rulefile",
+					},
+				},
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("400Mi"),
+					},
+				},
+			},
+		},
+		makeServiceMonitors(),
+		1,
+		map[string]BasicAuthCredentials{},
+	)
+}
+
+func makeServiceMonitors() map[string]*v1alpha1.ServiceMonitor {
+	res := map[string]*v1alpha1.ServiceMonitor{}
+
+	res["servicemonitor1"] = &v1alpha1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testservicemonitor1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"group": "group1",
+			},
+		},
+		Spec: v1alpha1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"group": "group1",
+				},
+			},
+			Endpoints: []v1alpha1.Endpoint{
+				v1alpha1.Endpoint{
+					Port:     "web",
+					Interval: "30s",
+				},
+			},
+		},
+	}
+
+	res["servicemonitor2"] = &v1alpha1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testservicemonitor2",
+			Namespace: "default",
+			Labels: map[string]string{
+				"group": "group2",
+			},
+		},
+		Spec: v1alpha1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"group": "group2",
+				},
+			},
+			Endpoints: []v1alpha1.Endpoint{
+				v1alpha1.Endpoint{
+					Port:     "web",
+					Interval: "30s",
+				},
+			},
+		},
+	}
+
+	return res
+}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -109,7 +109,8 @@ func makeServiceMonitors() map[string]*v1alpha1.ServiceMonitor {
 		Spec: v1alpha1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"group": "group2",
+					"group":  "group2",
+					"group3": "group3",
 				},
 			},
 			Endpoints: []v1alpha1.Endpoint{

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -218,3 +218,37 @@ func TestStatefulSetVolumeSkip(t *testing.T) {
 		t.Fatal("Volumes mounted in a Pod should not be reconciled.")
 	}
 }
+
+func TestDeterministicRuleFileHashing(t *testing.T) {
+	cmr, err := makeRuleConfigMap(makeConfigMap())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		testcmr, err := makeRuleConfigMap(makeConfigMap())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if cmr.Checksum != testcmr.Checksum {
+			t.Fatalf("Non-deterministic rule file hash generation")
+		}
+	}
+}
+
+func makeConfigMap() *v1.ConfigMap {
+	res := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcm",
+			Namespace: "default",
+		},
+		Data: map[string]string{},
+	}
+
+	res.Data["test1"] = "value 1"
+	res.Data["test2"] = "value 2"
+	res.Data["test3"] = "value 3"
+
+	return res
+}


### PR DESCRIPTION
Because maps have a non-deterministic order when newly instantiated, we need to use means to make sure that the prometheus yaml configuration we generate is deterministic.

This changes any use of a map in the config to use the `yaml.MapSlice`, which ensures deterministic map behavior, because the `yaml.MapItem`s are sorted by their keys before marshaling to yaml.

Note that this does rely on Kubernetes not changing the order or arrays in objects, as the `Alertmanagers` and `Endpoints` lists are reflected 1 to 1 in the generated config. If this does turn out to be a problem we'll have to find a way to sort those items as well, but that will likely require individual sorting for each of the lists.

Let me know if you want to keep the test that I wrote to make sure that it is deterministic or not.

@fabxc @mxinden 