### PR TITLE
documentation: fix storage doc

### DIFF
--- a/Documentation/user-guides/storage.md
+++ b/Documentation/user-guides/storage.md
@@ -70,12 +70,13 @@ spec:
   ...
   storage:
     volumeClaimTemplate:
-      selector:
-        matchLabels:
-          app: "my-example-prometheus"
-      resources:
-        requests:
-          storage: 50Gi
+      spec:
+        selector:
+          matchLabels:
+            app: "my-example-prometheus"
+        resources:
+          requests:
+            storage: 50Gi
 
 ---
 


### PR DESCRIPTION
spec.storage.volumeClaimTemplate.spec was missing from Manual storage provisioning documentation

Fixes #466