### PR TITLE
grafana watcher example: Remove imagePullPolicy

### DIFF
--- a/contrib/grafana-watcher/examples/grafana-bundle.yaml
+++ b/contrib/grafana-watcher/examples/grafana-bundle.yaml
@@ -76,7 +76,6 @@ spec:
             cpu: 200m
       - name: grafana-watcher
         image: quay.io/coreos/grafana-watcher:v0.0.4
-        imagePullPolicy: Never
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://localhost:3000'


### PR DESCRIPTION
Maybe I miss a reason for that being there but probably just cruft?