### PR TITLE
tests: Fix jsonnet docker build

### DIFF
--- a/scripts/jenkins/jsonnet/Dockerfile
+++ b/scripts/jenkins/jsonnet/Dockerfile
@@ -1,10 +1,17 @@
 FROM golang:1.8-stretch
 
-ADD https://github.com/google/jsonnet/archive/v0.9.4.tar.gz /tmp
-RUN apt-get update -y && apt-get install -y g++ make git python-pip
-RUN cd /tmp && cd jsonnet-0.9.4 && make && mv jsonnet /usr/local/bin
+ENV JSONNET_VERSION 0.9.4
 
-RUN git clone https://github.com/ksonnet/ksonnet-lib.git /ksonnet-lib && cd /ksonnet-lib && git checkout bd6b2d618d6963ea6a81fcc5623900d8ba110a32
+RUN apt-get update -y && apt-get install -y g++ make git python-pip
+RUN cd /tmp && wget https://github.com/google/jsonnet/archive/v${JSONNET_VERSION}.tar.gz && \
+    tar xvfz v${JSONNET_VERSION}.tar.gz && \
+    cd jsonnet-${JSONNET_VERSION} && \
+    make && mv jsonnet /usr/local/bin && \
+    rm -rf /tmp/v${JSONNET_VERSION}.tar.gz /tmp/jsonnet-${JSONNET_VERSION}
+
+RUN git clone https://github.com/ksonnet/ksonnet-lib.git /ksonnet-lib && \
+    cd /ksonnet-lib && \
+    git checkout bd6b2d618d6963ea6a81fcc5623900d8ba110a32
 
 RUN pip install json2yaml
 RUN mkdir -p /go/src/github.com/coreos/prometheus-operator

--- a/scripts/jenkins/jsonnet/Dockerfile
+++ b/scripts/jenkins/jsonnet/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.8-stretch
 
 ADD https://github.com/google/jsonnet/archive/v0.9.4.tar.gz /tmp
 RUN apt-get update -y && apt-get install -y g++ make git python-pip
-RUN cd /tmp && cd jsonnet-0.9.4 && make && mv jsonnet /usr/local/bin && cd / && rm -rf /tmp/jsonnet-0.9.4
+RUN cd /tmp && cd jsonnet-0.9.4 && make && mv jsonnet /usr/local/bin
 
 RUN git clone https://github.com/ksonnet/ksonnet-lib.git /ksonnet-lib && cd /ksonnet-lib && git checkout bd6b2d618d6963ea6a81fcc5623900d8ba110a32
 

--- a/scripts/jenkins/jsonnet/Dockerfile
+++ b/scripts/jenkins/jsonnet/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.8-stretch
 
 ADD https://github.com/google/jsonnet/archive/v0.9.4.tar.gz /tmp
 RUN apt-get update -y && apt-get install -y g++ make git python-pip
-RUN cd /tmp && tar xvfz v0.9.4.tar.gz && cd jsonnet-0.9.4 && make && mv jsonnet /usr/local/bin && cd / && rm -rf /tmp/jsonnet-0.9.4 /tmp/jsonnet-0.9.4.tar.gz
+RUN cd /tmp && cd jsonnet-0.9.4 && make && mv jsonnet /usr/local/bin && cd / && rm -rf /tmp/jsonnet-0.9.4
 
 RUN git clone https://github.com/ksonnet/ksonnet-lib.git /ksonnet-lib && cd /ksonnet-lib && git checkout bd6b2d618d6963ea6a81fcc5623900d8ba110a32
 


### PR DESCRIPTION
According to the docker file reference [1] `ADD` will unpack recognized
compression formats as a directory. There is no need for us anymore to
unpack jsonnet.

[1] https://docs.docker.com/engine/reference/builder/#add

//CC @bison 