### PR TITLE
grafana helm chart: add server root url configuration

### DIFF
--- a/helm/grafana/templates/grafana-deployment.yaml
+++ b/helm/grafana/templates/grafana-deployment.yaml
@@ -23,6 +23,8 @@ spec:
       - name: grafana
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         env:
+        - name: GF_SERVER_ROOT_URL
+          value: "{{ .Values.server_root_url }}"
         - name: GF_AUTH_BASIC_ENABLED
           value: "true"
         - name: GF_AUTH_ANONYMOUS_ENABLED

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -5,6 +5,8 @@ annotations: {}
 adminUser: "admin"
 adminPassword: "admin"
 
+server_root_url: "%(protocol)s://%(domain)s:%(http_port)s/"
+
 service:
 
   ## Annotations to be added to the Service


### PR DESCRIPTION
This change is needed to allow configuring the `root_url` in cases the default doesn't work. For example to be able to load properly through simply running `kubectl proxy` you can do:

```
helm install opsgoodness/grafana --name my-release --set server_root_url=http://127.0.0.1:8001/api/v1/proxy/namespaces/default/services/my-release-grafana:80/
```

I realize now it isn't perfect since doing that requires not using a generated release name, I don't think there is a way to have a variable in a variable for the helm template? but yea.