### PR TITLE
Cleanup thirdypartyresource before deleting the chart

### DIFF
--- a/helm/prometheus-operator/templates/clusterrole.yaml
+++ b/helm/prometheus-operator/templates/clusterrole.yaml
@@ -13,51 +13,35 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "fullname" . }}
 rules:
-- apiGroups:
-  - extensions
-  resources:
-  - thirdpartyresources
-  verbs:
-  - "*"
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - "*"
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - alertmanagers
-  - prometheuses
-  - servicemonitors
-  verbs:
-  - "*"
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs: ["*"]
-- apiGroups: [""]
-  resources:
-  - configmaps
-  - secrets
-  verbs: ["*"]
-- apiGroups: [""]
-  resources:
-  - pods
-  verbs: ["list", "delete"]
-- apiGroups: [""]
-  resources:
-  - services
-  - endpoints
-  verbs: ["get", "create", "update"]
-- apiGroups: [""]
-  resources:
-  - nodes
-  verbs: ["list", "watch"]
-- apiGroups: [""]
-  resources:
-  - namespaces
-  verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["*"]
+
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete", "list"]
+
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["create", "get", "update"]
+
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "update"]
+
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["*"]
+
+  - apiGroups: ["extensions"]
+    resources: ["thirdpartyresources"]
+    verbs: ["create", "get"]
+
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["alertmanagers", "prometheuses", "servicemonitors"]
+    verbs: ["*"]
 {{- end }}

--- a/helm/prometheus-operator/templates/clusterrole.yaml
+++ b/helm/prometheus-operator/templates/clusterrole.yaml
@@ -13,35 +13,54 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "fullname" . }}
 rules:
-  - apiGroups: [""]
-    resources: ["configmaps", "secrets"]
-    verbs: ["*"]
-
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["delete", "list"]
-
-  - apiGroups: [""]
-    resources: ["services", "endpoints"]
-    verbs: ["create", "get", "update"]
-
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["list", "watch"]
-
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["get", "update"]
-
-  - apiGroups: ["apps"]
-    resources: ["statefulsets"]
-    verbs: ["*"]
-
-  - apiGroups: ["extensions"]
-    resources: ["thirdpartyresources"]
-    verbs: ["create", "get"]
-
-  - apiGroups: ["monitoring.coreos.com"]
-    resources: ["alertmanagers", "prometheuses", "servicemonitors"]
-    verbs: ["*"]
+- apiGroups:
+  - extensions
+  resources:
+  - thirdpartyresources
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - servicemonitors
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  verbs: ["*"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "delete"]
+- apiGroups: [""]
+  resources:
+  - services
+  - endpoints
+  verbs: ["get", "create", "update"]
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list"]
 {{- end }}

--- a/helm/prometheus-operator/templates/delete-crd-job.yaml
+++ b/helm/prometheus-operator/templates/delete-crd-job.yaml
@@ -4,6 +4,7 @@ kind: Job
 metadata:
   annotations:
     helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: hook-succeeded
   labels:
      app: {{ template "name" . }}
      chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -25,7 +26,7 @@ spec:
         command:
           - ./kubectl
           - delete
-          - thirdpartyresource
+          - customresourcedefinitions
           - --ignore-not-found=true
           - alertmanager.monitoring.coreos.com
           - prometheus.monitoring.coreos.com

--- a/helm/prometheus-operator/templates/delete-tpr-job.yaml
+++ b/helm/prometheus-operator/templates/delete-tpr-job.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.cleanupOnDelete -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: pre-delete
+  labels:
+     app: {{ template "name" . }}
+     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+     heritage: {{ .Release.Service }}
+     release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-delete-tpr
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+      name: {{ template "fullname" . }}-delete-tpr
+    spec:
+      containers:
+      - name: hyperkube
+        image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+        imagePullPolicy: "{{ .Values.global.hyperkube.pullPolicy }}"
+        command:
+          - ./kubectl
+          - delete
+          - thirdpartyresource
+          - --ignore-not-found=true
+          - alertmanager.monitoring.coreos.com
+          - prometheus.monitoring.coreos.com
+          - service-monitor.monitoring.coreos.com
+      restartPolicy: OnFailure
+    {{- if .Values.rbacEnable }}
+      serviceAccountName: {{ template "fullname" . }}
+    {{- end }}
+{{- end }}

--- a/helm/prometheus-operator/values.yaml
+++ b/helm/prometheus-operator/values.yaml
@@ -40,14 +40,9 @@ nodeSelector: {}
 ##
 rbacEnable: true
 
-## IF true, remove the thirdypartyresource
+## IF true, remove the crd
 ##
 cleanupOnDelete: false
-
-## If true, collect & send anonymous usage statistics
-## Ref: https://github.com/coreos/prometheus-operator#installation
-##
-sendAnalytics: true
 
 ## Prometheus-operator resource limits & requests
 ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/

--- a/helm/prometheus-operator/values.yaml
+++ b/helm/prometheus-operator/values.yaml
@@ -40,6 +40,15 @@ nodeSelector: {}
 ##
 rbacEnable: true
 
+## IF true, remove the thirdypartyresource
+##
+cleanupOnDelete: false
+
+## If true, collect & send anonymous usage statistics
+## Ref: https://github.com/coreos/prometheus-operator#installation
+##
+sendAnalytics: true
+
 ## Prometheus-operator resource limits & requests
 ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
When you 

1 - install the chart
2- delete the chart 
3- install the chart again

 you got the error below. This job will delete the tpr before deleting the chart.

```
$ helm install prometheus-operator --name prometheus-operator
Error: jobs.batch "prometheus-operator-prometheus-operator-cleanup-tpr" already exists
```