### PR TITLE
*: update default versions and example usages

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -432,7 +432,7 @@ metadata:
     alertmanager: "main"
 spec:
   replicas: 3
-  version: v0.7.0
+  version: v0.7.1
 ```
 
 Read more in the [alerting guide](alerting.md) on how to configure the Alertmanager as it will not spin up unless it has a valid configuration mounted through a `Secret`. Note that the `Secret` has to be in the same namespace as the `Alertmanager` resource as well as have the name `alertmanager-<name-of-alertmanager-object` and the key of the configuration is `alertmanager.yaml`.

--- a/Documentation/user-guides/exposing-prometheus-and-alertmanager.md
+++ b/Documentation/user-guides/exposing-prometheus-and-alertmanager.md
@@ -15,7 +15,7 @@ metadata:
   name: "main"
 spec:
   replicas: 1
-  version: v1.7.0
+  version: v1.7.1
   resources:
     requests:
       memory: 400Mi
@@ -51,7 +51,7 @@ metadata:
   name: "main"
 spec:
   replicas: 3
-  version: v0.7.0
+  version: v0.7.1
   resources:
     requests:
       memory: 400Mi
@@ -115,7 +115,7 @@ metadata:
   name: "main"
 spec:
   replicas: 1
-  version: v1.7.0
+  version: v1.7.1
   externalUrl: http://127.0.0.1:8001/api/v1/proxy/namespaces/default/services/prometheus-main:web/
   resources:
     requests:
@@ -135,7 +135,7 @@ metadata:
   name: "main"
 spec:
   replicas: 3
-  version: v0.7.0
+  version: v0.7.1
   externalUrl: http://127.0.0.1:8001/api/v1/proxy/namespaces/default/services/alertmanager-main:web/
   resources:
     requests:
@@ -243,7 +243,7 @@ metadata:
   name: "main"
 spec:
   replicas: 1
-  version: v1.7.0
+  version: v1.7.1
   externalUrl: http://monitoring.my.systems/prometheus
   resources:
     requests:
@@ -255,7 +255,7 @@ metadata:
   name: "main"
 spec:
   replicas: 3
-  version: v0.7.0
+  version: v0.7.1
   externalUrl: http://monitoring.my.systems/alertmanager
   resources:
     requests:

--- a/contrib/kube-prometheus/manifests/alertmanager/alertmanager.yaml
+++ b/contrib/kube-prometheus/manifests/alertmanager/alertmanager.yaml
@@ -6,4 +6,4 @@ metadata:
     alertmanager: "main"
 spec:
   replicas: 3
-  version: v0.7.0
+  version: v0.7.1

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -34,7 +34,7 @@ import (
 const (
 	governingServiceName = "alertmanager-operated"
 	defaultBaseImage     = "quay.io/prometheus/alertmanager"
-	defaultVersion       = "v0.7.0"
+	defaultVersion       = "v0.7.1"
 )
 
 var (

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -78,17 +78,17 @@ func TestAlertmanagerVersionMigration(t *testing.T) {
 	name := "test"
 
 	am := framework.MakeBasicAlertmanager(name, 1)
-	am.Spec.Version = "v0.6.0"
+	am.Spec.Version = "v0.7.0"
 	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
 		t.Fatal(err)
 	}
 
-	am.Spec.Version = "v0.6.1"
+	am.Spec.Version = "v0.7.1"
 	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
 		t.Fatal(err)
 	}
 
-	am.Spec.Version = "v0.6.0"
+	am.Spec.Version = "v0.7.0"
 	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestMeshInitialization(t *testing.T) {
 		},
 		Spec: v1alpha1.AlertmanagerSpec{
 			Replicas: &amountAlertmanagers,
-			Version:  "v0.7.0",
+			Version:  "v0.7.1",
 		},
 	}
 


### PR DESCRIPTION
This updates the Prometheus and Alertmanager versions we default to and is used in example manifests to the latest releases.

@fabxc @mxinden 