### PR TITLE
Check createDatasourceFromFile error

### DIFF
--- a/contrib/grafana-watcher/Makefile
+++ b/contrib/grafana-watcher/Makefile
@@ -3,7 +3,7 @@ all: build
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 REGISTRY = quay.io/coreos
-TAG = v0.0.4
+TAG = v0.0.5
 NAME = grafana-watcher
 
 build:

--- a/contrib/grafana-watcher/examples/grafana-bundle.yaml
+++ b/contrib/grafana-watcher/examples/grafana-bundle.yaml
@@ -73,7 +73,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.4
+        image: quay.io/coreos/grafana-watcher:v0.0.5
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://localhost:3000'
@@ -107,4 +107,3 @@ spec:
       - name: grafana-dashboards
         configMap:
           name: grafana-dashboards
-

--- a/contrib/grafana-watcher/updater/datasource.go
+++ b/contrib/grafana-watcher/updater/datasource.go
@@ -82,7 +82,7 @@ func (u *GrafanaDatasourceUpdater) createDatasourcesFromFiles() error {
 	}
 
 	for _, fp := range filePaths {
-		u.createDatasourceFromFile(fp)
+		err = u.createDatasourceFromFile(fp)
 		if err != nil {
 			return err
 		}

--- a/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.4
+        image: quay.io/coreos/grafana-watcher:v0.0.5
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://localhost:3000'


### PR DESCRIPTION
Previously the error result of createDatasourceFromFile in the loop in createDatasourcesFromFile was dropped.  This meant any errors from datasource creation would be ignored.  This change makes the loop check and propagate any errors.