### PR TITLE
kube-prometheus: Update RBAC for kube-state-metrics

### DIFF
--- a/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-cluster-role.yaml
@@ -7,7 +7,10 @@ rules:
   resources:
   - nodes
   - pods
+  - services
   - resourcequotas
+  - replicationcontrollers
+  - limitranges
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:


### PR DESCRIPTION
After installing kube-prometheus from hack/cluster-monitoring/self-hosted-deploy I noticed that the API server logs were getting flooded with RBAC DENY messages for kube-state-metrics:

```
I0629 16:36:49.945856       5 rbac.go:87] RBAC DENY: user "system:serviceaccount:monitoring:kube-state-metrics" groups [system:serviceaccounts system:serviceaccounts:monitoring system:authenticated] cannot "list" resource "replicationcontrollers" cluster-wide
```

Looks like kube-state-metrics needs additional permissions for replicationcontrollers, limitranges, and services. Once I added those permissions the messages went away and kube-state-metrics seems to be happy.