### PR TITLE
Update prometheus-k8s-roles.yaml

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-roles.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-roles.yaml
@@ -39,6 +39,7 @@ rules:
   resources:
   - services
   - endpoints
+  - pods
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Resource pods added to role prometheus-k8s for namespace default. This is required to monitor kube-apiserver.