### PR TITLE
test: Add slack integration to master job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,5 +128,13 @@ job('po-tests-master') {
             onlyIfBuildSucceeds(false)
             onlyIfBuildFails(false)
         }
+        slackNotifier {
+            room('#team-monitoring')
+            teamDomain('coreos')
+            authTokenCredentialId('team-monitoring-slack-jenkins')
+            notifyFailure(true)
+            notifyRegression(true)
+            notifyRepeatedFailure(true)
+        }
     }
 }


### PR DESCRIPTION
From now on, if a job on master fails, it will be reported in our #team-monitoring slack channel.