### PR TITLE
WIP: Move to v1 from v1alpha1

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -25,6 +25,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/errgroup"
@@ -32,10 +35,12 @@ import (
 	"github.com/coreos/prometheus-operator/pkg/alertmanager"
 	"github.com/coreos/prometheus-operator/pkg/analytics"
 	"github.com/coreos/prometheus-operator/pkg/api"
+	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
 	"github.com/coreos/prometheus-operator/pkg/migrator"
 	prometheuscontroller "github.com/coreos/prometheus-operator/pkg/prometheus"
 	"github.com/go-kit/kit/log"
+	clientGoAPI "k8s.io/client-go/pkg/api"
 )
 
 var (
@@ -127,6 +132,12 @@ func Main() int {
 			return 1
 		}
 	default:
+		conf.GroupVersion = &schema.GroupVersion{
+			Group:   v1.Group,
+			Version: v1.Version,
+		}
+		conf.APIPath = "/apis"
+		conf.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: clientGoAPI.Codecs}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/alertmanager/collector.go
+++ b/pkg/alertmanager/collector.go
@@ -15,7 +15,7 @@
 package alertmanager
 
 import (
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/tools/cache"
@@ -48,11 +48,11 @@ func (c *alertmanagerCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect implements the prometheus.Collector interface.
 func (c *alertmanagerCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, p := range c.store.List() {
-		c.collectAlertmanager(ch, p.(*v1alpha1.Alertmanager))
+		c.collectAlertmanager(ch, p.(*v1.Alertmanager))
 	}
 }
 
-func (c *alertmanagerCollector) collectAlertmanager(ch chan<- prometheus.Metric, a *v1alpha1.Alertmanager) {
+func (c *alertmanagerCollector) collectAlertmanager(ch chan<- prometheus.Metric, a *v1.Alertmanager) {
 	replicas := float64(minReplicas)
 	if a.Spec.Replicas != nil {
 		replicas = float64(*a.Spec.Replicas)

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/pkg/apis/apps/v1beta1"
 
 	"github.com/blang/semver"
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/pkg/errors"
 )
 
@@ -41,7 +41,7 @@ var (
 	probeTimeoutSeconds int32 = 3
 )
 
-func makeStatefulSet(am *v1alpha1.Alertmanager, old *v1beta1.StatefulSet, config Config) (*v1beta1.StatefulSet, error) {
+func makeStatefulSet(am *monitoringv1.Alertmanager, old *v1beta1.StatefulSet, config Config) (*v1beta1.StatefulSet, error) {
 	// TODO(fabxc): is this the right point to inject defaults?
 	// Ideally we would do it before storing but that's currently not possible.
 	// Potentially an update handler on first insertion.
@@ -107,7 +107,7 @@ func makeStatefulSet(am *v1alpha1.Alertmanager, old *v1beta1.StatefulSet, config
 	return statefulset, nil
 }
 
-func makeStatefulSetService(p *v1alpha1.Alertmanager) *v1.Service {
+func makeStatefulSetService(p *monitoringv1.Alertmanager) *v1.Service {
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: governingServiceName,
@@ -139,7 +139,7 @@ func makeStatefulSetService(p *v1alpha1.Alertmanager) *v1.Service {
 	return svc
 }
 
-func makeStatefulSetSpec(a *v1alpha1.Alertmanager, config Config) (*v1beta1.StatefulSetSpec, error) {
+func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*v1beta1.StatefulSetSpec, error) {
 	image := fmt.Sprintf("%s:%s", a.Spec.BaseImage, a.Spec.Version)
 	versionStr := strings.TrimLeft(a.Spec.Version, "v")
 
@@ -297,7 +297,7 @@ func prefixedName(name string) string {
 	return fmt.Sprintf("alertmanager-%s", name)
 }
 
-func subPathForStorage(s *v1alpha1.StorageSpec) string {
+func subPathForStorage(s *monitoringv1.StorageSpec) string {
 	if s == nil {
 		return ""
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,14 +23,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
 	"github.com/coreos/prometheus-operator/pkg/prometheus"
 )
 
 type API struct {
 	kclient *kubernetes.Clientset
-	mclient *v1alpha1.MonitoringV1alpha1Client
+	mclient *v1.MonitoringV1alpha1Client
 	logger  log.Logger
 }
 
@@ -45,7 +45,7 @@ func New(conf prometheus.Config, l log.Logger) (*API, error) {
 		return nil, err
 	}
 
-	mclient, err := v1alpha1.NewForConfig(cfg)
+	mclient, err := v1.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func New(conf prometheus.Config, l log.Logger) (*API, error) {
 }
 
 var (
-	prometheusRoute = regexp.MustCompile("/apis/monitoring.coreos.com/v1alpha1/namespaces/(.*)/prometheuses/(.*)/status")
+	prometheusRoute = regexp.MustCompile("/apis/monitoring.coreos.com/" + v1.Version + "/namespaces/(.*)/prometheuses/(.*)/status")
 )
 
 func (api *API) Register(mux *http.ServeMux) {

--- a/pkg/client/monitoring/v1/alertmanager.go
+++ b/pkg/client/monitoring/v1/alertmanager.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package v1
 
 import (
 	"encoding/json"

--- a/pkg/client/monitoring/v1/client.go
+++ b/pkg/client/monitoring/v1/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package v1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -23,9 +23,10 @@ import (
 )
 
 const (
-	Group   = "monitoring.coreos.com"
-	Version = "v1alpha1"
+	Group = "monitoring.coreos.com"
 )
+
+var Version = "v1"
 
 type MonitoringV1alpha1Interface interface {
 	RESTClient() rest.Interface

--- a/pkg/client/monitoring/v1/prometheus.go
+++ b/pkg/client/monitoring/v1/prometheus.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package v1
 
 import (
 	"encoding/json"

--- a/pkg/client/monitoring/v1/servicemonitor.go
+++ b/pkg/client/monitoring/v1/servicemonitor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package v1
 
 import (
 	"encoding/json"

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/prometheus/collector.go
+++ b/pkg/prometheus/collector.go
@@ -15,7 +15,7 @@
 package prometheus
 
 import (
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/tools/cache"
@@ -48,11 +48,11 @@ func (c *prometheusCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect implements the prometheus.Collector interface.
 func (c *prometheusCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, p := range c.store.List() {
-		c.collectPrometheus(ch, p.(*v1alpha1.Prometheus))
+		c.collectPrometheus(ch, p.(*v1.Prometheus))
 	}
 }
 
-func (c *prometheusCollector) collectPrometheus(ch chan<- prometheus.Metric, p *v1alpha1.Prometheus) {
+func (c *prometheusCollector) collectPrometheus(ch chan<- prometheus.Metric, p *v1.Prometheus) {
 	replicas := float64(minReplicas)
 	if p.Spec.Replicas != nil {
 		replicas = float64(*p.Spec.Replicas)

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -25,7 +25,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 )
 
 var (
@@ -50,7 +50,7 @@ func stringMapToMapSlice(m map[string]string) yaml.MapSlice {
 	return res
 }
 
-func generateConfig(p *v1alpha1.Prometheus, mons map[string]*v1alpha1.ServiceMonitor, ruleConfigMaps int, basicAuthSecrets map[string]BasicAuthCredentials) ([]byte, error) {
+func generateConfig(p *v1.Prometheus, mons map[string]*v1.ServiceMonitor, ruleConfigMaps int, basicAuthSecrets map[string]BasicAuthCredentials) ([]byte, error) {
 	versionStr := p.Spec.Version
 	if versionStr == "" {
 		versionStr = DefaultVersion
@@ -127,7 +127,7 @@ func generateConfig(p *v1alpha1.Prometheus, mons map[string]*v1alpha1.ServiceMon
 	return yaml.Marshal(cfg)
 }
 
-func generateServiceMonitorConfig(version semver.Version, m *v1alpha1.ServiceMonitor, ep v1alpha1.Endpoint, i int, basicAuthSecrets map[string]BasicAuthCredentials) yaml.MapSlice {
+func generateServiceMonitorConfig(version semver.Version, m *v1.ServiceMonitor, ep v1.Endpoint, i int, basicAuthSecrets map[string]BasicAuthCredentials) yaml.MapSlice {
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
@@ -348,7 +348,7 @@ func generateServiceMonitorConfig(version semver.Version, m *v1alpha1.ServiceMon
 	return cfg
 }
 
-func k8sSDFromServiceMonitor(m *v1alpha1.ServiceMonitor) yaml.MapItem {
+func k8sSDFromServiceMonitor(m *v1.ServiceMonitor) yaml.MapItem {
 	nsel := m.Spec.NamespaceSelector
 	namespaces := []string{}
 	if !nsel.Any && len(nsel.MatchNames) == 0 {
@@ -400,7 +400,7 @@ func k8sSDAllNamespaces() yaml.MapItem {
 	}
 }
 
-func generateAlertmanagerConfig(version semver.Version, am v1alpha1.AlertmanagerEndpoints) yaml.MapSlice {
+func generateAlertmanagerConfig(version semver.Version, am v1.AlertmanagerEndpoints) yaml.MapSlice {
 	if am.Scheme == "" {
 		am.Scheme = "http"
 	}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/pkg/api/v1"
 
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 )
 
 func TestConfigGeneration(t *testing.T) {
@@ -49,14 +49,14 @@ func TestConfigGeneration(t *testing.T) {
 func generateTestConfig(version string) ([]byte, error) {
 	replicas := int32(1)
 	return generateConfig(
-		&v1alpha1.Prometheus{
+		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
 			},
-			Spec: v1alpha1.PrometheusSpec{
-				Alerting: v1alpha1.AlertingSpec{
-					Alertmanagers: []v1alpha1.AlertmanagerEndpoints{
+			Spec: monitoringv1.PrometheusSpec{
+				Alerting: monitoringv1.AlertingSpec{
+					Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
 						{
 							Name:      "alertmanager-main",
 							Namespace: "default",
@@ -89,10 +89,10 @@ func generateTestConfig(version string) ([]byte, error) {
 	)
 }
 
-func makeServiceMonitors() map[string]*v1alpha1.ServiceMonitor {
-	res := map[string]*v1alpha1.ServiceMonitor{}
+func makeServiceMonitors() map[string]*monitoringv1.ServiceMonitor {
+	res := map[string]*monitoringv1.ServiceMonitor{}
 
-	res["servicemonitor1"] = &v1alpha1.ServiceMonitor{
+	res["servicemonitor1"] = &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testservicemonitor1",
 			Namespace: "default",
@@ -100,14 +100,14 @@ func makeServiceMonitors() map[string]*v1alpha1.ServiceMonitor {
 				"group": "group1",
 			},
 		},
-		Spec: v1alpha1.ServiceMonitorSpec{
+		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"group": "group1",
 				},
 			},
-			Endpoints: []v1alpha1.Endpoint{
-				v1alpha1.Endpoint{
+			Endpoints: []monitoringv1.Endpoint{
+				monitoringv1.Endpoint{
 					Port:     "web",
 					Interval: "30s",
 				},
@@ -115,7 +115,7 @@ func makeServiceMonitors() map[string]*v1alpha1.ServiceMonitor {
 		},
 	}
 
-	res["servicemonitor2"] = &v1alpha1.ServiceMonitor{
+	res["servicemonitor2"] = &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testservicemonitor2",
 			Namespace: "default",
@@ -123,15 +123,15 @@ func makeServiceMonitors() map[string]*v1alpha1.ServiceMonitor {
 				"group": "group2",
 			},
 		},
-		Spec: v1alpha1.ServiceMonitorSpec{
+		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"group":  "group2",
 					"group3": "group3",
 				},
 			},
-			Endpoints: []v1alpha1.Endpoint{
-				v1alpha1.Endpoint{
+			Endpoints: []monitoringv1.Endpoint{
+				monitoringv1.Endpoint{
 					Port:     "web",
 					Interval: "30s",
 				},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/pkg/apis/apps/v1beta1"
 
 	"github.com/blang/semver"
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -70,7 +70,7 @@ var (
 	}
 )
 
-func makeStatefulSet(p v1alpha1.Prometheus, old *v1beta1.StatefulSet, config *Config, ruleConfigMaps []*v1.ConfigMap) (*v1beta1.StatefulSet, error) {
+func makeStatefulSet(p monitoringv1.Prometheus, old *v1beta1.StatefulSet, config *Config, ruleConfigMaps []*v1.ConfigMap) (*v1beta1.StatefulSet, error) {
 	// TODO(fabxc): is this the right point to inject defaults?
 	// Ideally we would do it before storing but that's currently not possible.
 	// Potentially an update handler on first insertion.
@@ -239,7 +239,7 @@ func makeConfigSecret(name string, configMaps []*v1.ConfigMap) (*v1.Secret, erro
 	}, nil
 }
 
-func makeStatefulSetService(p *v1alpha1.Prometheus) *v1.Service {
+func makeStatefulSetService(p *monitoringv1.Prometheus) *v1.Service {
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: governingServiceName,
@@ -264,7 +264,7 @@ func makeStatefulSetService(p *v1alpha1.Prometheus) *v1.Service {
 	return svc
 }
 
-func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.ConfigMap) (*v1beta1.StatefulSetSpec, error) {
+func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMaps []*v1.ConfigMap) (*v1beta1.StatefulSetSpec, error) {
 	// Prometheus may take quite long to shut down to checkpoint existing data.
 	// Allow up to 10 minutes for clean termination.
 	terminationGracePeriod := int64(600)
@@ -506,7 +506,7 @@ func prefixedName(name string) string {
 	return fmt.Sprintf("prometheus-%s", name)
 }
 
-func subPathForStorage(s *v1alpha1.StorageSpec) string {
+func subPathForStorage(s *monitoringv1.StorageSpec) string {
 	if s == nil {
 		return ""
 	}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -15,13 +15,14 @@
 package prometheus
 
 import (
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	"reflect"
+	"testing"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/apps/v1beta1"
-	"reflect"
-	"testing"
 )
 
 var (
@@ -38,7 +39,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 		"testannotation": "testannotationvalue",
 	}
 
-	sset, err := makeStatefulSet(v1alpha1.Prometheus{
+	sset, err := makeStatefulSet(monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,
 			Annotations: annotations,
@@ -72,13 +73,13 @@ func TestStatefulSetPVC(t *testing.T) {
 		},
 	}
 
-	sset, err := makeStatefulSet(v1alpha1.Prometheus{
+	sset, err := makeStatefulSet(monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,
 			Annotations: annotations,
 		},
-		Spec: v1alpha1.PrometheusSpec{
-			Storage: &v1alpha1.StorageSpec{
+		Spec: monitoringv1.PrometheusSpec{
+			Storage: &monitoringv1.StorageSpec{
 				VolumeClaimTemplate: pvc,
 			},
 		},
@@ -159,8 +160,8 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 		},
 	}
 
-	sset, err := makeStatefulSet(v1alpha1.Prometheus{
-		Spec: v1alpha1.PrometheusSpec{
+	sset, err := makeStatefulSet(monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
 			Secrets: []string{
 				"test-secret1",
 			},
@@ -241,8 +242,8 @@ func TestStatefulSetVolumeSkip(t *testing.T) {
 		},
 	}
 
-	sset, err := makeStatefulSet(v1alpha1.Prometheus{
-		Spec: v1alpha1.PrometheusSpec{
+	sset, err := makeStatefulSet(monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
 			Secrets: []string{
 				"test-secret1",
 				"test-secret2",

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/coreos/prometheus-operator/pkg/alertmanager"
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/prometheus"
 	testFramework "github.com/coreos/prometheus-operator/test/framework"
 	"github.com/pkg/errors"
@@ -170,12 +170,12 @@ func TestPrometheusReloadConfig(t *testing.T) {
 
 	name := "test"
 	replicas := int32(1)
-	p := &v1alpha1.Prometheus{
+	p := &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
-		Spec: v1alpha1.PrometheusSpec{
+		Spec: monitoringv1.PrometheusSpec{
 			Replicas: &replicas,
 			Version:  "v1.5.0",
 			Resources: v1.ResourceRequirements{
@@ -430,21 +430,21 @@ func TestPrometheusDiscoverTargetPort(t *testing.T) {
 	group := "servicediscovery-test"
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
-	if _, err := framework.MonClient.ServiceMonitors(ns).Create(&v1alpha1.ServiceMonitor{
+	if _, err := framework.MonClient.ServiceMonitors(ns).Create(&monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: prometheusName,
 			Labels: map[string]string{
 				"group": group,
 			},
 		},
-		Spec: v1alpha1.ServiceMonitorSpec{
+		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"group": group,
 				},
 			},
-			Endpoints: []v1alpha1.Endpoint{
-				v1alpha1.Endpoint{
+			Endpoints: []monitoringv1.Endpoint{
+				monitoringv1.Endpoint{
 					TargetPort: intstr.FromInt(9090),
 					Interval:   "30s",
 				},

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/coreos/prometheus-operator/pkg/alertmanager"
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/pkg/errors"
 )
 
@@ -45,12 +45,12 @@ receivers:
   - url: 'http://alertmanagerwh:30500/'
 `
 
-func (f *Framework) MakeBasicAlertmanager(name string, replicas int32) *v1alpha1.Alertmanager {
-	return &v1alpha1.Alertmanager{
+func (f *Framework) MakeBasicAlertmanager(name string, replicas int32) *monitoringv1.Alertmanager {
+	return &monitoringv1.Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1alpha1.AlertmanagerSpec{
+		Spec: monitoringv1.AlertmanagerSpec{
 			Replicas: &replicas,
 		},
 	}
@@ -107,7 +107,7 @@ func (f *Framework) AlertmanagerConfigSecret(name string) (*v1.Secret, error) {
 	return s, nil
 }
 
-func (f *Framework) CreateAlertmanagerAndWaitUntilReady(ns string, a *v1alpha1.Alertmanager) error {
+func (f *Framework) CreateAlertmanagerAndWaitUntilReady(ns string, a *monitoringv1.Alertmanager) error {
 	amConfigSecretName := fmt.Sprintf("alertmanager-%s", a.Name)
 	s, err := f.AlertmanagerConfigSecret(amConfigSecretName)
 	if err != nil {
@@ -138,7 +138,7 @@ func (f *Framework) WaitForAlertmanagerReady(ns, name string, replicas int) erro
 	return errors.Wrap(err, fmt.Sprintf("failed to create an Alertmanager cluster (%s) with %d instances", name, replicas))
 }
 
-func (f *Framework) UpdateAlertmanagerAndWaitUntilReady(ns string, a *v1alpha1.Alertmanager) error {
+func (f *Framework) UpdateAlertmanagerAndWaitUntilReady(ns string, a *monitoringv1.Alertmanager) error {
 	_, err := f.MonClient.Alertmanagers(ns).Update(a)
 	if err != nil {
 		return err

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -27,14 +27,14 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
 	"github.com/pkg/errors"
 )
 
 type Framework struct {
 	KubeClient     kubernetes.Interface
-	MonClient      *v1alpha1.MonitoringV1alpha1Client
+	MonClient      *monitoringv1.MonitoringV1alpha1Client
 	HTTPClient     *http.Client
 	MasterHost     string
 	Namespace      *v1.Namespace
@@ -59,7 +59,7 @@ func New(ns, kubeconfig, opImage string) (*Framework, error) {
 		return nil, errors.Wrap(err, "creating http-client failed")
 	}
 
-	mclient, err := v1alpha1.NewForConfig(config)
+	mclient, err := monitoringv1.NewForConfig(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating monitoring client failed")
 	}
@@ -137,17 +137,17 @@ func (f *Framework) setupPrometheusOperator(opImage string) error {
 	}
 	f.OperatorPod = &pl.Items[0]
 
-	err = k8sutil.WaitForCRDReady(f.KubeClient.Core().RESTClient(), v1alpha1.Group, v1alpha1.Version, v1alpha1.PrometheusName)
+	err = k8sutil.WaitForCRDReady(f.KubeClient.Core().RESTClient(), monitoringv1.Group, monitoringv1.Version, monitoringv1.PrometheusName)
 	if err != nil {
 		return err
 	}
 
-	err = k8sutil.WaitForCRDReady(f.KubeClient.Core().RESTClient(), v1alpha1.Group, v1alpha1.Version, v1alpha1.ServiceMonitorName)
+	err = k8sutil.WaitForCRDReady(f.KubeClient.Core().RESTClient(), monitoringv1.Group, monitoringv1.Version, monitoringv1.ServiceMonitorName)
 	if err != nil {
 		return err
 	}
 
-	return k8sutil.WaitForCRDReady(f.KubeClient.Core().RESTClient(), v1alpha1.Group, v1alpha1.Version, v1alpha1.AlertmanagerName)
+	return k8sutil.WaitForCRDReady(f.KubeClient.Core().RESTClient(), monitoringv1.Group, monitoringv1.Version, monitoringv1.AlertmanagerName)
 }
 
 func (ctx *TestCtx) SetupPrometheusRBAC(t *testing.T, ns string, kubeClient kubernetes.Interface) {

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -27,18 +27,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/pkg/api/v1"
 
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/prometheus"
 	"github.com/pkg/errors"
 )
 
-func (f *Framework) MakeBasicPrometheus(ns, name, group string, replicas int32) *v1alpha1.Prometheus {
-	return &v1alpha1.Prometheus{
+func (f *Framework) MakeBasicPrometheus(ns, name, group string, replicas int32) *monitoringv1.Prometheus {
+	return &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
-		Spec: v1alpha1.PrometheusSpec{
+		Spec: monitoringv1.PrometheusSpec{
 			Replicas: &replicas,
 			Version:  prometheus.DefaultVersion,
 			ServiceMonitorSelector: &metav1.LabelSelector{
@@ -61,10 +61,10 @@ func (f *Framework) MakeBasicPrometheus(ns, name, group string, replicas int32) 
 	}
 }
 
-func (f *Framework) AddAlertingToPrometheus(p *v1alpha1.Prometheus, ns, name string) {
-	p.Spec.Alerting = v1alpha1.AlertingSpec{
-		Alertmanagers: []v1alpha1.AlertmanagerEndpoints{
-			v1alpha1.AlertmanagerEndpoints{
+func (f *Framework) AddAlertingToPrometheus(p *monitoringv1.Prometheus, ns, name string) {
+	p.Spec.Alerting = monitoringv1.AlertingSpec{
+		Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
+			monitoringv1.AlertmanagerEndpoints{
 				Namespace: ns,
 				Name:      fmt.Sprintf("alertmanager-%s", name),
 				Port:      intstr.FromString("web"),
@@ -73,22 +73,22 @@ func (f *Framework) AddAlertingToPrometheus(p *v1alpha1.Prometheus, ns, name str
 	}
 }
 
-func (f *Framework) MakeBasicServiceMonitor(name string) *v1alpha1.ServiceMonitor {
-	return &v1alpha1.ServiceMonitor{
+func (f *Framework) MakeBasicServiceMonitor(name string) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
 				"group": name,
 			},
 		},
-		Spec: v1alpha1.ServiceMonitorSpec{
+		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"group": name,
 				},
 			},
-			Endpoints: []v1alpha1.Endpoint{
-				v1alpha1.Endpoint{
+			Endpoints: []monitoringv1.Endpoint{
+				monitoringv1.Endpoint{
 					Port:     "web",
 					Interval: "30s",
 				},
@@ -122,7 +122,7 @@ func (f *Framework) MakePrometheusService(name, group string, serviceType v1.Ser
 	return service
 }
 
-func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Prometheus) error {
+func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *monitoringv1.Prometheus) error {
 	_, err := f.MonClient.Prometheuses(ns).Create(p)
 	if err != nil {
 		return err
@@ -135,7 +135,7 @@ func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Pro
 	return nil
 }
 
-func (f *Framework) UpdatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Prometheus) error {
+func (f *Framework) UpdatePrometheusAndWaitUntilReady(ns string, p *monitoringv1.Prometheus) error {
 	_, err := f.MonClient.Prometheuses(ns).Update(p)
 	if err != nil {
 		return err
@@ -147,7 +147,7 @@ func (f *Framework) UpdatePrometheusAndWaitUntilReady(ns string, p *v1alpha1.Pro
 	return nil
 }
 
-func (f *Framework) WaitForPrometheusReady(p *v1alpha1.Prometheus, timeout time.Duration) error {
+func (f *Framework) WaitForPrometheusReady(p *monitoringv1.Prometheus, timeout time.Duration) error {
 	return wait.Poll(2*time.Second, timeout, func() (bool, error) {
 		st, _, err := prometheus.PrometheusStatus(f.KubeClient, p)
 		if err != nil {
@@ -181,7 +181,7 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(ns, name string) error {
 	return nil
 }
 
-func (f *Framework) WaitForPrometheusRunImageAndReady(ns string, p *v1alpha1.Prometheus) error {
+func (f *Framework) WaitForPrometheusRunImageAndReady(ns string, p *monitoringv1.Prometheus) error {
 	if err := WaitForPodsRunImage(f.KubeClient, ns, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name)); err != nil {
 		return err
 	}


### PR DESCRIPTION
A super early version, migration is buggy hence, tests will fail.

So we cannot update the CRD version as that field is immutable. Which means the only option is to run a migration.

1. Do we release a `0.12.0` with the TPR --> CRD changes and then have another migration which moves from `v1alpha1` to `v1`.
2. Do we make `v1alpha1` to `v1` part of the TPR --> CRD change and delay `0.12.0` to tomorrow (hopefully)?

I favour a `0.12.0` now and then a migration because we have the setup for a migration in place and adding a new kind of migration is fairly straight forward. This PR in its current state is trying to migrate to `v1` as part of TPR --> CRD change.