### PR TITLE
helm/prometheus: add externalLabels spec to be configured

### DIFF
--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.2
+version: 0.0.3

--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -44,6 +44,7 @@ Parameter | Description | Default
 --- | --- | ---
 `alertingEndpoints` | Alertmanagers to which alerts will be sent | `[]`
 `config` | Prometheus configuration directives | `{}`
+`externalLabels` | The labels to add to any time series or alerts when communicating with external systems  | `{}`
 `externalUrl` | External URL at which Prometheus will be reachable | `""`
 `image.repository` | Image | `quay.io/prometheus/prometheus`
 `image.tag` | Image tag | `v1.5.2`

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -21,6 +21,10 @@ spec:
         port: http
 {{- end }}
   baseImage: "{{ .Values.image.repository }}"
+{{- if .Values.externalLabels }}
+  externalLabels:
+{{ toYaml .Values.externalLabels | indent 4}}
+{{- end }}
 {{- if .Values.externalUrl }}
   externalUrl: "{{ .Values.externalUrl }}"
 {{- else if .Values.ingress.fqdn }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -15,6 +15,10 @@ config:
   specifiedInValues: true
   value: {}
 
+## External labels to add to any time series or alerts when communicating with external systems
+##
+externalLabels: {}
+
 ## External URL at which Prometheus will be reachable
 ##
 externalUrl: ""


### PR DESCRIPTION
Adds the externalLabel spec option from #365 to the Prometheus helm chart.