### PR TITLE
prometheus: allow specifying alertmanager url path prefix

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -32,6 +32,7 @@ AlertmanagerEndpoints defines a selection of a single Endpoints object containin
 | name | Name of Endpoints object in Namespace. | string | true |
 | port | Port the Alertmanager API is exposed on. | intstr.IntOrString | true |
 | scheme | Scheme to use when firing alerts. | string | true |
+| pathPrefix | Prefix for the HTTP path alerts are pushed to. | string | true |
 
 ## AlertmanagerList
 

--- a/pkg/client/monitoring/v1alpha1/types.go
+++ b/pkg/client/monitoring/v1alpha1/types.go
@@ -154,6 +154,8 @@ type AlertmanagerEndpoints struct {
 	Port intstr.IntOrString `json:"port"`
 	// Scheme to use when firing alerts.
 	Scheme string `json:"scheme"`
+	// Prefix for the HTTP path alerts are pushed to.
+	PathPrefix string `json:"pathPrefix"`
 }
 
 // ServiceMonitor defines monitoring for a set of services.

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -332,6 +332,10 @@ func generateAlertmanagerConfig(am v1alpha1.AlertmanagerEndpoints) yaml.MapSlice
 		am.Scheme = "http"
 	}
 
+	if am.PathPrefix == "" {
+		am.PathPrefix = "/"
+	}
+
 	cfg := yaml.MapSlice{
 		{
 			Key: "kubernetes_sd_configs",


### PR DESCRIPTION
Fixes #378 

While we don't recommend configuring the Alertmanager like this, it is not a completely unreasonable thing to support, for example if the Alertmanager is running outside or in another Kubernetes cluster.

@fabxc @mxinden 

/cc @galexrt 