### PR TITLE
Adding a configurable scrapeTimeout for prometheus operator.

### DIFF
--- a/pkg/client/monitoring/v1alpha1/types.go
+++ b/pkg/client/monitoring/v1alpha1/types.go
@@ -66,6 +66,8 @@ type PrometheusSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Time duration Prometheus shall retain data for.
 	Retention string `json:"retention,omitempty"`
+	// Number of seconds to wait for target to respond before erroring.
+	ScrapeTimeout string `json:"scrape_timeout,omitempty"`
 	// Interval between consecutive evaluations.
 	EvaluationInterval string `json:"evaluationInterval,omitempty"`
 	// The labels to add to any time series or alerts when communicating with

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -76,8 +76,7 @@ func generateConfig(p *v1alpha1.Prometheus, mons map[string]*v1alpha1.ServiceMon
 		Key: "global",
 		Value: yaml.MapSlice{
 			{Key: "evaluation_interval", Value: evaluationInterval},
-			{Key: "scrape_timeout", Value: "30s"},
-			{Key: "scrape_interval", Value: scrapeTimeout},
+			{Key: "scrape_timeout", Value: scrapeTimeout},
 			{Key: "external_labels", Value: stringMapToMapSlice(p.Spec.ExternalLabels)},
 		},
 	})

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -67,12 +67,17 @@ func generateConfig(p *v1alpha1.Prometheus, mons map[string]*v1alpha1.ServiceMon
 	if p.Spec.EvaluationInterval != "" {
 		evaluationInterval = p.Spec.EvaluationInterval
 	}
+	scrapeTimeout := "10s"
+	if p.Spec.ScrapeTimeout != "" {
+		scrapeTimeout = p.Spec.ScrapeTimeout
+	}
 
 	cfg = append(cfg, yaml.MapItem{
 		Key: "global",
 		Value: yaml.MapSlice{
 			{Key: "evaluation_interval", Value: evaluationInterval},
-			{Key: "scrape_interval", Value: "30s"},
+			{Key: "scrape_timeout", Value: "30s"},
+			{Key: "scrape_interval", Value: scrapeTimeout},
 			{Key: "external_labels", Value: stringMapToMapSlice(p.Spec.ExternalLabels)},
 		},
 	})

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -76,6 +76,7 @@ func generateConfig(p *v1alpha1.Prometheus, mons map[string]*v1alpha1.ServiceMon
 		Key: "global",
 		Value: yaml.MapSlice{
 			{Key: "evaluation_interval", Value: evaluationInterval},
+			{Key: "scrape_interval", Value: "30s"},
 			{Key: "scrape_timeout", Value: scrapeTimeout},
 			{Key: "external_labels", Value: stringMapToMapSlice(p.Spec.ExternalLabels)},
 		},


### PR DESCRIPTION
Hi CoreOS team,

I couldn't find a comprehensive developers guide for ensuring this works. I figured I'd make a local build locally and test it out in our QA cluster. If there's something faster and easier than just running ``go test`` in the pkg/prometheus subdir, I'd love to hear about it. 

Cheers!