### PR TITLE
kube-prometheus: update serviceMonitorSelector

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: prometheus-k8s
   serviceMonitorSelector:
     matchExpression:
-    - {key: k8s-apps, operator: Exists}
+    - {key: k8s-app, operator: Exists}
   ruleSelector:
     matchLabels:
       role: prometheus-rulefiles


### PR DESCRIPTION
In commit 9cd05a8c39c6ed03688859de92372d93af5cc6e2 the labels on the ServiceMonitors were changed from k8s-apps to k8s-app. This commit makes the Prometheus serviceMonitorSelector match that change.