### PR TITLE
small changes in k8s/minikube and example-app

### DIFF
--- a/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-svc.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-svc.yaml
@@ -11,4 +11,4 @@ spec:
     protocol: TCP
     targetPort: web
   selector:
-    prometheus: prometheus-frontend
+    prometheus: frontend

--- a/contrib/kube-prometheus/manifests/k8s/minikube/kube-controller-manager.yaml
+++ b/contrib/kube-prometheus/manifests/k8s/minikube/kube-controller-manager.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: kube-system
   name: kube-controller-manager-prometheus-discovery
   labels:
     k8s-app: kube-controller-manager
@@ -16,6 +17,7 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
+  namespace: kube-system
   name: kube-controller-manager-prometheus-discovery
   labels:
     k8s-app: kube-controller-manager

--- a/contrib/kube-prometheus/manifests/k8s/minikube/kube-scheduler.yaml
+++ b/contrib/kube-prometheus/manifests/k8s/minikube/kube-scheduler.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: kube-system
   name: kube-scheduler-prometheus-discovery
   labels:
     k8s-app: kube-scheduler

--- a/contrib/kube-prometheus/manifests/k8s/minikube/kube-scheduler.yaml
+++ b/contrib/kube-prometheus/manifests/k8s/minikube/kube-scheduler.yaml
@@ -17,6 +17,7 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
+  namespace: kube-system
   name: kube-scheduler-prometheus-discovery
   labels:
     k8s-app: kube-scheduler


### PR DESCRIPTION
I found some minor issues that I have fixed. Please review and let me know if you agree:

1) in example-app, the selector of prometheus-frontend-svc was incorrect.
2) in kube-scheduler and kube-controller discovery services for minikube, the namespace has to be kube-system to be compatible with the current deployment of k8s-app ServiceMonitor, otherwise the service won't be selected by the ServiceMonitor.
(note: the self-hosted resources are okay)