### PR TITLE
Update charts to accept fullname up to 63 characters

### DIFF
--- a/helm/kube-prometheus/charts/exporter-kube-dns/templates/_helpers.tpl
+++ b/helm/kube-prometheus/charts/exporter-kube-dns/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,5 +12,5 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/kube-prometheus/charts/exporter-kube-scheduler/templates/_helpers.tpl
+++ b/helm/kube-prometheus/charts/exporter-kube-scheduler/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,5 +12,5 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/kube-prometheus/charts/exporter-kube-state/templates/_helpers.tpl
+++ b/helm/kube-prometheus/charts/exporter-kube-state/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,5 +12,5 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
Hi, 

In testing, I found some of objects created with truncated name, like `abcd-monitor-exporter-no`, `abcd-monitor-exporter-ku`, which is exactly 24 characters long.

But Kubernetes now accept service names up to 63 characters (https://github.com/kubernetes/kubernetes/pull/29523), and helm had updated their charts too (https://github.com/kubernetes/helm/pull/1740).