### PR TITLE
helm/kube-prometheus: Bump alertmanager and prometheus dependency versions

### DIFF
--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -1,10 +1,10 @@
 dependencies:
   - name: alertmanager
-    version: 0.0.1
+    version: 0.0.3
     repository: http://charts.opsgoodness.com
 
   - name: prometheus
-    version: 0.0.1
+    version: 0.0.3
     repository: http://charts.opsgoodness.com
 
   - name: exporter-kube-api


### PR DESCRIPTION
This bumps the version of `alertmanager` and `prometheus` dependencies, resolving some errors.

Not sure if there are other implications to these bumps...

Fixes #498