### PR TITLE
Fixing storage for persisted prometheus

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -123,6 +123,8 @@ func makeStatefulSet(p v1alpha1.Prometheus, old *v1beta1.StatefulSet, config *Co
 		pvcTemplate := storageSpec.VolumeClaimTemplate
 		pvcTemplate.Name = volumeName(p.Name)
 		pvcTemplate.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+		pvcTemplate.Spec.Resources = storageSpec.VolumeClaimTemplate.Spec.Resources
+		pvcTemplate.Spec.Selector = storageSpec.VolumeClaimTemplate.Spec.Selector
 		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, pvcTemplate)
 	}
 


### PR DESCRIPTION
While setting the pvc template in the statefulset `Spec.Resources` and `Spec.Selector` where not being properly propagated.

This commit fixes this issue.

````
✔ ~/workspace/go-workspace/src/github.com/coreos/prometheus-operator [master|●1]
13:08 $ kubectl create -f ~/workspace/kubernetes-pvtest/prom.yaml
prometheus "persisted" created
✔ ~/workspace/go-workspace/src/github.com/coreos/prometheus-operator [master|●1]
13:09 $ kubectl get pvc
NAME                                             STATUS    VOLUME                                     CAPACITY   ACCESSMODES   AGE
prometheus-persisted-db-prometheus-persisted-0   Bound     pvc-7d61f054-5b74-11e7-bd6d-0e70723885a2   1Gi        RWO           45s
✔ ~/workspace/go-workspace/src/github.com/coreos/prometheus-operator [master|●1]
13:09 $ kubectl get pvc prometheus-persisted-db-prometheus-persisted-0 -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/aws-ebs-additional-resource-tags: Test1=foo, Test2=bar
    volume.beta.kubernetes.io/storage-class: gp2
    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/aws-ebs
  creationTimestamp: 2017-06-27T20:09:13Z
  labels:
    app: prometheus
    prometheus: persisted
  name: prometheus-persisted-db-prometheus-persisted-0
  namespace: default
  resourceVersion: "6409393"
  selfLink: /api/v1/namespaces/default/persistentvolumeclaims/prometheus-persisted-db-prometheus-persisted-0
  uid: 7d61f054-5b74-11e7-bd6d-0e70723885a2
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  volumeName: pvc-7d61f054-5b74-11e7-bd6d-0e70723885a2
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound
✔ ~/workspace/go-workspace/src/github.com/coreos/prometheus-operator [master|●1]
13:10 $ kubectl get statefulsets -o yaml
apiVersion: v1
items:
- apiVersion: apps/v1beta1
  kind: StatefulSet
  metadata:
    creationTimestamp: 2017-06-27T20:09:13Z
    generation: 1
    labels:
      app: prometheus
      prometheus: persisted
    name: prometheus-persisted
    namespace: default
    resourceVersion: "6409387"
    selfLink: /apis/apps/v1beta1/namespaces/default/statefulsets/prometheus-persisted
    uid: 7d603e44-5b74-11e7-bd6d-0e70723885a2
  spec:
    replicas: 1
    selector:
      matchLabels:
        app: prometheus
        prometheus: persisted
    serviceName: prometheus-operated
    template:
      metadata:
        creationTimestamp: null
        labels:
          app: prometheus
          prometheus: persisted
      spec:
        containers:
        - args:
          - -storage.local.retention=24h
          - -storage.local.num-fingerprint-mutexes=4096
          - -storage.local.path=/var/prometheus/data
          - -storage.local.chunk-encoding-version=2
          - -config.file=/etc/prometheus/config/prometheus.yaml
          - -storage.local.target-heap-size=1431655764
          - -web.route-prefix=/
          image: quay.io/prometheus/prometheus:v1.7.0
          imagePullPolicy: IfNotPresent
          livenessProbe:
            failureThreshold: 10
            httpGet:
              path: /status
              port: web
              scheme: HTTP
            initialDelaySeconds: 300
            periodSeconds: 5
            successThreshold: 1
            timeoutSeconds: 3
          name: prometheus
          ports:
          - containerPort: 9090
            name: web
            protocol: TCP
          readinessProbe:
            failureThreshold: 6
            httpGet:
              path: /status
              port: web
              scheme: HTTP
            periodSeconds: 5
            successThreshold: 1
            timeoutSeconds: 3
          resources:
            requests:
              memory: 2Gi
          terminationMessagePath: /dev/termination-log
          volumeMounts:
          - mountPath: /etc/prometheus/config
            name: config
            readOnly: true
          - mountPath: /etc/prometheus/rules
            name: rules
            readOnly: true
          - mountPath: /var/prometheus/data
            name: prometheus-persisted-db
            subPath: prometheus-db
        - args:
          - -reload-url=http://localhost:9090/-/reload
          - -config-volume-dir=/etc/prometheus/config
          - -rule-volume-dir=/etc/prometheus/rules
          image: quay.io/coreos/prometheus-config-reloader:v0.0.1
          imagePullPolicy: IfNotPresent
          name: prometheus-config-reloader
          resources:
            limits:
              cpu: 5m
              memory: 10Mi
          terminationMessagePath: /dev/termination-log
          volumeMounts:
          - mountPath: /etc/prometheus/config
            name: config
            readOnly: true
          - mountPath: /etc/prometheus/rules
            name: rules
        dnsPolicy: ClusterFirst
        restartPolicy: Always
        securityContext: {}
        terminationGracePeriodSeconds: 600
        volumes:
        - name: config
          secret:
            defaultMode: 420
            secretName: prometheus-persisted
        - emptyDir: {}
          name: rules
    volumeClaimTemplates:
    - metadata:
        annotations:
          volume.beta.kubernetes.io/aws-ebs-additional-resource-tags: Test1=foo, Test2=bar
          volume.beta.kubernetes.io/storage-class: gp2
        creationTimestamp: null
        name: prometheus-persisted-db
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 1Gi
      status:
        phase: Pending
  status:
    replicas: 1
kind: List
metadata: {}
resourceVersion: ""
selfLink: ""
````