### PR TITLE
prometheus: configure namespaces to actually necessary namespaces

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -20,6 +20,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -49,6 +51,16 @@ func stringMapToMapSlice(m map[string]string) yaml.MapSlice {
 }
 
 func generateConfig(p *v1alpha1.Prometheus, mons map[string]*v1alpha1.ServiceMonitor, ruleConfigMaps int, basicAuthSecrets map[string]BasicAuthCredentials) ([]byte, error) {
+	versionStr := p.Spec.Version
+	if versionStr == "" {
+		versionStr = defaultVersion
+	}
+
+	version, err := semver.Parse(strings.TrimLeft(versionStr, "v"))
+	if err != nil {
+		return nil, errors.Wrap(err, "parse version")
+	}
+
 	cfg := yaml.MapSlice{}
 
 	cfg = append(cfg, yaml.MapItem{
@@ -84,12 +96,12 @@ func generateConfig(p *v1alpha1.Prometheus, mons map[string]*v1alpha1.ServiceMon
 	var scrapeConfigs []yaml.MapSlice
 	for _, identifier := range identifiers {
 		for i, ep := range mons[identifier].Spec.Endpoints {
-			scrapeConfigs = append(scrapeConfigs, generateServiceMonitorConfig(mons[identifier], ep, i, basicAuthSecrets))
+			scrapeConfigs = append(scrapeConfigs, generateServiceMonitorConfig(version, mons[identifier], ep, i, basicAuthSecrets))
 		}
 	}
 	var alertmanagerConfigs []yaml.MapSlice
 	for _, am := range p.Spec.Alerting.Alertmanagers {
-		alertmanagerConfigs = append(alertmanagerConfigs, generateAlertmanagerConfig(am))
+		alertmanagerConfigs = append(alertmanagerConfigs, generateAlertmanagerConfig(version, am))
 	}
 
 	cfg = append(cfg, yaml.MapItem{
@@ -110,18 +122,7 @@ func generateConfig(p *v1alpha1.Prometheus, mons map[string]*v1alpha1.ServiceMon
 	return yaml.Marshal(cfg)
 }
 
-func generateServiceMonitorConfig(m *v1alpha1.ServiceMonitor, ep v1alpha1.Endpoint, i int, basicAuthSecrets map[string]BasicAuthCredentials) yaml.MapSlice {
-	nsel := m.Spec.NamespaceSelector
-	namespaces := []string{}
-	if !nsel.Any && len(nsel.MatchNames) == 0 {
-		namespaces = append(namespaces, m.Namespace)
-	}
-	if !nsel.Any && len(nsel.MatchNames) > 0 {
-		for i := range nsel.MatchNames {
-			namespaces = append(namespaces, nsel.MatchNames[i])
-		}
-	}
-
+func generateServiceMonitorConfig(version semver.Version, m *v1alpha1.ServiceMonitor, ep v1alpha1.Endpoint, i int, basicAuthSecrets map[string]BasicAuthCredentials) yaml.MapSlice {
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
@@ -131,26 +132,17 @@ func generateServiceMonitorConfig(m *v1alpha1.ServiceMonitor, ep v1alpha1.Endpoi
 			Key:   "honor_labels",
 			Value: ep.HonorLabels,
 		},
-		{
-			Key: "kubernetes_sd_configs",
-			Value: []yaml.MapSlice{
-				yaml.MapSlice{
-					{
-						Key:   "role",
-						Value: "endpoints",
-					},
-					{
-						Key: "namespaces",
-						Value: yaml.MapSlice{
-							{
-								Key:   "names",
-								Value: namespaces,
-							},
-						},
-					},
-				},
-			},
-		},
+	}
+
+	switch version.Major {
+	case 1:
+		if version.Minor < 7 {
+			cfg = append(cfg, k8sSDAllNamespaces())
+		} else {
+			cfg = append(cfg, k8sSDFromServiceMonitor(m))
+		}
+	case 2:
+		cfg = append(cfg, k8sSDFromServiceMonitor(m))
 	}
 
 	if ep.Interval != "" {
@@ -247,6 +239,36 @@ func generateServiceMonitorConfig(m *v1alpha1.ServiceMonitor, ep v1alpha1.Endpoi
 		}
 	}
 
+	if version.Major == 1 && version.Minor < 7 {
+		// Filter targets based on the namespace selection configuration.
+		// By default we only discover services within the namespace of the
+		// ServiceMonitor.
+		// Selections allow extending this to all namespaces or to a subset
+		// of them specified by label or name matching.
+		//
+		// Label selections are not supported yet as they require either supported
+		// in the upstream SD integration or require out-of-band implementation
+		// in the operator with configuration reload.
+		//
+		// There's no explicit nil for the selector, we decide for the default
+		// case if it's all zero values.
+		nsel := m.Spec.NamespaceSelector
+
+		if !nsel.Any && len(nsel.MatchNames) == 0 {
+			relabelings = append(relabelings, yaml.MapSlice{
+				{Key: "action", Value: "keep"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_namespace"}},
+				{Key: "regex", Value: m.Namespace},
+			})
+		} else if len(nsel.MatchNames) > 0 {
+			relabelings = append(relabelings, yaml.MapSlice{
+				{Key: "action", Value: "keep"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_namespace"}},
+				{Key: "regex", Value: strings.Join(nsel.MatchNames, "|")},
+			})
+		}
+	}
+
 	// Filter targets based on correct port for the endpoint.
 	if ep.Port != "" {
 		relabelings = append(relabelings, yaml.MapSlice{
@@ -321,7 +343,59 @@ func generateServiceMonitorConfig(m *v1alpha1.ServiceMonitor, ep v1alpha1.Endpoi
 	return cfg
 }
 
-func generateAlertmanagerConfig(am v1alpha1.AlertmanagerEndpoints) yaml.MapSlice {
+func k8sSDFromServiceMonitor(m *v1alpha1.ServiceMonitor) yaml.MapItem {
+	nsel := m.Spec.NamespaceSelector
+	namespaces := []string{}
+	if !nsel.Any && len(nsel.MatchNames) == 0 {
+		namespaces = append(namespaces, m.Namespace)
+	}
+	if !nsel.Any && len(nsel.MatchNames) > 0 {
+		for i := range nsel.MatchNames {
+			namespaces = append(namespaces, nsel.MatchNames[i])
+		}
+	}
+
+	return k8sSDWithNamespaces(namespaces)
+}
+
+func k8sSDWithNamespaces(namespaces []string) yaml.MapItem {
+	return yaml.MapItem{
+		Key: "kubernetes_sd_configs",
+		Value: []yaml.MapSlice{
+			yaml.MapSlice{
+				{
+					Key:   "role",
+					Value: "endpoints",
+				},
+				{
+					Key: "namespaces",
+					Value: yaml.MapSlice{
+						{
+							Key:   "names",
+							Value: namespaces,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func k8sSDAllNamespaces() yaml.MapItem {
+	return yaml.MapItem{
+		Key: "kubernetes_sd_configs",
+		Value: []yaml.MapSlice{
+			yaml.MapSlice{
+				{
+					Key:   "role",
+					Value: "endpoints",
+				},
+			},
+		},
+	}
+}
+
+func generateAlertmanagerConfig(version semver.Version, am v1alpha1.AlertmanagerEndpoints) yaml.MapSlice {
 	if am.Scheme == "" {
 		am.Scheme = "http"
 	}
@@ -331,27 +405,19 @@ func generateAlertmanagerConfig(am v1alpha1.AlertmanagerEndpoints) yaml.MapSlice
 	}
 
 	cfg := yaml.MapSlice{
-		{
-			Key: "kubernetes_sd_configs",
-			Value: []yaml.MapSlice{
-				yaml.MapSlice{
-					{
-						Key:   "role",
-						Value: "endpoints",
-					},
-					{
-						Key: "namespaces",
-						Value: yaml.MapSlice{
-							{
-								Key:   "names",
-								Value: []string{am.Namespace},
-							},
-						},
-					},
-				},
-			},
-		},
+		{Key: "path_prefix", Value: am.PathPrefix},
 		{Key: "scheme", Value: am.Scheme},
+	}
+
+	switch version.Major {
+	case 1:
+		if version.Minor < 7 {
+			cfg = append(cfg, k8sSDAllNamespaces())
+		} else {
+			cfg = append(cfg, k8sSDWithNamespaces([]string{am.Namespace}))
+		}
+	case 2:
+		cfg = append(cfg, k8sSDWithNamespaces([]string{am.Namespace}))
 	}
 
 	var relabelings []yaml.MapSlice
@@ -373,6 +439,14 @@ func generateAlertmanagerConfig(am v1alpha1.AlertmanagerEndpoints) yaml.MapSlice
 			{Key: "action", Value: "keep"},
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_container_port_number"}},
 			{Key: "regex", Value: am.Port.String()},
+		})
+	}
+
+	if version.Major == 1 && version.Minor < 7 {
+		relabelings = append(relabelings, yaml.MapSlice{
+			{Key: "action", Value: "keep"},
+			{Key: "source_labels", Value: []string{"__meta_kubernetes_namespace"}},
+			{Key: "regex", Value: am.Namespace},
 		})
 	}
 

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -27,24 +27,26 @@ import (
 )
 
 func TestConfigGeneration(t *testing.T) {
-	cfg, err := generateTestConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i < 1000; i++ {
-		testcfg, err := generateTestConfig()
+	for _, v := range CompatibilityMatrix {
+		cfg, err := generateTestConfig(v)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if !bytes.Equal(cfg, testcfg) {
-			t.Fatalf("Config generation is not deterministic.\n\n\nFirst generation: \n\n%s\n\nDifferent generation: \n\n%s\n\n", string(cfg), string(testcfg))
+		for i := 0; i < 1000; i++ {
+			testcfg, err := generateTestConfig(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(cfg, testcfg) {
+				t.Fatalf("Config generation is not deterministic.\n\n\nFirst generation: \n\n%s\n\nDifferent generation: \n\n%s\n\n", string(cfg), string(testcfg))
+			}
 		}
 	}
 }
 
-func generateTestConfig() ([]byte, error) {
+func generateTestConfig(version string) ([]byte, error) {
 	replicas := int32(1)
 	return generateConfig(
 		&v1alpha1.Prometheus{
@@ -62,6 +64,7 @@ func generateTestConfig() ([]byte, error) {
 						},
 					},
 				},
+				Version:  version,
 				Replicas: &replicas,
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -51,6 +51,22 @@ var (
 		managedByOperatorLabel: managedByOperatorLabelValue,
 	}
 	probeTimeoutSeconds int32 = 3
+
+	CompatibilityMatrix = []string{
+		"v1.4.0",
+		"v1.4.1",
+		"v1.5.0",
+		"v1.5.1",
+		"v1.5.2",
+		"v1.5.3",
+		"v1.6.0",
+		"v1.6.1",
+		"v1.6.2",
+		"v1.6.3",
+		"v1.7.0",
+		"v1.7.1",
+		"v2.0.0-alpha.2",
+	}
 )
 
 func makeStatefulSet(p v1alpha1.Prometheus, old *v1beta1.StatefulSet, config *Config, ruleConfigMaps []*v1.ConfigMap) (*v1beta1.StatefulSet, error) {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -88,28 +88,23 @@ func TestPrometheusVersionMigration(t *testing.T) {
 	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
 	name := "test"
+	startVersion := prometheus.CompatibilityMatrix[0]
+	compatibilityMatrix := prometheus.CompatibilityMatrix[1:]
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
-
-	p.Spec.Version = "v1.5.1"
+	p.Spec.Version = startVersion
 	if err := framework.CreatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	p.Spec.Version = "v1.6.1"
-	if err := framework.UpdatePrometheusAndWaitUntilReady(ns, p); err != nil {
-		t.Fatal(err)
-	}
-	if err := framework.WaitForPrometheusRunImageAndReady(ns, p); err != nil {
-		t.Fatal(err)
-	}
-
-	p.Spec.Version = "v1.5.1"
-	if err := framework.UpdatePrometheusAndWaitUntilReady(ns, p); err != nil {
-		t.Fatal(err)
-	}
-	if err := framework.WaitForPrometheusRunImageAndReady(ns, p); err != nil {
-		t.Fatal(err)
+	for _, v := range compatibilityMatrix {
+		p.Spec.Version = v
+		if err := framework.UpdatePrometheusAndWaitUntilReady(ns, p); err != nil {
+			t.Fatal(err)
+		}
+		if err := framework.WaitForPrometheusRunImageAndReady(ns, p); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -317,7 +317,7 @@ func TestPrometheusDiscovery(t *testing.T) {
 	}
 
 	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
-	p.Spec.Version = "v1.5.0"
+	p.Spec.Version = "v1.7.1"
 	if err := framework.CreatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}
@@ -352,7 +352,7 @@ func TestPrometheusAlertmanagerDiscovery(t *testing.T) {
 
 	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
 	framework.AddAlertingToPrometheus(p, ns, alertmanagerName)
-	p.Spec.Version = "v1.5.0"
+	p.Spec.Version = "v1.7.1"
 	if err := framework.CreatePrometheusAndWaitUntilReady(ns, p); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Through the ServiceMonitors we're able to infer the namespaces the Prometheus instance will need.

This allows us to run Prometheus instances with the RBAC roles set for the namespaces the instance will actually need.

@fabxc @mxinden @Gouthamve

Closes #39