### PR TITLE
Adding Field to Storage Spec to use a PVC Spec instead of v1alpha1.Storage

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -194,9 +194,10 @@ StorageSpec defines the configured storage for a group Prometheus servers.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| class | Name of the StorageClass to use when requesting storage provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses | string | true |
-| selector | A label query over volumes to consider for binding. | *[metav1.LabelSelector](https://kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | true |
-| resources | Resources represents the minimum resources the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources | [v1.ResourceRequirements](https://kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | true |
+| class | Name of the StorageClass to use when requesting storage provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses DEPRECATED | string | true |
+| selector | A label query over volumes to consider for binding. DEPRECATED | *[metav1.LabelSelector](https://kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | true |
+| resources | Resources represents the minimum resources the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources DEPRECATED | [v1.ResourceRequirements](https://kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | true |
+| volumeClaimTemplate | Pvc A pvc spec to be used by the Prometheus statefulsets. | v1.PersistentVolumeClaim | false |
 
 ## TLSConfig
 

--- a/Documentation/user-guides/storage.md
+++ b/Documentation/user-guides/storage.md
@@ -28,16 +28,22 @@ It is recommended to use volumes that have high I/O throughput therefore we're u
 The `StorageClass` that was created can be specified in the `storage` section in the `Prometheus` resource.
 
 ```yaml
-apiVersion: "monitoring.coreos.com/v1alpha1"
-kind: "Prometheus"
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: Prometheus
 metadata:
-  name: "persisted"
+  name: persisted
 spec:
+  replicas: 1
+  resources:
   storage:
-    class: ssd
-    resources:
-      requests:
-        storage: 40Gi
+    volumeClaimTemplate:
+      metadata:
+        annotations:
+          annotation1: foo
+      spec:
+        resources:
+          requests:
+            storage: 1Gi
 ```
 
 > The full documentation of the `storage` field can be found in the [spec documentation](../api.md#storagespec).
@@ -47,7 +53,7 @@ When now creating the `Prometheus` object a `PersistentVolumeClaim` is used for 
 
 ## Manual storage provisioning
 
-The storage specification of the [Prometheus](../api.md#prometheus) kind is flexible enough to support arbitrary storage, not just those created via StorageClasses.
+The Prometheus TPR specification allows you to support arbitrary storage, via a PersistentVolumeClaim.
 
 The easiest way to use a volume that cannot be automatically provisioned (for whatever reason) is to use a label selector alongside a manually created PersistentVolume.
 
@@ -63,12 +69,13 @@ metadata:
 spec:
   ...
   storage:
-    selector:
-      matchLabels:
-        app: "my-example-prometheus"
-    resources:
-      requests:
-        storage: 50Gi
+    volumeClaimTemplate:
+      selector:
+        matchLabels:
+          app: "my-example-prometheus"
+      resources:
+        requests:
+          storage: 50Gi
 
 ---
 
@@ -90,9 +97,9 @@ spec:
 
 ### Disabling Default StorageClasses
 
-In order to manually provoision volumes, as of Kubernetes 1.6.0, you may need to disable the default `StorageClass` that is automatically created for certain Cloud Providers. Default StorageClasses are pre-installed on Azure, AWS, GCE, OpenStack, and vSphere. 
+In order to manually provoision volumes, as of Kubernetes 1.6.0, you may need to disable the default `StorageClass` that is automatically created for certain Cloud Providers. Default StorageClasses are pre-installed on Azure, AWS, GCE, OpenStack, and vSphere.
 
-The default `StorageClass`s behavior will override manual storage provisioning, causing `PerisistentVolumeClaim`s not to bind manually created `PersistentVolume`s automatically. 
+The default `StorageClass`s behavior will override manual storage provisioning, causing `PerisistentVolumeClaim`s not to bind manually created `PersistentVolume`s automatically.
 
 To override this behavior, you must explicitely create the same resource, but set it to *not* be default ([see changelog for details](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#volumes)).
 
@@ -102,7 +109,7 @@ To accomplish this on a Google Container Engine cluster, create the following `S
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
-  name: standard 
+  name: standard
   annotations:
     # disable this default storage class by setting this annotation to false.
     storageclass.beta.kubernetes.io/is-default-class: "false"

--- a/pkg/client/monitoring/v1alpha1/types.go
+++ b/pkg/client/monitoring/v1alpha1/types.go
@@ -135,12 +135,17 @@ type AlertingSpec struct {
 type StorageSpec struct {
 	// Name of the StorageClass to use when requesting storage provisioning. More
 	// info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+	// DEPRECATED
 	Class string `json:"class"`
 	// A label query over volumes to consider for binding.
+	// DEPRECATED
 	Selector *metav1.LabelSelector `json:"selector"`
 	// Resources represents the minimum resources the volume should have. More
 	// info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources
+	// DEPRECATED
 	Resources v1.ResourceRequirements `json:"resources"`
+	// Pvc A pvc spec to be used by the Prometheus statefulsets.
+	VolumeClaimTemplate v1.PersistentVolumeClaim `json:"volumeClaimTemplate,omitempty"`
 }
 
 // AlertmanagerEndpoints defines a selection of a single Endpoints object


### PR DESCRIPTION
All test passes, and tested in a cluster.

Prometheus manifest:

````
apiVersion: monitoring.coreos.com/v1alpha1
kind: Prometheus
metadata:
  name: persisted
spec:
  replicas: 1
  resources:
  pvc:
    metadata:
      name: myclaim
      annotations:
        volume.beta.kubernetes.io/storage-class: gp2
        aws-ebs-additional-resource-tags: 'Test1=foo, Test2=bar'
    spec:
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 1Gi
          #storageClassName: gp2
````

````
kubectl get statefulsets prometheus-persisted -o yaml
apiVersion: apps/v1beta1
kind: StatefulSet
metadata:
  creationTimestamp: 2017-06-13T00:03:10Z
  generation: 1
  labels:
    app: prometheus
    prometheus: persisted
  name: prometheus-persisted
  namespace: default
  resourceVersion: "4307003"
  selfLink: /apis/apps/v1beta1/namespaces/default/statefulsets/prometheus-persisted
  uid: af95ac53-4fcb-11e7-901b-0e70723885a2
spec:
  replicas: 1
  selector:
    matchLabels:
      app: prometheus
      prometheus: persisted
  serviceName: prometheus-operated
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: prometheus
        prometheus: persisted
    spec:
      containers:
      - args:
        - -storage.local.retention=24h
        - -storage.local.num-fingerprint-mutexes=4096
        - -storage.local.path=/var/prometheus/data
        - -storage.local.chunk-encoding-version=2
        - -config.file=/etc/prometheus/config/prometheus.yaml
        - -storage.local.target-heap-size=1431655764
        image: quay.io/prometheus/prometheus:v1.7.0
        imagePullPolicy: IfNotPresent
        livenessProbe:
          failureThreshold: 10
          httpGet:
            path: /status
            port: web
            scheme: HTTP
          initialDelaySeconds: 300
          periodSeconds: 5
          successThreshold: 1
          timeoutSeconds: 3
        name: prometheus
        ports:
        - containerPort: 9090
          name: web
          protocol: TCP
        readinessProbe:
          failureThreshold: 6
          httpGet:
            path: /status
            port: web
            scheme: HTTP
          periodSeconds: 5
          successThreshold: 1
          timeoutSeconds: 3
        resources:
          requests:
            memory: 2Gi
        terminationMessagePath: /dev/termination-log
        volumeMounts:
        - mountPath: /etc/prometheus/config
          name: config
          readOnly: true
        - mountPath: /etc/prometheus/rules
          name: rules
          readOnly: true
        - mountPath: /var/prometheus/data
          name: prometheus-persisted-db
      - args:
        - -reload-url=http://localhost:9090/-/reload
        - -config-volume-dir=/etc/prometheus/config
        - -rule-volume-dir=/etc/prometheus/rules
        image: quay.io/coreos/prometheus-config-reloader:v0.0.1
        imagePullPolicy: IfNotPresent
        name: prometheus-config-reloader
        resources:
          limits:
            cpu: 5m
            memory: 10Mi
        terminationMessagePath: /dev/termination-log
        volumeMounts:
        - mountPath: /etc/prometheus/config
          name: config
          readOnly: true
        - mountPath: /etc/prometheus/rules
          name: rules
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      securityContext: {}
      terminationGracePeriodSeconds: 600
      volumes:
      - name: config
        secret:
          defaultMode: 420
          secretName: prometheus-persisted
      - emptyDir: {}
        name: rules
  volumeClaimTemplates:
  - metadata:
      annotations:
        volume.beta.kubernetes.io/aws-ebs-additional-resource-tags: Test1=foo, Test2=bar
        volume.beta.kubernetes.io/storage-class: gp2
      creationTimestamp: null
      name: prometheus-persisted-db
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 1Gi
    status:
      phase: Pending
status:
  replicas: 1
````