### PR TITLE
helm/prometheus: don't limit selectors to MatchLabels

### DIFF
--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -59,6 +59,7 @@ Parameter | Description | Default
 `retention` | How long to retain metrics | `24h`
 `routePrefix` | Prefix used to register routes, overriding externalUrl route | `/`
 `rules` | Prometheus alerting & recording rules | `{}`
+`rulesSelector` | Rules ConfigMap selector | `{}`
 `secrets` | List of Secrets in the same namespace as the Prometheus object, which shall be mounted into the Prometheus Pods. | `{}`
 `service.annotations` | Annotations to be added to the Prometheus Service | `{}`
 `service.clusterIP` | Cluster-internal IP address for Prometheus Service | `""`
@@ -68,6 +69,7 @@ Parameter | Description | Default
 `service.nodePort` | Port to expose Prometheus Service on each node | `39090`
 `service.type` | Prometheus Service type | `ClusterIP`
 `serviceMonitors` | ServiceMonitor third-party resources to create & be scraped by this Prometheus instance | `[]`
+`serviceMonitorsSelector` | ServiceMonitor ConfigMap selector | `{}`
 `storageSpec` | Prometheus StorageSpec for persistent data | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -62,7 +62,8 @@ spec:
 {{- end }}
 {{- if .Values.rulesSelector }}
   ruleSelector:
-{{ toYaml .Values.rulesSelector | indent 4 }}
+    matchLabels:
+{{ toYaml .Values.rulesSelector | indent 6 }}
 {{- else }}
   ruleSelector:
     matchLabels:

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -53,8 +53,7 @@ spec:
 {{- end }}
 {{- if .Values.serviceMonitorsSelector }}
   serviceMonitorSelector:
-    matchLabels:
-{{ toYaml .Values.serviceMonitorsSelector | indent 6 }}
+{{ toYaml .Values.serviceMonitorsSelector | indent 4 }}
 {{- else }}
   serviceMonitorSelector:
     matchLabels:
@@ -63,8 +62,7 @@ spec:
 {{- end }}
 {{- if .Values.rulesSelector }}
   ruleSelector:
-    matchLabels:
-{{ toYaml .Values.rulesSelector | indent 6 }}
+{{ toYaml .Values.rulesSelector | indent 4 }}
 {{- else }}
   ruleSelector:
     matchLabels:

--- a/helm/prometheus/templates/rules.yaml
+++ b/helm/prometheus/templates/rules.yaml
@@ -8,7 +8,9 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    {{- if .Values.rulesSelector }}
 {{ toYaml .Values.rulesSelector | indent 4 }}
+    {{- end }}
   name: prometheus-{{ .Release.Name }}-rules
 data:
 {{ toYaml .Values.rules.value | indent 2 }}

--- a/helm/prometheus/templates/servicemonitors.yaml
+++ b/helm/prometheus/templates/servicemonitors.yaml
@@ -16,7 +16,7 @@ items:
         chart: {{ $chartName }}-{{ $chartVersion }}
         heritage: {{ $releaseService }}
         release: {{ $releaseName }}
-{{ toYaml .Values.serviceMonitorSelector | indent 8 }}
+{{ toYaml .labels | indent 8 }}
       name: {{ .name }}
     spec:
       endpoints:

--- a/helm/prometheus/templates/servicemonitors.yaml
+++ b/helm/prometheus/templates/servicemonitors.yaml
@@ -16,7 +16,9 @@ items:
         chart: {{ $chartName }}-{{ $chartVersion }}
         heritage: {{ $releaseService }}
         release: {{ $releaseName }}
-{{ toYaml .labels | indent 8 }}
+        {{- if .serviceMonitorSelectorLabels }}
+{{ toYaml .serviceMonitorSelectorLabels | indent 8 }}
+        {{- end }}
       name: {{ .name }}
     spec:
       endpoints:

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -147,6 +147,10 @@ serviceMonitors: []
   ##
   # - name: ""
 
+    ## Labels to set used for the ServiceMonitorSelector.
+    ##
+    # serviceMonitorSelectorLabels: {}
+
     ## Service label for use in assembling a job name of the form <label value>-<port>
     ## If no label is specified, the service name is used.
     ##


### PR DESCRIPTION
This updates the prometheus Helm chart so `matchLabels` isn't hard coded in the serviceMonitorSelector. You'll have to specify how to match via values.yaml.

Example usage:
```yaml
serviceMonitorsSelector:
  matchExpressions:
  - key: k8s-app
    operator: Exists

serviceMonitors:
  - name: "alertmanager"
    serviceMonitorSelectorLabels:
      k8s-app: alertmanager
    selector:
      matchLabels:
        alertmanager: main
    namespaceSelector:
      matchNames:
        - monitoring
    endpoints:
      - port: http
        interval: 30s
```

Also fixes/removes the `.Values.serviceMonitorSelector` typo in the `servicemonitors.yaml` template.

This is a breaking change compared to current parameter functionality.

Also related to #507 (should fix / clear up usage confusion).