### PR TITLE
Implement StatefulSet updates (+ full PodTemplate updates)

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -99,6 +99,11 @@ func makeStatefulSet(am *v1alpha1.Alertmanager, old *v1beta1.StatefulSet, config
 	if old != nil {
 		statefulset.Annotations = old.Annotations
 	}
+
+	if !config.StatefulSetUpdatesAvailable {
+		statefulset.Spec.UpdateStrategy = v1beta1.StatefulSetUpdateStrategy{}
+	}
+
 	return statefulset, nil
 }
 
@@ -189,6 +194,9 @@ func makeStatefulSetSpec(a *v1alpha1.Alertmanager, config Config) (*v1beta1.Stat
 	return &v1beta1.StatefulSetSpec{
 		ServiceName: governingServiceName,
 		Replicas:    a.Spec.Replicas,
+		UpdateStrategy: v1beta1.StatefulSetUpdateStrategy{
+			Type: v1beta1.RollingUpdateStatefulSetStrategyType,
+		},
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -130,14 +130,21 @@ func makeStatefulSet(p v1alpha1.Prometheus, old *v1beta1.StatefulSet, config *Co
 
 	if old != nil {
 		statefulset.Annotations = old.Annotations
-
-		// mounted volumes are not reconciled as StatefulSets do not allow
-		// modification of the PodTemplate.
-		// TODO(brancz): remove this once StatefulSets allow modification of the
-		// PodTemplate.
-		statefulset.Spec.Template.Spec.Containers[0].VolumeMounts = old.Spec.Template.Spec.Containers[0].VolumeMounts
-		statefulset.Spec.Template.Spec.Volumes = old.Spec.Template.Spec.Volumes
 	}
+
+	if !config.StatefulSetUpdatesAvailable {
+		statefulset.Spec.UpdateStrategy = v1beta1.StatefulSetUpdateStrategy{}
+
+		if old != nil {
+			// Mounted volumes are not reconciled as StatefulSets do not allow
+			// modification of the PodTemplate.
+			//
+			// TODO(brancz): remove this when dropping 1.6 compatibility.
+			statefulset.Spec.Template.Spec.Containers[0].VolumeMounts = old.Spec.Template.Spec.Containers[0].VolumeMounts
+			statefulset.Spec.Template.Spec.Volumes = old.Spec.Template.Spec.Volumes
+		}
+	}
+
 	return statefulset, nil
 }
 
@@ -420,9 +427,13 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 			Port: intstr.FromString("web"),
 		},
 	}
+
 	return &v1beta1.StatefulSetSpec{
 		ServiceName: governingServiceName,
 		Replicas:    p.Spec.Replicas,
+		UpdateStrategy: v1beta1.StatefulSetUpdateStrategy{
+			Type: v1beta1.RollingUpdateStatefulSetStrategyType,
+		},
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{


### PR DESCRIPTION
With Kubernetes 1.7 we now have the ability to perform real rolling updates and more importantly the whole StatefulSet and PodTemplate can be mutated.

I made sure to keep compatibility with Kubernetes versions before 1.7, in which case we fallback to the previous strategy.

Fixes #510 
Closes #49 

@fabxc @Gouthamve @mxinden 