### PR TITLE
helm/kube-prometheus: Use valid defaults for service nodePort values.

### DIFF
--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.3
+version: 0.0.4

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -94,7 +94,7 @@ service:
   ## Port to expose on each node
   ## Only used if service.type is 'NodePort'
   ##
-  nodePort: 39093
+  nodePort: 30903
 
   ## Service type
   ##

--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.1
+version: 0.0.2

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -32,7 +32,7 @@ service:
   ## Port to expose on each node
   ## Only used if service.type is 'NodePort'
   ##
-  nodePort: 39093
+  nodePort: 30902
 
   ## Service type
   ##

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.1
+version: 0.0.2

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -95,7 +95,7 @@ alertmanager:
     ## Port to expose on each node
     ## Only used if service.type is 'NodePort'
     ##
-    nodePort: 39093
+    nodePort: 30903
 
     ## Service type
     ##
@@ -228,7 +228,7 @@ prometheus:
     ## Port to expose on each node
     ## Only used if service.type is 'NodePort'
     ##
-    nodePort: 39090
+    nodePort: 30900
 
     ## Service type
     ##

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.3
+version: 0.0.4

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -122,7 +122,7 @@ service:
   ## Port to expose on each node
   ## Only used if service.type is 'NodePort'
   ##
-  nodePort: 39090
+  nodePort: 30900
 
   ## Service type
   ##


### PR DESCRIPTION
This sets valid default values for service `nodePort`, avoiding errors
when using service of type NodePort.

Fixes #496