### PR TITLE
Remove scrape: true annotation

### DIFF
--- a/contrib/grafana-watcher/examples/grafana-bundle.yaml
+++ b/contrib/grafana-watcher/examples/grafana-bundle.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/scrape: 'true'
   labels:
     app: grafana
     name: grafana


### PR DESCRIPTION
This is probably cruft, grafana has no /metrics endpoint.