### PR TITLE
grafana chart for kube-prometheus

### DIFF
--- a/contrib/grafana-watcher/Makefile
+++ b/contrib/grafana-watcher/Makefile
@@ -3,7 +3,7 @@ all: build
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 REGISTRY = quay.io/coreos
-TAG = v0.0.5
+TAG = v0.0.6
 NAME = grafana-watcher
 
 build:

--- a/contrib/grafana-watcher/examples/grafana-bundle.yaml
+++ b/contrib/grafana-watcher/examples/grafana-bundle.yaml
@@ -73,7 +73,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.5
+        image: quay.io/coreos/grafana-watcher:v0.0.6
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://localhost:3000'

--- a/contrib/grafana-watcher/grafana/dashboard.go
+++ b/contrib/grafana-watcher/grafana/dashboard.go
@@ -76,20 +76,16 @@ func (c *DashboardsClient) Delete(slug string) error {
 		return err
 	}
 
-	_, err = c.HTTPClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return doRequest(c.HTTPClient, req)
 }
 
 func (c *DashboardsClient) Create(dashboardJson io.Reader) error {
 	importDashboardUrl := makeUrl(c.BaseUrl, "/api/dashboards/import")
-	_, err := c.HTTPClient.Post(importDashboardUrl, "application/json", dashboardJson)
+	req, err := http.NewRequest("POST", importDashboardUrl, dashboardJson)
 	if err != nil {
 		return err
 	}
+	req.Header.Add("Content-Type", "application/json")
 
-	return nil
+	return doRequest(c.HTTPClient, req)
 }

--- a/contrib/grafana-watcher/grafana/datasource.go
+++ b/contrib/grafana-watcher/grafana/datasource.go
@@ -78,22 +78,18 @@ func (c *DatasourcesClient) Delete(id int) error {
 		return err
 	}
 
-	_, err = c.HTTPClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return doRequest(c.HTTPClient, req)
 }
 
 func (c *DatasourcesClient) Create(datasourceJson io.Reader) error {
 	createUrl := makeUrl(c.BaseUrl, "/api/datasources")
-	_, err := c.HTTPClient.Post(createUrl, "application/json", datasourceJson)
+	req, err := http.NewRequest("POST", createUrl, datasourceJson)
 	if err != nil {
 		return err
 	}
+	req.Header.Add("Content-Type", "application/json")
 
-	return nil
+	return doRequest(c.HTTPClient, req)
 }
 
 func makeUrl(baseUrl *url.URL, endpoint string) string {

--- a/contrib/grafana-watcher/grafana/grafana.go
+++ b/contrib/grafana-watcher/grafana/grafana.go
@@ -15,6 +15,7 @@
 package grafana
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 )
@@ -42,4 +43,16 @@ func (c *Clientset) Dashboards() DashboardsInterface {
 
 func (c *Clientset) Datasources() DatasourcesInterface {
 	return NewDatasourcesClient(c.BaseUrl, c.HTTPClient)
+}
+
+func doRequest(c *http.Client, req *http.Request) error {
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("doRequest failed, Code:%d, Status:%s", resp.StatusCode, resp.Status)
+	}
+	return nil
 }

--- a/contrib/grafana-watcher/grafana/grafana.go
+++ b/contrib/grafana-watcher/grafana/grafana.go
@@ -52,7 +52,7 @@ func doRequest(c *http.Client, req *http.Request) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("doRequest failed, Code:%d, Status:%s", resp.StatusCode, resp.Status)
+		return fmt.Errorf("Unexpected status code returned from Grafana API (got: %d, expected: 200, msg:%s)", resp.StatusCode, resp.Status)
 	}
 	return nil
 }

--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -1,0 +1,9 @@
+description: Grafana instance for kube-prometheus
+engine: gotpl
+maintainers:
+- email: weiwei.inf@gmail.com
+  name: Wei Wei
+name: grafana
+sources:
+- https://github.com/coreos/prometheus-operator
+version: 0.0.1

--- a/helm/grafana/README.md
+++ b/helm/grafana/README.md
@@ -1,0 +1,66 @@
+# Grafana Helm Chart
+
+* Installs the web dashboarding system [Grafana](http://grafana.org/)
+
+## TL;DR;
+
+```console
+$ helm install opsgoodness/grafana
+```
+## Introduction
+
+This chart bootstraps an [Grafana](http://grafana.org) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager, and preinstalled some defaut dashboard for dashboarding Kubernetes metrics.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release opsgoodness/grafana
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the my-release deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+
+## Configuration
+
+Parameter | Description | Default
+--- | --- | ---
+`adminUser` | Grafana admin user name | `admin`
+`adminPassword` | Grafana admin user password | `admin`
+`image.repository` | Image | `grafana/grafana`
+`image.tag` | Image tag | `4.4.1`
+`ingress.enabled` | If true, Grafana Ingress will be created | `false`
+`ingress.annotations` | Annotations for Grafana Ingress | `{}`
+`ingress.fqdn` | Grafana Ingress fully-qualified domain name | `""`
+`ingress.tls` | TLS configuration for Grafana Ingress | `[]`
+`nodeSelector` | Node labels for pod assignment | `{}`
+`resources` | Pod resource requests & limits | `{}`
+`service.annotations` | Annotations to be added to the Grafana Service | `{}`
+`service.clusterIP` | Cluster-internal IP address for Grafana Service | `""`
+`service.externalIPs` | List of external IP addresses at which the Grafana Service will be available | `[]`
+`service.loadBalancerIP` | External IP address to assign to Grafana Service | `""`
+`service.loadBalancerSourceRanges` | List of client IPs allowed to access Grafana Service | `[]`
+`service.nodePort` | Port to expose Grafana Service on each node | `39093`
+`service.type` | Grafana Service type | `ClusterIP`
+`storageSpec` | Grafana StorageSpec for persistent data | `{}`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+$ helm install opsgoodness/grafana --name my-release --set adminUser=bob
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install opsgoodness/grafana --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/helm/grafana/templates/NOTES.txt
+++ b/helm/grafana/templates/NOTES.txt
@@ -1,0 +1,36 @@
+1. Get your '{{ .Values.adminUser }}' user password by running:
+
+   kubectl get secret --namespace {{ .Release.Namespace }} {{ template "grafana.server.fullname" . }} -o jsonpath="{.data.grafana-admin-password}" | base64 --decode ; echo
+
+2. The Grafana server can be accessed via port 80 on the following DNS name from within your cluster:
+
+   {{ template "grafana.server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{ if .Values.ingress.enabled }}
+   From outside the cluster, the server URL(s) are:
+     http://{{ .Values.ingress.fqdn }}
+{{ else }}
+   Get the Grafana URL to visit by running these commands in the same shell:
+{{ if contains "NodePort" .Values.service.type -}}
+     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grafana.server.fullname" . }})
+     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+     echo http://$NODE_IP:$NODE_PORT
+{{ else if contains "LoadBalancer" .Values.service.type -}}
+   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "grafana.server.fullname" . }}'
+     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "grafana.server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+     echo http://$SERVICE_IP:80
+{{ else if contains "ClusterIP"  .Values.service.type }}
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "grafana.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000
+{{- end }}
+{{- end }}
+
+3. Login with the password from step 1 and the username: {{ .Values.adminUser }}
+
+{{- if .Values.storageSpec }}
+{{- else }}
+#################################################################################
+######   WARNING: Persistence is disabled!!! You will lose your data when   #####
+######            the Grafana pod is terminated.                            #####
+#################################################################################
+{{- end }}

--- a/helm/grafana/templates/_helpers.tpl
+++ b/helm/grafana/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "grafana.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "grafana.fullname" -}}
+{{- $name := default "grafana" .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified server name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "grafana.server.fullname" -}}
+{{- printf "%s-%s" .Release.Name "grafana" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/grafana/templates/dashboards-configmap.yaml
+++ b/helm/grafana/templates/dashboards-configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "grafana.server.fullname" . }}
+data:
+{{ toYaml .Values.serverDashboardFiles | indent 2 }}
+  {{- if .Values.dataSource }}
+{{ toYaml .Values.dataSource | indent 2 }}
+  {{- else }}
+  prometheus-datasource.json: |+
+    {
+      "access": "proxy",
+      "basicAuth": false,
+      "name": "prometheus",
+      "type": "prometheus",
+      "url": "http://{{ printf "%s-%s" .Release.Name "prometheus" }}:9090"
+    }
+  {{- end }}

--- a/helm/grafana/templates/grafana-deployment.yaml
+++ b/helm/grafana/templates/grafana-deployment.yaml
@@ -1,17 +1,27 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: grafana
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "grafana.server.fullname" . }}
 spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+      {{- range $key, $value := .Values.annotations }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
       labels:
-        app: grafana
+        app: {{ template "grafana.fullname" . }}
+        release: "{{ .Release.Name }}"
     spec:
       containers:
       - name: grafana
-        image: grafana/grafana:4.4.1
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         env:
         - name: GF_AUTH_BASIC_ENABLED
           value: "true"
@@ -20,12 +30,12 @@ spec:
         - name: GF_SECURITY_ADMIN_USER
           valueFrom:
             secretKeyRef:
-              name: grafana-credentials
+              name: {{ template "grafana.server.fullname" . }}
               key: user
         - name: GF_SECURITY_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: grafana-credentials
+              name: {{ template "grafana.server.fullname" . }}
               key: password
         volumeMounts:
         - name: grafana-storage
@@ -49,16 +59,13 @@ spec:
         - name: GRAFANA_USER
           valueFrom:
             secretKeyRef:
-              name: grafana-credentials
+              name: {{ template "grafana.server.fullname" . }}
               key: user
         - name: GRAFANA_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: grafana-credentials
+              name: {{ template "grafana.server.fullname" . }}
               key: password
-        volumeMounts:
-        - name: grafana-dashboards
-          mountPath: /var/grafana-dashboards
         resources:
           requests:
             memory: "16Mi"
@@ -67,11 +74,16 @@ spec:
             memory: "32Mi"
             cpu: "100m"
         volumeMounts:
-        - name: grafana-dashboards
-          mountPath: /var/grafana-dashboards
+          - name: grafana-dashboards
+            mountPath: /var/grafana-dashboards
       volumes:
-      - name: grafana-storage
-        emptyDir: {}
-      - name: grafana-dashboards
-        configMap:
-          name: grafana-dashboards
+        - name: grafana-storage
+          {{- if .Values.storageSpec }}
+          persistentVolumeClaim:
+            claimName: {{ template "grafana.server.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: grafana-dashboards
+          configMap:
+            name: {{ template "grafana.server.fullname" . }}

--- a/helm/grafana/templates/ingress.yaml
+++ b/helm/grafana/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled -}}
+{{- $releaseName := .Release.Name -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "grafana.server.fullname" . }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.fqdn }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
+              servicePort: 80
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/helm/grafana/templates/pvc.yaml
+++ b/helm/grafana/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.storageSpec -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "grafana.server.fullname" . }}
+spec:
+  accessModes:
+    - {{ .Values.storageSpec.accessMode }}
+  storageClassName: {{ .Values.storageSpec.class }}
+  resources:
+    requests:
+      storage: {{ .Values.storageSpec.resources.requests.storage | quote }}
+{{- end -}}

--- a/helm/grafana/templates/secret.yaml
+++ b/helm/grafana/templates/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "grafana.server.fullname" . }}
+type: Opaque
+data:
+  {{- if .Values.adminPassword }}
+  password: {{ .Values.adminPassword | b64enc | quote }}
+  {{- else }}
+  password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{- end }}
+  user: {{ .Values.adminUser | b64enc | quote }}

--- a/helm/grafana/templates/svc.yaml
+++ b/helm/grafana/templates/svc.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "grafana.server.fullname" . }}
+spec:
+  ports:
+    - name: "http"
+      port: 80
+      protocol: TCP
+      targetPort: 3000
+{{- if contains "NodePort" .Values.service.type }}
+  {{- if .Values.service.nodePort }}
+      nodePort:  {{ .Values.service.nodePort }}
+  {{- end }}
+{{- end }}
+  selector:
+    app: {{ template "grafana.fullname" . }}
+  type: "{{ .Values.service.type }}"
+{{- if contains "LoadBalancer" .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end -}}
+  {{- if .Values.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+  {{- range .Values.service.loadBalancerSourceRanges }}
+  - {{ . }}
+  {{- end }}
+  {{- end -}}
+{{- end -}}

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -1,0 +1,3499 @@
+nodeSelector: {}
+
+annotations: {}
+
+adminUser: "admin"
+adminPassword: "admin"
+
+service:
+
+  ## Annotations to be added to the Service
+  ##
+  annotations: {}
+
+  ## Cluster-internal IP address for Alertmanager Service
+  ##
+  clusterIP: ""
+
+  ## List of external IP addresses at which the Alertmanager Service will be available
+  ##
+  externalIPs: []
+
+  ## External IP address to assign to Alertmanager Service
+  ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+  ##
+  loadBalancerIP: ""
+
+  ## List of client IPs allowed to access Alertmanager Service
+  ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+  ##
+  loadBalancerSourceRanges: []
+
+  ## Port to expose on each node
+  ## Only used if service.type is 'NodePort'
+  ##
+  nodePort: 39093
+
+  ## Service type
+  ##
+  type: ClusterIP
+
+## Grafana Docker image
+##
+image:
+  repository: grafana/grafana
+  tag: 4.4.1
+
+storageSpec: {}
+#   class: default
+#   accessMode:
+#   resources:
+#     requests:
+#       storage: 2Gi
+#   selector: {}
+
+resources: {}
+  # requests:
+  #   memory: 400Mi
+
+ingress:
+  ## If true, Grafana Ingress will be created
+  ##
+  enabled: false
+
+  ## Annotations for Alertmanager Ingress
+  ##
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+
+  fqdn: ""
+
+  ## TLS configuration for Alertmanager Ingress
+  ## Secret must be manually created in the namespace
+  ##
+  tls: []
+    # - secretName: alertmanager-general-tls
+    #   hosts:
+    #     - alertmanager.example.com
+
+
+
+# Set datasource in beginning
+dataSource: {}
+
+serverDashboardFiles:
+  all-nodes-dashboard.json: |+
+    {
+      "dashboard":
+    {
+        "__inputs": [
+            {
+                "description": "",
+                "label": "prometheus",
+                "name": "DS_PROMETHEUS",
+                "pluginId": "prometheus",
+                "pluginName": "Prometheus",
+                "type": "datasource"
+            }
+        ],
+        "__requires": [
+            {
+                "id": "grafana",
+                "name": "Grafana",
+                "type": "grafana",
+                "version": "4.1.1"
+            },
+            {
+                "id": "graph",
+                "name": "Graph",
+                "type": "panel",
+                "version": ""
+            },
+            {
+                "id": "prometheus",
+                "name": "Prometheus",
+                "type": "datasource",
+                "version": "1.0.0"
+            },
+            {
+                "id": "singlestat",
+                "name": "Singlestat",
+                "type": "panel",
+                "version": ""
+            }
+        ],
+        "annotations": {
+            "list": []
+        },
+        "description": "Dashboard to get an overview of one server",
+        "editable": true,
+        "gnetId": 22,
+        "graphTooltip": 0,
+        "hideControls": false,
+        "id": null,
+        "links": [],
+        "refresh": false,
+        "rows": [
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 3,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(node_cpu{mode=\"idle\"}[2m])) * 100",
+                                "hide": false,
+                                "intervalFactor": 10,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 50
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Idle cpu",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "percent",
+                                "label": "cpu usage",
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 9,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(node_load1)",
+                                "intervalFactor": 4,
+                                "legendFormat": "load 1m",
+                                "refId": "A",
+                                "step": 20,
+                                "target": ""
+                            },
+                            {
+                                "expr": "sum(node_load5)",
+                                "intervalFactor": 4,
+                                "legendFormat": "load 5m",
+                                "refId": "B",
+                                "step": 20,
+                                "target": ""
+                            },
+                            {
+                                "expr": "sum(node_load15)",
+                                "intervalFactor": 4,
+                                "legendFormat": "load 15m",
+                                "refId": "C",
+                                "step": 20,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "System load",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "percentunit",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 4,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "node_memory_SwapFree{instance=\"172.17.0.1:9100\",job=\"prometheus\"}",
+                                "yaxis": 2
+                            }
+                        ],
+                        "span": 9,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(node_memory_MemTotal) - sum(node_memory_MemFree) - sum(node_memory_Buffers) - sum(node_memory_Cached)",
+                                "intervalFactor": 2,
+                                "legendFormat": "memory usage",
+                                "metric": "memo",
+                                "refId": "A",
+                                "step": 4,
+                                "target": ""
+                            },
+                            {
+                                "expr": "sum(node_memory_Buffers)",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "memory buffers",
+                                "metric": "memo",
+                                "refId": "B",
+                                "step": 4,
+                                "target": ""
+                            },
+                            {
+                                "expr": "sum(node_memory_Cached)",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "memory cached",
+                                "metric": "memo",
+                                "refId": "C",
+                                "step": 4,
+                                "target": ""
+                            },
+                            {
+                                "expr": "sum(node_memory_MemFree)",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "memory free",
+                                "metric": "memo",
+                                "refId": "D",
+                                "step": 4,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory usage",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(50, 172, 45, 0.97)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(245, 54, 54, 0.9)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "percent",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": true,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 5,
+                        "interval": null,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "((sum(node_memory_MemTotal) - sum(node_memory_MemFree) - sum(node_memory_Buffers) - sum(node_memory_Cached)) / sum(node_memory_MemTotal)) * 100",
+                                "intervalFactor": 2,
+                                "metric": "",
+                                "refId": "A",
+                                "step": 60,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": "80, 90",
+                        "title": "Memory usage",
+                        "type": "singlestat",
+                        "valueFontSize": "80%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 6,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "read",
+                                "yaxis": 1
+                            },
+                            {
+                                "alias": "{instance=\"172.17.0.1:9100\"}",
+                                "yaxis": 2
+                            },
+                            {
+                                "alias": "io time",
+                                "yaxis": 2
+                            }
+                        ],
+                        "span": 9,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(node_disk_bytes_read[5m]))",
+                                "hide": false,
+                                "intervalFactor": 4,
+                                "legendFormat": "read",
+                                "refId": "A",
+                                "step": 8,
+                                "target": ""
+                            },
+                            {
+                                "expr": "sum(rate(node_disk_bytes_written[5m]))",
+                                "intervalFactor": 4,
+                                "legendFormat": "written",
+                                "refId": "B",
+                                "step": 8
+                            },
+                            {
+                                "expr": "sum(rate(node_disk_io_time_ms[5m]))",
+                                "intervalFactor": 4,
+                                "legendFormat": "io time",
+                                "refId": "C",
+                                "step": 8
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk I/O",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "ms",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(50, 172, 45, 0.97)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(245, 54, 54, 0.9)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "percentunit",
+                        "gauge": {
+                            "maxValue": 1,
+                            "minValue": 0,
+                            "show": true,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 7,
+                        "interval": null,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "(sum(node_filesystem_size{device!=\"rootfs\"}) - sum(node_filesystem_free{device!=\"rootfs\"})) / sum(node_filesystem_size{device!=\"rootfs\"})",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 60,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": "0.75, 0.9",
+                        "title": "Disk space usage",
+                        "type": "singlestat",
+                        "valueFontSize": "80%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "current"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 8,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "transmitted ",
+                                "yaxis": 2
+                            }
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(node_network_receive_bytes{device!~\"lo\"}[5m]))",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Network received",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 10,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "transmitted ",
+                                "yaxis": 2
+                            }
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(node_network_transmit_bytes{device!~\"lo\"}[5m]))",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "",
+                                "refId": "B",
+                                "step": 10,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Network transmitted",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [
+            "prometheus"
+        ],
+        "templating": {
+            "list": []
+        },
+        "time": {
+            "from": "now-1h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "browser",
+        "title": "All Nodes",
+        "version": 1
+    }
+    ,
+      "inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "pluginId": "prometheus",
+          "type": "datasource",
+          "value": "prometheus"
+        }
+      ],
+      "overwrite": true
+    }
+  deployment-dashboard.json: |+
+    {
+      "dashboard":
+    {
+        "__inputs": [
+            {
+                "description": "",
+                "label": "prometheus",
+                "name": "DS_PROMETHEUS",
+                "pluginId": "prometheus",
+                "pluginName": "Prometheus",
+                "type": "datasource"
+            }
+        ],
+        "__requires": [
+            {
+                "id": "singlestat",
+                "name": "Singlestat",
+                "type": "panel",
+                "version": ""
+            },
+            {
+                "id": "graph",
+                "name": "Graph",
+                "type": "panel",
+                "version": ""
+            },
+            {
+                "id": "grafana",
+                "name": "Grafana",
+                "type": "grafana",
+                "version": "3.1.1"
+            },
+            {
+                "id": "prometheus",
+                "name": "Prometheus",
+                "type": "datasource",
+                "version": "1.0.0"
+            }
+        ],
+        "annotations": {
+            "list": []
+        },
+        "editable": true,
+        "gnetId": null,
+        "hideControls": false,
+        "id": null,
+        "links": [],
+        "rows": [
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "200px",
+                "panels": [
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(50, 172, 45, 0.97)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "none",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": false,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 8,
+                        "interval": null,
+                        "isNew": true,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "cores",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 4,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": true
+                        },
+                        "targets": [
+                            {
+                                "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m])) ",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 600
+                            }
+                        ],
+                        "thresholds": "",
+                        "title": "CPU",
+                        "type": "singlestat",
+                        "valueFontSize": "110%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(50, 172, 45, 0.97)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "none",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": false,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 9,
+                        "interval": null,
+                        "isNew": true,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "GB",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "80%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 4,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": true
+                        },
+                        "targets": [
+                            {
+                                "expr": "sum(container_memory_usage_bytes{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}) / 1024^3",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 600
+                            }
+                        ],
+                        "thresholds": "",
+                        "title": "Memory",
+                        "type": "singlestat",
+                        "valueFontSize": "110%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(50, 172, 45, 0.97)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "Bps",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": false,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": false
+                        },
+                        "id": 7,
+                        "interval": null,
+                        "isNew": true,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 4,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": true
+                        },
+                        "targets": [
+                            {
+                                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m])) ",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 600
+                            }
+                        ],
+                        "thresholds": "",
+                        "title": "Network",
+                        "type": "singlestat",
+                        "valueFontSize": "80%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    }
+                ],
+                "showTitle": false,
+                "title": "Row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "100px",
+                "panels": [
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(50, 172, 45, 0.97)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "decimals": null,
+                        "editable": true,
+                        "error": false,
+                        "format": "none",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": false,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": false
+                        },
+                        "id": 5,
+                        "interval": null,
+                        "isNew": true,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                                "intervalFactor": 2,
+                                "metric": "kube_deployment_spec_replicas",
+                                "refId": "A",
+                                "step": 600
+                            }
+                        ],
+                        "thresholds": "",
+                        "title": "Desired Replicas",
+                        "type": "singlestat",
+                        "valueFontSize": "80%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(50, 172, 45, 0.97)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "none",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": false,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 6,
+                        "interval": null,
+                        "isNew": true,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 600
+                            }
+                        ],
+                        "thresholds": "",
+                        "title": "Available Replicas",
+                        "type": "singlestat",
+                        "valueFontSize": "80%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(50, 172, 45, 0.97)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "none",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": false,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 3,
+                        "interval": null,
+                        "isNew": true,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "max(kube_deployment_status_observed_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                                "intervalFactor": 2,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 600
+                            }
+                        ],
+                        "thresholds": "",
+                        "title": "Observed Generation",
+                        "type": "singlestat",
+                        "valueFontSize": "80%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(50, 172, 45, 0.97)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "none",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": false,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 2,
+                        "interval": null,
+                        "isNew": true,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "max(kube_deployment_metadata_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                                "intervalFactor": 2,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 600
+                            }
+                        ],
+                        "thresholds": "",
+                        "title": "Metadata Generation",
+                        "type": "singlestat",
+                        "valueFontSize": "80%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "350px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 1,
+                        "isNew": true,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "hideZero": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "max(kube_deployment_status_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                                "intervalFactor": 2,
+                                "legendFormat": "current replicas",
+                                "refId": "A",
+                                "step": 30
+                            },
+                            {
+                                "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                                "intervalFactor": 2,
+                                "legendFormat": "available",
+                                "refId": "B",
+                                "step": 30
+                            },
+                            {
+                                "expr": "max(kube_deployment_status_replicas_unavailable{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                                "intervalFactor": 2,
+                                "legendFormat": "unavailable",
+                                "refId": "C",
+                                "step": 30
+                            },
+                            {
+                                "expr": "min(kube_deployment_status_replicas_updated{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                                "intervalFactor": 2,
+                                "legendFormat": "updated",
+                                "refId": "D",
+                                "step": 30
+                            },
+                            {
+                                "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                                "intervalFactor": 2,
+                                "legendFormat": "desired",
+                                "refId": "E",
+                                "step": 30
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Replicas",
+                        "tooltip": {
+                            "msResolution": true,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "transparent": false,
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "none",
+                                "label": "",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    }
+                ],
+                "showTitle": false,
+                "title": "New row"
+            }
+        ],
+        "schemaVersion": 12,
+        "sharedCrosshair": true,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+            "list": [
+                {
+                    "allValue": ".*",
+                    "current": {},
+                    "datasource": "${DS_PROMETHEUS}",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Namespace",
+                    "multi": false,
+                    "name": "deployment_namespace",
+                    "options": [],
+                    "query": "label_values(kube_deployment_metadata_generation, namespace)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": null,
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {},
+                    "datasource": "${DS_PROMETHEUS}",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Deployment",
+                    "multi": false,
+                    "name": "deployment_name",
+                    "options": [],
+                    "query": "label_values(kube_deployment_metadata_generation{namespace=\"$deployment_namespace\"}, deployment)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tagsQuery": "deployment",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
+        "time": {
+            "from": "now-6h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "browser",
+        "title": "Deployment",
+        "version": 2
+    }
+    ,
+      "inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "pluginId": "prometheus",
+          "type": "datasource",
+          "value": "prometheus"
+        }
+      ],
+      "overwrite": true
+    }
+  kubernetes-pods-dashboard.json: |+
+    {
+      "dashboard":
+    {
+        "__inputs": [
+            {
+                "description": "",
+                "label": "prometheus",
+                "name": "DS_PROMETHEUS",
+                "pluginId": "prometheus",
+                "pluginName": "Prometheus",
+                "type": "datasource"
+            }
+        ],
+        "__requires": [
+            {
+                "id": "graph",
+                "name": "Graph",
+                "type": "panel",
+                "version": ""
+            },
+            {
+                "id": "grafana",
+                "name": "Grafana",
+                "type": "grafana",
+                "version": "3.1.1"
+            },
+            {
+                "id": "prometheus",
+                "name": "Prometheus",
+                "type": "datasource",
+                "version": "1.0.0"
+            }
+        ],
+        "annotations": {
+            "list": []
+        },
+        "editable": true,
+        "gnetId": null,
+        "hideControls": false,
+        "id": null,
+        "links": [],
+        "rows": [
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 1,
+                        "isNew": true,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": false,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum by(container_name) (container_memory_usage_bytes{pod_name=\"$pod\", container_name=~\"$container\", container_name!=\"POD\"})",
+                                "interval": "10s",
+                                "intervalFactor": 1,
+                                "legendFormat": "Current: {{ container_name }}",
+                                "metric": "container_memory_usage_bytes",
+                                "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "expr": "kube_pod_container_resource_requests_memory_bytes{pod=\"$pod\", container=~\"$container\"}",
+                                "interval": "10s",
+                                "intervalFactor": 2,
+                                "legendFormat": "Requested: {{ container }}",
+                                "metric": "kube_pod_container_resource_requests_memory_bytes",
+                                "refId": "B",
+                                "step": 20
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory Usage",
+                        "tooltip": {
+                            "msResolution": true,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "Row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 2,
+                        "isNew": true,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": false,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum by (container_name)( rate(container_cpu_usage_seconds_total{image!=\"\",container_name!=\"POD\",pod_name=\"$pod\"}[1m] ) )",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{ container_name }}",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "CPU Usage",
+                        "tooltip": {
+                            "msResolution": true,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "collapse": false,
+                "editable": true,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {
+                            "threshold1": null,
+                            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+                            "threshold2": null,
+                            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+                        },
+                        "id": 3,
+                        "isNew": true,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": false,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sort_desc(sum by (pod_name) (rate (container_network_receive_bytes_total{pod_name=\"$pod\"}[1m]) ))",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{ pod_name }}",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Network I/O",
+                        "tooltip": {
+                            "msResolution": true,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "show": true
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "title": "New row"
+            }
+        ],
+        "schemaVersion": 12,
+        "sharedCrosshair": true,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+            "list": [
+                {
+                    "allValue": ".*",
+                    "current": {},
+                    "datasource": "${DS_PROMETHEUS}",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "Namespace",
+                    "multi": false,
+                    "name": "namespace",
+                    "options": [],
+                    "query": "label_values(kube_pod_info, namespace)",
+                    "refresh": 1,
+                    "regex": "",
+                    "type": "query"
+                },
+                {
+                    "current": {},
+                    "datasource": "${DS_PROMETHEUS}",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": "Pod",
+                    "multi": false,
+                    "name": "pod",
+                    "options": [],
+                    "query": "label_values(kube_pod_info{namespace=~\"$namespace\"}, pod)",
+                    "refresh": 1,
+                    "regex": "",
+                    "type": "query"
+                },
+                {
+                    "allValue": ".*",
+                    "current": {},
+                    "datasource": "${DS_PROMETHEUS}",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "Container",
+                    "multi": false,
+                    "name": "container",
+                    "options": [],
+                    "query": "label_values(kube_pod_container_info{namespace=\"$namespace\", pod=\"$pod\"}, container)",
+                    "refresh": 1,
+                    "regex": "",
+                    "type": "query"
+                }
+            ]
+        },
+        "time": {
+            "from": "now-6h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "browser",
+        "title": "Pods",
+        "version": 26
+    }
+    ,
+      "inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "pluginId": "prometheus",
+          "type": "datasource",
+          "value": "prometheus"
+        }
+      ],
+      "overwrite": true
+    }
+  node-dashboard.json: |+
+    {
+      "dashboard":
+    {
+        "__inputs": [
+            {
+                "description": "",
+                "label": "prometheus",
+                "name": "DS_PROMETHEUS",
+                "pluginId": "prometheus",
+                "pluginName": "Prometheus",
+                "type": "datasource"
+            }
+        ],
+        "__requires": [
+            {
+                "id": "grafana",
+                "name": "Grafana",
+                "type": "grafana",
+                "version": "4.1.1"
+            },
+            {
+                "id": "graph",
+                "name": "Graph",
+                "type": "panel",
+                "version": ""
+            },
+            {
+                "id": "prometheus",
+                "name": "Prometheus",
+                "type": "datasource",
+                "version": "1.0.0"
+            },
+            {
+                "id": "singlestat",
+                "name": "Singlestat",
+                "type": "panel",
+                "version": ""
+            }
+        ],
+        "annotations": {
+            "list": []
+        },
+        "description": "Dashboard to get an overview of one server",
+        "editable": true,
+        "gnetId": 22,
+        "graphTooltip": 0,
+        "hideControls": false,
+        "id": null,
+        "links": [],
+        "refresh": false,
+        "rows": [
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 3,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "100 - (avg by (cpu) (irate(node_cpu{mode=\"idle\", instance=\"$server\"}[5m])) * 100)",
+                                "hide": false,
+                                "intervalFactor": 10,
+                                "legendFormat": "{{cpu}}",
+                                "refId": "A",
+                                "step": 50
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Idle cpu",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "percent",
+                                "label": "cpu usage",
+                                "logBase": 1,
+                                "max": 100,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 9,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "node_load1{instance=\"$server\"}",
+                                "intervalFactor": 4,
+                                "legendFormat": "load 1m",
+                                "refId": "A",
+                                "step": 20,
+                                "target": ""
+                            },
+                            {
+                                "expr": "node_load5{instance=\"$server\"}",
+                                "intervalFactor": 4,
+                                "legendFormat": "load 5m",
+                                "refId": "B",
+                                "step": 20,
+                                "target": ""
+                            },
+                            {
+                                "expr": "node_load15{instance=\"$server\"}",
+                                "intervalFactor": 4,
+                                "legendFormat": "load 15m",
+                                "refId": "C",
+                                "step": 20,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "System load",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "percentunit",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 4,
+                        "legend": {
+                            "alignAsTable": false,
+                            "avg": false,
+                            "current": false,
+                            "hideEmpty": false,
+                            "hideZero": false,
+                            "max": false,
+                            "min": false,
+                            "rightSide": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "node_memory_SwapFree{instance=\"172.17.0.1:9100\",job=\"prometheus\"}",
+                                "yaxis": 2
+                            }
+                        ],
+                        "span": 9,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"} - node_memory_Buffers{instance=\"$server\"} - node_memory_Cached{instance=\"$server\"}",
+                                "hide": false,
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "memory used",
+                                "metric": "",
+                                "refId": "C",
+                                "step": 4
+                            },
+                            {
+                                "expr": "node_memory_Buffers{instance=\"$server\"}",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "memory buffers",
+                                "metric": "",
+                                "refId": "E",
+                                "step": 4
+                            },
+                            {
+                                "expr": "node_memory_Cached{instance=\"$server\"}",
+                                "intervalFactor": 2,
+                                "legendFormat": "memory cached",
+                                "metric": "",
+                                "refId": "F",
+                                "step": 4
+                            },
+                            {
+                                "expr": "node_memory_MemFree{instance=\"$server\"}",
+                                "intervalFactor": 2,
+                                "legendFormat": "memory free",
+                                "metric": "",
+                                "refId": "D",
+                                "step": 4
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory usage",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(50, 172, 45, 0.97)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(245, 54, 54, 0.9)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "percent",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": true,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 5,
+                        "interval": null,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "((node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}  - node_memory_Buffers{instance=\"$server\"} - node_memory_Cached{instance=\"$server\"}) / node_memory_MemTotal{instance=\"$server\"}) * 100",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 60,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": "80, 90",
+                        "title": "Memory usage",
+                        "type": "singlestat",
+                        "valueFontSize": "80%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 6,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "read",
+                                "yaxis": 1
+                            },
+                            {
+                                "alias": "{instance=\"172.17.0.1:9100\"}",
+                                "yaxis": 2
+                            },
+                            {
+                                "alias": "io time",
+                                "yaxis": 2
+                            }
+                        ],
+                        "span": 9,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum by (instance) (rate(node_disk_bytes_read{instance=\"$server\"}[2m]))",
+                                "hide": false,
+                                "intervalFactor": 4,
+                                "legendFormat": "read",
+                                "refId": "A",
+                                "step": 8,
+                                "target": ""
+                            },
+                            {
+                                "expr": "sum by (instance) (rate(node_disk_bytes_written{instance=\"$server\"}[2m]))",
+                                "intervalFactor": 4,
+                                "legendFormat": "written",
+                                "refId": "B",
+                                "step": 8
+                            },
+                            {
+                                "expr": "sum by (instance) (rate(node_disk_io_time_ms{instance=\"$server\"}[2m]))",
+                                "intervalFactor": 4,
+                                "legendFormat": "io time",
+                                "refId": "C",
+                                "step": 8
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Disk I/O",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "ms",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(50, 172, 45, 0.97)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(245, 54, 54, 0.9)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "format": "percentunit",
+                        "gauge": {
+                            "maxValue": 1,
+                            "minValue": 0,
+                            "show": true,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 7,
+                        "interval": null,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": false
+                        },
+                        "targets": [
+                            {
+                                "expr": "(sum(node_filesystem_size{device!=\"rootfs\",instance=\"$server\"}) - sum(node_filesystem_free{device!=\"rootfs\",instance=\"$server\"})) / sum(node_filesystem_size{device!=\"rootfs\",instance=\"$server\"})",
+                                "intervalFactor": 2,
+                                "refId": "A",
+                                "step": 60,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": "0.75, 0.9",
+                        "title": "Disk space usage",
+                        "type": "singlestat",
+                        "valueFontSize": "80%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "current"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 8,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "transmitted ",
+                                "yaxis": 2
+                            }
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "rate(node_network_receive_bytes{instance=\"$server\",device!~\"lo\"}[5m])",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "{{device}}",
+                                "refId": "A",
+                                "step": 10,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Network received",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "alerting": {},
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "editable": true,
+                        "error": false,
+                        "fill": 1,
+                        "grid": {},
+                        "id": 10,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 2,
+                        "links": [],
+                        "nullPointMode": "connected",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "transmitted ",
+                                "yaxis": 2
+                            }
+                        ],
+                        "span": 6,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "rate(node_network_transmit_bytes{instance=\"$server\",device!~\"lo\"}[5m])",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "{{device}}",
+                                "refId": "B",
+                                "step": 10,
+                                "target": ""
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Network transmitted",
+                        "tooltip": {
+                            "msResolution": false,
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "cumulative"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "New row",
+                "titleSize": "h6"
+            }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [
+            "prometheus"
+        ],
+        "templating": {
+            "list": [
+                {
+                    "allValue": null,
+                    "current": {},
+                    "datasource": "${DS_PROMETHEUS}",
+                    "hide": 0,
+                    "includeAll": false,
+                    "label": null,
+                    "multi": false,
+                    "name": "server",
+                    "options": [],
+                    "query": "label_values(node_boot_time, instance)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
+        "time": {
+            "from": "now-1h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "browser",
+        "title": "Nodes",
+        "version": 1
+    }
+    ,
+      "inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "pluginId": "prometheus",
+          "type": "datasource",
+          "value": "prometheus"
+        }
+      ],
+      "overwrite": true
+    }
+  resource-requests-dashboard.json: |+
+    {
+      "dashboard":
+    {
+        "__inputs": [
+            {
+                "description": "",
+                "label": "prometheus",
+                "name": "DS_PROMETHEUS",
+                "pluginId": "prometheus",
+                "pluginName": "Prometheus",
+                "type": "datasource"
+            }
+        ],
+        "__requires": [
+            {
+                "id": "grafana",
+                "name": "Grafana",
+                "type": "grafana",
+                "version": "4.1.1"
+            },
+            {
+                "id": "graph",
+                "name": "Graph",
+                "type": "panel",
+                "version": ""
+            },
+            {
+                "id": "prometheus",
+                "name": "Prometheus",
+                "type": "datasource",
+                "version": "1.0.0"
+            },
+            {
+                "id": "singlestat",
+                "name": "Singlestat",
+                "type": "panel",
+                "version": ""
+            }
+        ],
+        "annotations": {
+            "list": []
+        },
+        "description": "Dashboard to show the resource requests vs allocatable in the cluster",
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "hideControls": false,
+        "id": null,
+        "links": [],
+        "rows": [
+            {
+                "collapse": false,
+                "height": "300",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "description": "This represents the total [CPU resource requests](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu) in the cluster.\nFor comparison the total [allocatable CPU cores](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md) is also shown.",
+                        "fill": 1,
+                        "id": 1,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 9,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "min(sum(kube_node_status_allocatable_cpu_cores) by (instance))",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "Allocatable CPU Cores",
+                                "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "expr": "max(sum(kube_pod_container_resource_requests_cpu_cores) by (instance))",
+                                "intervalFactor": 2,
+                                "legendFormat": "Requested CPU Cores",
+                                "refId": "B",
+                                "step": 10
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "CPU Cores",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": "CPU Cores",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(50, 172, 45, 0.97)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(245, 54, 54, 0.9)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "decimals": null,
+                        "format": "percent",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": true,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 2,
+                        "interval": null,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": true
+                        },
+                        "targets": [
+                            {
+                                "expr": "max(sum(kube_pod_container_resource_requests_cpu_cores) by (instance)) / min(sum(kube_node_status_allocatable_cpu_cores) by (instance)) * 100",
+                                "intervalFactor": 2,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 240
+                            }
+                        ],
+                        "thresholds": "80, 90",
+                        "title": "CPU Cores",
+                        "type": "singlestat",
+                        "valueFontSize": "110%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "CPU Cores",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "300",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "${DS_PROMETHEUS}",
+                        "description": "This represents the total [memory resource requests](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory) in the cluster.\nFor comparison the total [allocatable memory](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md) is also shown.",
+                        "fill": 1,
+                        "id": 3,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "span": 9,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "min(sum(kube_node_status_allocatable_memory_bytes) by (instance))",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "Allocatable Memory",
+                                "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "expr": "max(sum(kube_pod_container_resource_requests_memory_bytes) by (instance))",
+                                "intervalFactor": 2,
+                                "legendFormat": "Requested Memory",
+                                "refId": "B",
+                                "step": 10
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": "Memory",
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
+                            }
+                        ]
+                    },
+                    {
+                        "cacheTimeout": null,
+                        "colorBackground": false,
+                        "colorValue": false,
+                        "colors": [
+                            "rgba(50, 172, 45, 0.97)",
+                            "rgba(237, 129, 40, 0.89)",
+                            "rgba(245, 54, 54, 0.9)"
+                        ],
+                        "datasource": "${DS_PROMETHEUS}",
+                        "decimals": null,
+                        "format": "percent",
+                        "gauge": {
+                            "maxValue": 100,
+                            "minValue": 0,
+                            "show": true,
+                            "thresholdLabels": false,
+                            "thresholdMarkers": true
+                        },
+                        "id": 4,
+                        "interval": null,
+                        "links": [],
+                        "mappingType": 1,
+                        "mappingTypes": [
+                            {
+                                "name": "value to text",
+                                "value": 1
+                            },
+                            {
+                                "name": "range to text",
+                                "value": 2
+                            }
+                        ],
+                        "maxDataPoints": 100,
+                        "nullPointMode": "connected",
+                        "nullText": null,
+                        "postfix": "",
+                        "postfixFontSize": "50%",
+                        "prefix": "",
+                        "prefixFontSize": "50%",
+                        "rangeMaps": [
+                            {
+                                "from": "null",
+                                "text": "N/A",
+                                "to": "null"
+                            }
+                        ],
+                        "span": 3,
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)",
+                            "full": false,
+                            "lineColor": "rgb(31, 120, 193)",
+                            "show": true
+                        },
+                        "targets": [
+                            {
+                                "expr": "max(sum(kube_pod_container_resource_requests_memory_bytes) by (instance)) / min(sum(kube_node_status_allocatable_memory_bytes) by (instance)) * 100",
+                                "intervalFactor": 2,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 240
+                            }
+                        ],
+                        "thresholds": "80, 90",
+                        "title": "Memory",
+                        "type": "singlestat",
+                        "valueFontSize": "110%",
+                        "valueMaps": [
+                            {
+                                "op": "=",
+                                "text": "N/A",
+                                "value": "null"
+                            }
+                        ],
+                        "valueName": "avg"
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Memory",
+                "titleSize": "h6"
+            }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+            "list": []
+        },
+        "time": {
+            "from": "now-3h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "browser",
+        "title": "Resource Requests",
+        "version": 1
+    }
+    ,
+      "inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "pluginId": "prometheus",
+          "type": "datasource",
+          "value": "prometheus"
+        }
+      ],
+      "overwrite": true
+    }


### PR DESCRIPTION
Add a grafana chart for kube-prometheus, mainly from stable/grafana & prometheus-oprator/contrib/kube-prometheus/grafana, made some adjustment to fit into kube-prometheus.

This pr only adds the grafana chart, to included into kube-prometheus(add this to requrements.yaml), I must publish this chart into a helm repo (which I don't have), but I have test it use manual manage dependency.