### PR TITLE
Use nodeSelector value in grafana helm chart

### DIFF
--- a/helm/grafana/templates/grafana-deployment.yaml
+++ b/helm/grafana/templates/grafana-deployment.yaml
@@ -76,6 +76,10 @@ spec:
         volumeMounts:
           - name: grafana-dashboards
             mountPath: /var/grafana-dashboards
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+    {{ toYaml .Values.nodeSelector | indent 4 }}
+    {{- end }}
       volumes:
         - name: grafana-storage
           {{- if .Values.storageSpec }}


### PR DESCRIPTION
Currently the `nodeSelector` value is ignored.