### PR TITLE
Add recomendation to install operator before alertmanager/prometheus

### DIFF
--- a/helm/alertmanager/README.md
+++ b/helm/alertmanager/README.md
@@ -14,6 +14,7 @@ This chart bootstraps an [Alertmanager](https://github.com/prometheus/alertmanag
 
 ## Prerequisites
   - Kubernetes 1.4+ with Beta APIs & ThirdPartyResources enabled
+  - [Prometheus operator](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/README.md).
 
 ## Installing the Chart
 

--- a/helm/alertmanager/README.md
+++ b/helm/alertmanager/README.md
@@ -14,7 +14,7 @@ This chart bootstraps an [Alertmanager](https://github.com/prometheus/alertmanag
 
 ## Prerequisites
   - Kubernetes 1.4+ with Beta APIs & ThirdPartyResources enabled
-  - [Prometheus operator](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/README.md).
+  - [prometheus-operator](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/README.md).
 
 ## Installing the Chart
 

--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -14,6 +14,7 @@ This chart bootstraps a [Prometheus](https://github.com/prometheus/prometheus) d
 
 ## Prerequisites
   - Kubernetes 1.4+ with Beta APIs & ThirdPartyResources enabled
+  - [Prometheus operator](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/README.md).
 
 ## Installing the Chart
 

--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a [Prometheus](https://github.com/prometheus/prometheus) d
 
 ## Prerequisites
   - Kubernetes 1.4+ with Beta APIs & ThirdPartyResources enabled
-  - [Prometheus operator](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/README.md).
+  - [prometheus-operator](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/README.md).
 
 ## Installing the Chart
 


### PR DESCRIPTION
Because the `thirdypartyresource` is not yet installed, you got an error when you are trying to install  prometheus/alermanager.

```
$ helm install alertmanager --name alertmanager --debug
[debug] Created tunnel using local port: '57662'

[debug] SERVER: "localhost:57662"

[debug] CHART PATH: /Users/grubio/work/src/github.com/coreos/prometheus-operator/helm/alertmanager

Error: apiVersion "monitoring.coreos.com/v1alpha1" in alertmanager/templates/alertmanager.yaml is not available
```