### PR TITLE
Use exponential backoff for prometheus reloading.

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -50,7 +50,7 @@ func init() {
 	flagset.StringVar(&cfg.KubeletObject, "kubelet-service", "", "Service/Endpoints object to write kubelets into in format \"namespace/name\"")
 	flagset.BoolVar(&cfg.TLSInsecure, "tls-insecure", false, "- NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate.")
 	flagset.BoolVar(&analyticsEnabled, "analytics", true, "Send analytical event (Cluster Created/Deleted etc.) to Google Analytics")
-	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", "quay.io/coreos/prometheus-config-reloader:v0.0.1", "Config and rule reload image")
+	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", "quay.io/coreos/prometheus-config-reloader:v0.0.2", "Config and rule reload image")
 	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "quay.io/coreos/configmap-reload:v0.0.1", "Reload Image")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", "quay.io/prometheus/alertmanager", "Alertmanager default base image")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", "quay.io/prometheus/prometheus", "Prometheus default base image")

--- a/contrib/prometheus-config-reloader/Makefile
+++ b/contrib/prometheus-config-reloader/Makefile
@@ -4,7 +4,7 @@ FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 NAME = prometheus-config-reloader
 REPO = quay.io/coreos/$(NAME)
-TAG = v0.0.1
+TAG = v0.0.2
 IMAGE = $(REPO):$(TAG)
 
 build:

--- a/contrib/prometheus-config-reloader/examples/prometheus-config-reloader.yaml
+++ b/contrib/prometheus-config-reloader/examples/prometheus-config-reloader.yaml
@@ -30,7 +30,7 @@ spec:
           mountPath: /etc/prometheus/rules
           readOnly: true
       - name: prometheus-config-reloader
-        image: quay.io/coreos/prometheus-config-reloader:v0.0.1
+        image: quay.io/coreos/prometheus-config-reloader:v0.0.2
         args:
         - '-config-volume-dir=/etc/prometheus/config'
         - '-rule-volume-dir=/etc/prometheus/rules'

--- a/helm/prometheus-operator/README.md
+++ b/helm/prometheus-operator/README.md
@@ -90,7 +90,7 @@ Parameter | Description | Default
 `kubeletService.name` | The name of the kubelet service to be created | `kubelet`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `prometheusConfigReloader.repository` | prometheus-config-reloader image | `quay.io/coreos/prometheus-config-reloader`
-`prometheusConfigReloader.tag` | prometheus-config-reloader tag | `v0.0.1`
+`prometheusConfigReloader.tag` | prometheus-config-reloader tag | `v0.0.2`
 `rbacEnable` | If true, create & use RBAC resources | `true`
 `resources` | Pod resource requests & limits | `{}`
 `sendAnalytics` | Collect & send anonymous usage statistics | `true`

--- a/helm/prometheus-operator/values.yaml
+++ b/helm/prometheus-operator/values.yaml
@@ -10,7 +10,7 @@ global:
 ##
 prometheusConfigReloader:
   repository: quay.io/coreos/prometheus-config-reloader
-  tag: v0.0.1
+  tag: v0.0.2
 
 ## Configmap-reload image to use for reloading configmaps
 ##


### PR DESCRIPTION
On startup, prometheus may not be ready to be reloaded.
Or, during operation, something may go wrong with prometheus temporarily.

In either case, reloading would fail. This situation would not be fixed until
another change was detected.

Here we fix this by retrying until success.

Fixes #436