### PR TITLE
grafana-watcher: retry failed updates from ConfigMap changes

### DIFF
--- a/contrib/grafana-watcher/examples/grafana-bundle.yaml
+++ b/contrib/grafana-watcher/examples/grafana-bundle.yaml
@@ -73,7 +73,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.7
+        image: quay.io/coreos/grafana-watcher:v0.0.8
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://localhost:3000'

--- a/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.7
+        image: quay.io/coreos/grafana-watcher:v0.0.8
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://localhost:3000'

--- a/helm/grafana/templates/grafana-deployment.yaml
+++ b/helm/grafana/templates/grafana-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: grafana-watcher
-        image: quay.io/coreos/grafana-watcher:v0.0.7
+        image: quay.io/coreos/grafana-watcher:v0.0.8
         args:
           - '--watch-dir=/var/grafana-dashboards'
           - '--grafana-url=http://localhost:3000'


### PR DESCRIPTION
Currently, an update will only be partially applied if an
error occurs in one of the handler routines. The grafana
system will be left in a dirty intermediate state until
the ConfigMap is updated again. This change will retry failed updates
until all scheduled updates have succeeded OR until the ConfigMap
is changed again.

This log file from the `grafana-watcher` container in the `grafanaXXX` pod from a `kube-prometheus` deployment shows the retry loop working correctly (I have no idea why I get so many timouts T_T):

```
2017/08/04 20:45:25 Waiting for Grafana to be available.
2017/08/04 20:45:41 Initializing datasources.
2017/08/04 20:45:41 Retrieving existing datasources
2017/08/04 20:45:41 Deleting 0 datasources
2017/08/04 20:45:41 Creating datasource from: /var/grafana-dashboards/prometheus-datasource.json
2017/08/04 20:45:42 Initializing dashboards.
2017/08/04 20:45:42 Retrieving existing dashboards
2017/08/04 20:45:58 Deleting 0 dashboards
2017/08/04 20:45:58 Creating dashboard from: /var/grafana-dashboards/all-nodes-dashboard.json
2017/08/04 20:45:58 Creating dashboard from: /var/grafana-dashboards/deployment-dashboard.json
2017/08/04 20:46:24 Creating dashboard from: /var/grafana-dashboards/kubernetes-pods-dashboard.json
2017/08/04 20:46:50 Creating dashboard from: /var/grafana-dashboards/node-dashboard.json
2017/08/04 20:47:06 Creating dashboard from: /var/grafana-dashboards/resource-requests-dashboard.json
2017/08/04 20:47:12 Starting...
2017/08/04 20:48:32 ConfigMap modified
2017/08/04 20:48:32 Retrieving existing dashboards
2017/08/04 20:49:02 error: Get http://admin:admin@localhost:3000/api/search: dial tcp: i/o timeout
2017/08/04 20:49:02 Retrieving existing datasources
2017/08/04 20:49:17 Deleting 1 datasources
2017/08/04 20:49:17 Deleting datasource: 1
2017/08/04 20:49:18 Creating datasource from: /var/grafana-dashboards/prometheus-datasource.json
2017/08/04 20:49:29 Retrieving existing dashboards
2017/08/04 20:49:44 Deleting 5 dashboards
2017/08/04 20:49:44 Deleting dashboard: all-nodes
2017/08/04 20:49:45 Deleting dashboard: deployment
2017/08/04 20:50:10 error during retry attempt: Delete http://admin:admin@localhost:3000/api/dashboards/db/deployment: dial tcp [::1]:3000: connect: cannot assign requested address
2017/08/04 20:50:20 Retrieving existing dashboards
2017/08/04 20:50:31 Deleting 4 dashboards
2017/08/04 20:50:31 Deleting dashboard: deployment
2017/08/04 20:50:31 Deleting dashboard: nodes
2017/08/04 20:51:01 error during retry attempt: Delete http://admin:admin@localhost:3000/api/dashboards/db/nodes: dial tcp: i/o timeout
2017/08/04 20:51:11 Retrieving existing dashboards
2017/08/04 20:51:41 error during retry attempt: Get http://admin:admin@localhost:3000/api/search: dial tcp: i/o timeout
2017/08/04 20:51:51 Retrieving existing dashboards
2017/08/04 20:52:21 error during retry attempt: Get http://admin:admin@localhost:3000/api/search: dial tcp: i/o timeout
2017/08/04 20:52:31 Retrieving existing dashboards
2017/08/04 20:52:57 Deleting 3 dashboards
2017/08/04 20:52:57 Deleting dashboard: nodes
2017/08/04 20:52:57 Deleting dashboard: pods
2017/08/04 20:53:18 Deleting dashboard: resource-requests
2017/08/04 20:53:48 error during retry attempt: Delete http://admin:admin@localhost:3000/api/dashboards/db/resource-requests: dial tcp: i/o timeout
2017/08/04 20:53:58 Retrieving existing dashboards
2017/08/04 20:54:24 Deleting 1 dashboards
2017/08/04 20:54:24 Deleting dashboard: resource-requests
2017/08/04 20:54:25 Creating dashboard from: /var/grafana-dashboards/all-nodes-dashboard.json
2017/08/04 20:54:55 Creating dashboard from: /var/grafana-dashboards/deployment-dashboard.json
2017/08/04 20:55:15 Creating dashboard from: /var/grafana-dashboards/kubernetes-pods-dashboard.json
2017/08/04 20:55:45 Creating dashboard from: /var/grafana-dashboards/node-dashboard.json
2017/08/04 20:56:06 Creating dashboard from: /var/grafana-dashboards/resource-requests-dashboard.json
```

