### PR TITLE
prometheus: use computed route prefix instead of the spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.2 / 2017-06-21
+
+* [BUGFIX] Use computed route prefix instead of directly from manifest.
+
 ## 0.10.1 / 2017-06-13
 
 Attention: if the basic auth feature was previously used, the `key` and `name`

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -327,7 +327,7 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 	if p.Spec.RoutePrefix != "" {
 		webRoutePrefix = p.Spec.RoutePrefix
 	}
-	promArgs = append(promArgs, "-web.route-prefix="+p.Spec.RoutePrefix)
+	promArgs = append(promArgs, "-web.route-prefix="+webRoutePrefix)
 
 	localReloadURL := &url.URL{
 		Scheme: "http",


### PR DESCRIPTION
@fabxc @mxinden @Gouthamve 

I'll release a new patch release as soon as this is merged.