### PR TITLE
Fix basicAuth, swapping key and name

### DIFF
--- a/Documentation/user-guides/basic-auth.md
+++ b/Documentation/user-guides/basic-auth.md
@@ -14,11 +14,11 @@ spec:
   endpoints:
   - basicAuth:
       password:
-        key: basic-auth
-        name: password
+        name: basic-auth
+        key: password
       username:
-        key: basic-auth
-        name: user
+        name: basic-auth
+        key: user
     port: metrics
   namespaceSelector:
     matchNames:

--- a/contrib/kube-prometheus/manifests/examples/basic-auth/service-monitor.yaml
+++ b/contrib/kube-prometheus/manifests/examples/basic-auth/service-monitor.yaml
@@ -8,11 +8,11 @@ spec:
   endpoints:
   - basicAuth:
       password:
-        key: basic-auth
-        name: password
+        name: basic-auth
+        key: password
       username:
-        key: basic-auth
-        name: user
+        name: basic-auth
+        key: user
     port: metrics
   namespaceSelector:
     matchNames:

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -880,19 +880,19 @@ func (c *Operator) loadBasicAuthSecrets(mons map[string]*v1alpha1.ServiceMonitor
 
 				for _, secret := range s.Items {
 
-					if secret.Name == ep.BasicAuth.Username.Key {
+					if secret.Name == ep.BasicAuth.Username.Name {
 
-						if u, ok := secret.Data[ep.BasicAuth.Username.Name]; ok {
+						if u, ok := secret.Data[ep.BasicAuth.Username.Key]; ok {
 							username = string(u)
 						} else {
-							return nil, fmt.Errorf("Secret password of servicemonitor %s not found.")
+							return nil, fmt.Errorf("Secret password of servicemonitor %s not found.", mon.Name)
 						}
 
 					}
 
-					if secret.Name == ep.BasicAuth.Password.Key {
+					if secret.Name == ep.BasicAuth.Password.Name {
 
-						if p, ok := secret.Data[ep.BasicAuth.Password.Name]; ok {
+						if p, ok := secret.Data[ep.BasicAuth.Password.Key]; ok {
 							password = string(p)
 						} else {
 							return nil, fmt.Errorf("Secret username of servicemonitor %s not found.",
@@ -902,11 +902,16 @@ func (c *Operator) loadBasicAuthSecrets(mons map[string]*v1alpha1.ServiceMonitor
 					}
 				}
 
-				secrets[fmt.Sprintf("%s/%s/%d", mon.Namespace, mon.Name, i)] =
-					BasicAuthCredentials{
-						username: username,
-						password: password,
-					}
+				if username == "" && password == "" {
+					return nil, fmt.Errorf("Could not generate basicAuth for servicemonitor %s. Username and password are empty.",
+						mon.Name)
+				} else {
+					secrets[fmt.Sprintf("%s/%s/%d", mon.Namespace, mon.Name, i)] =
+						BasicAuthCredentials{
+							username: username,
+							password: password,
+						}
+				}
 
 			}
 		}


### PR DESCRIPTION
**Warning: This is a breaking change!!!**

The `key` and `name` were in a inverse (wrong) order.  Before applying this patch edit your `ServiceMonitor` and swap your `key` and `name` values of `basicAuth`.

fix #402