### PR TITLE
Support relabeling __address__ and __metrics_path__ for endpoints

### DIFF
--- a/pkg/client/monitoring/v1alpha1/types.go
+++ b/pkg/client/monitoring/v1alpha1/types.go
@@ -181,6 +181,8 @@ type ServiceMonitorSpec struct {
 
 // Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 type Endpoint struct {
+	// Address of http server scraped for this endpoint
+	Address string `json:"address,omitempty"`
 	// Name of the service port this endpoint refers to. Mutually exclusive with targetPort.
 	Port string `json:"port,omitempty"`
 	// Name or number of the target port of the endpoint. Mutually exclusive with port.


### PR DESCRIPTION
- An `Address` field added to `Endpoint` struct. If set, this will be used to replace `__address__`

- Endpoint paths are parsed to identify if this contains one or more `__meta` labels and necessary replacement config is generated. This also handles query string.

Fixes #387 