### PR TITLE
add serviceMonitor to alertmanager, prometheus-operator and prometheus

### DIFF
--- a/helm/alertmanager/templates/servicemonitor.yaml
+++ b/helm/alertmanager/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.selfServiceMonitor }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: prometheus
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: alertmanager
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+    prometheus: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+spec:
+  jobLabel: {{ template "name" . }}
+  selector:
+    matchLabels:
+      alertmanager: {{ .Release.Name }}
+      app: {{ template "name" . }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: http
+    interval: 30s
+{{- end }}

--- a/helm/alertmanager/templates/servicemonitor.yaml
+++ b/helm/alertmanager/templates/servicemonitor.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.selfServiceMonitor }}
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
+    app: {{ template "name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: alertmanager
     heritage: "{{ .Release.Service }}"
@@ -16,6 +16,7 @@ spec:
     matchLabels:
       alertmanager: {{ .Release.Name }}
       app: {{ template "name" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -21,6 +21,10 @@ config:
 ##
 externalUrl: ""
 
+## If true, create a serviceMonitor for alertmanager
+##
+selfServiceMonitor: true
+
 ## Alertmanager container image
 ##
 image:

--- a/helm/prometheus-operator/templates/create-servicemonitor-job.yaml
+++ b/helm/prometheus-operator/templates/create-servicemonitor-job.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-create-sm-job
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+      name: {{ template "fullname" . }}-create-sm-job
+    spec:
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          imagePullPolicy: "{{ .Values.global.hyperkube.pullPolicy }}"
+          command:
+            - ./kubectl
+            - apply 
+            - -f 
+            - /tmp/servicemonitor/servicemonitor-operator.yaml
+          volumeMounts:
+            - mountPath: "/tmp/servicemonitor"
+              name: tmp-configmap-servicemonitor
+      volumes:
+        - name: tmp-configmap-servicemonitor
+          configMap:
+            name: {{ template "fullname" . }}
+      restartPolicy: OnFailure
+      {{- if .Values.rbacEnable }}
+      serviceAccountName: {{ template "fullname" . }}
+      {{- end }}

--- a/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
+++ b/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+data:
+  servicemonitor-operator.yaml: |-
+      apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        labels:
+          app: {{ template "name" . }}
+          chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          heritage: "{{ .Release.Service }}"
+          release: "{{ .Release.Name }}"
+          prometheus: {{ .Release.Name }}
+        name: {{ .Values.jobLabel }}
+      spec:
+        jobLabel: {{ template "name" . }}
+        selector:
+          matchLabels:
+        selector:
+          matchLabels:
+            operated-prometheus: "true"
+        namespaceSelector:
+          matchNames:
+            - {{ .Release.Namespace | quote }}
+        endpoints:
+        - port: web
+          interval: 30s

--- a/helm/prometheus-operator/values.yaml
+++ b/helm/prometheus-operator/values.yaml
@@ -50,3 +50,5 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 50Mi
+
+jobLabel: prometheus-operator

--- a/helm/prometheus/templates/servicemonitor-prometheus.yaml
+++ b/helm/prometheus/templates/servicemonitor-prometheus.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.selfServiceMonitor }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: prometheus
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: prometheus
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+    prometheus: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+spec:
+  jobLabel: {{ template "name" . }}
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+      prometheus: prometheus
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: http
+    interval: 30s
+{{- end }}

--- a/helm/prometheus/templates/servicemonitor-prometheus.yaml
+++ b/helm/prometheus/templates/servicemonitor-prometheus.yaml
@@ -1,11 +1,10 @@
 {{- if .Values.selfServiceMonitor }}
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
+    app: {{ template "name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    component: prometheus
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
@@ -15,7 +14,8 @@ spec:
   selector:
     matchLabels:
       app: {{ template "name" . }}
-      prometheus: prometheus
+      prometheus: {{ .Release.Name }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -23,6 +23,10 @@ externalLabels: {}
 ##
 externalUrl: ""
 
+## If true, create a serviceMonitor for prometheus
+##
+selfServiceMonitor: true
+
 ## Prometheus container image
 ##
 image:


### PR DESCRIPTION
@mgoodness I didn't add the `serviceMonitor`for prometheus-operator because there's a circular dependency.
What do you think it's the right way to do:

1 - Run a job to apply the serviceMonitor after the creation of `tpr` or
2- Add a new chart on kube-prometheus to create the serviceMonitor for prometheus-operator

