### PR TITLE
Require prometheus service url to setup grafana

### DIFF
--- a/helm/grafana/README.md
+++ b/helm/grafana/README.md
@@ -43,6 +43,7 @@ Parameter | Description | Default
 `ingress.fqdn` | Grafana Ingress fully-qualified domain name | `""`
 `ingress.tls` | TLS configuration for Grafana Ingress | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
+`prometheus.serviceURL`| Prometheus service  url. Ex. prometheus-v01.namespace.svc.cluster.local| `{}`
 `resources` | Pod resource requests & limits | `{}`
 `service.annotations` | Annotations to be added to the Grafana Service | `{}`
 `service.clusterIP` | Cluster-internal IP address for Grafana Service | `""`

--- a/helm/grafana/templates/dashboards-configmap.yaml
+++ b/helm/grafana/templates/dashboards-configmap.yaml
@@ -20,6 +20,6 @@ data:
       "basicAuth": false,
       "name": "prometheus",
       "type": "prometheus",
-      "url": "http://{{ printf "%s-%s" .Release.Name "prometheus" }}:9090"
+      "url": "http://{{ required "A valid .Values.prometheus.serviceURL entry required!" .Values.prometheus.serviceURL}}:9090"
     }
   {{- end }}

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -38,6 +38,12 @@ service:
   ##
   type: ClusterIP
 
+## Prometheus
+##
+prometheus:
+  # Prometheus service URL. Ex. prometheus-v01.namespace.svc.cluster.local
+  serviceURL: ""
+  
 ## Grafana Docker image
 ##
 image:


### PR DESCRIPTION
The current prometheus url configuration on grafana is pointing to the grafana release name and not to  prometheus svc. With this patch the user will be forced to fill the right prometheus svc.