### PR TITLE
Scrapes cAdvisor port for metrics in Kubernetes 1.7

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -326,6 +326,8 @@ spec:
   endpoints:
   - port: http-metrics
     interval: 30s
+  - port: cadvisor
+    interval: 30s
     honorLabels: true
   selector:
     matchLabels:

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-monitor-kubelet.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-monitor-kubelet.yaml
@@ -9,6 +9,8 @@ spec:
   endpoints:
   - port: http-metrics
     interval: 30s
+  - port: cadvisor
+    interval: 30s
     honorLabels: true
   selector:
     matchLabels:

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -336,15 +336,19 @@ func (c *Operator) syncNodeEndpoints() {
 			},
 		},
 		Subsets: []v1.EndpointSubset{
-			v1.EndpointSubset{
+			{
 				Ports: []v1.EndpointPort{
-					v1.EndpointPort{
+					{
 						Name: "https-metrics",
 						Port: 10250,
 					},
-					v1.EndpointPort{
+					{
 						Name: "http-metrics",
 						Port: 10255,
+					},
+					{
+						Name: "cadvisor",
+						Port: 4194,
 					},
 				},
 			},
@@ -381,7 +385,7 @@ func (c *Operator) syncNodeEndpoints() {
 			Type:      v1.ServiceTypeClusterIP,
 			ClusterIP: "None",
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name: "https-metrics",
 					Port: 10250,
 				},


### PR DESCRIPTION
Kubernetes 1.7 [inadvertently stopped reporting cAdvisor metrics on the main /metrics endpoint](https://github.com/kubernetes/kubernetes/issues/48483). They are now only reported on the cAdvisor /metrics endpoint. As a temporary solution, I've added the cAdvisor port to the kubelet endpoint and servicemonitor so they get scraped as well.

I'm not totally sure it's a good idea to merge this, since [the original behavior might be restored soon](https://github.com/kubernetes/kubernetes/issues/48483#issuecomment-314828142), but I did want to bring it up in this repository in an attempt to save other folks some headdesking trying to figure out why pod-level metrics are not being reported in Kubernetes 1.7.

As a stopgap for my use case, I've built my own container with this fix and pushed it to a registry. Hopefully the original behavior will be restored in an upcoming point release of Kubernetes.