### PR TITLE
Update to latest kube-state-metrics

### DIFF
--- a/contrib/kube-prometheus/assets/prometheus/rules/kubelet.rules
+++ b/contrib/kube-prometheus/assets/prometheus/rules/kubelet.rules
@@ -1,5 +1,5 @@
 ALERT K8SNodeNotReady
-  IF kube_node_status_ready{condition="true"} == 0
+  IF kube_node_status_condition{condition="Ready", status="true"} == 0
   FOR 1h
   LABELS {
     severity = "warning",
@@ -11,12 +11,12 @@ ALERT K8SNodeNotReady
 
 ALERT K8SManyNodesNotReady
   IF
-    count(kube_node_status_ready{condition="true"} == 0) > 1
+    count(kube_node_status_condition{condition="Ready", status="true"} == 0) > 1
     AND
       (
-        count(kube_node_status_ready{condition="true"} == 0)
+        count(kube_node_status_condition{condition="Ready", status="true"} == 0)
       /
-        count(kube_node_status_ready{condition="true"})
+        count(kube_node_status_condition{condition="Ready", status="true"})
       ) > 0.2
   FOR 1m
   LABELS {

--- a/contrib/kube-prometheus/assets/prometheus/rules/node.rules
+++ b/contrib/kube-prometheus/assets/prometheus/rules/node.rules
@@ -9,7 +9,7 @@ ALERT NodeExporterDown
     description = "Prometheus could not scrape a node-exporter for more than 10m, or node-exporters have disappeared from discovery.",
   }
 ALERT K8SNodeOutOfDisk
-  IF kube_node_status_out_of_disk{condition="true"} == 1
+  IF kube_node_status_condition{condition"OutOfDisk", status="true"} == 1
   LABELS {
     service = "k8s",
     severity = "critical"
@@ -20,7 +20,7 @@ ALERT K8SNodeOutOfDisk
   }
  
 ALERT K8SNodeMemoryPressure
-  IF kube_node_status_memory_pressure{condition="true"} == 1
+  IF kube_node_status_condition{condition="MemoryPressure", status="true"} == 1
   LABELS {
     service = "k8s",
     severity = "warning"
@@ -31,7 +31,7 @@ ALERT K8SNodeMemoryPressure
   }
  
 ALERT K8SNodeDiskPressure
-  IF kube_node_status_disk_pressure{condition="true"} == 1
+  IF kube_node_status_condition{condition="DiskPressure", status="true"} == 1
   LABELS {
     service = "k8s",
     severity = "warning"

--- a/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-cluster-role.yaml
@@ -11,10 +11,20 @@ rules:
   - resourcequotas
   - replicationcontrollers
   - limitranges
+  - persistentvolumeclaims
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:
   - daemonsets
   - deployments
   - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
   verbs: ["list", "watch"]

--- a/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -12,7 +12,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v0.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.0.0
         ports:
         - name: metrics
           containerPort: 8080

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -328,7 +328,7 @@ data:
       }
   kubelet.rules: |+
     ALERT K8SNodeNotReady
-      IF kube_node_status_ready{condition="true"} == 0
+      IF kube_node_status_condition{condition="Ready", status="true"} == 0
       FOR 1h
       LABELS {
         severity = "warning",
@@ -340,12 +340,12 @@ data:
     
     ALERT K8SManyNodesNotReady
       IF
-        count(kube_node_status_ready{condition="true"} == 0) > 1
+        count(kube_node_status_condition{condition="Ready", status="true"} == 0) > 1
         AND
           (
-            count(kube_node_status_ready{condition="true"} == 0)
+            count(kube_node_status_condition{condition="Ready", status="true"} == 0)
           /
-            count(kube_node_status_ready{condition="true"})
+            count(kube_node_status_condition{condition="Ready", status="true"})
           ) > 0.2
       FOR 1m
       LABELS {
@@ -583,7 +583,7 @@ data:
         description = "Prometheus could not scrape a node-exporter for more than 10m, or node-exporters have disappeared from discovery.",
       }
     ALERT K8SNodeOutOfDisk
-      IF kube_node_status_out_of_disk{condition="true"} == 1
+      IF kube_node_status_condition{condition="OutOfDisk",status="true"} == 1
       LABELS {
         service = "k8s",
         severity = "critical"
@@ -594,7 +594,7 @@ data:
       }
      
     ALERT K8SNodeMemoryPressure
-      IF kube_node_status_memory_pressure{condition="true"} == 1
+      IF kube_node_status_condition{condition="MemoryPressure", status="true"} == 1
       LABELS {
         service = "k8s",
         severity = "warning"
@@ -605,7 +605,7 @@ data:
       }
      
     ALERT K8SNodeDiskPressure
-      IF kube_node_status_disk_pressure{condition="true"} == 1
+      IF kube_node_status_condition{condition="DiskPressure", status="true"} == 1
       LABELS {
         service = "k8s",
         severity = "warning"

--- a/helm/kube-prometheus/charts/exporter-kube-state/Chart.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-state/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-state
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: Cloud Posse LLC
     email: hello@cloudposse.com

--- a/helm/kube-prometheus/charts/exporter-kube-state/templates/configmap.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-state/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
     # NOTE: These rules were kindly contributed by the SoundCloud engineering team.
 
     ALERT K8SNodeNotReady
-      IF kube_node_status_ready{condition="true"} == 0
+      IF kube_node_status_condition{condition="Ready", status="true"} == 0
       FOR 1h
       LABELS {
         service = "k8s",
@@ -26,12 +26,12 @@ data:
 
     ALERT K8SManyNodesNotReady
       IF
-        count by (cluster) (kube_node_status_ready{condition="true"} == 0) > 1
+        count by (cluster) (kube_node_status_condition{condition="Ready", status="true"} == 0) > 1
         AND
           (
-            count by (cluster) (kube_node_status_ready{condition="true"} == 0)
+            count by (cluster) (kube_node_status_condition{condition="Ready", status="true"} == 0)
           /
-            count by (cluster) (kube_node_status_ready{condition="true"})
+            count by (cluster) (kube_node_status_condition{condition="Ready", status="true"})
           ) > 0.2
       FOR 1m
       LABELS {

--- a/helm/kube-prometheus/charts/exporter-kube-state/values.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-state/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: gcr.io/google_containers/kube-state-metrics
-  tag: v0.3.0
+  tag: v1.0.0
   pullPolicy: IfNotPresent
 service:
   name: nginx


### PR DESCRIPTION
I updated to this release on our QA cluster.  I visually checked the kube-prometheus grafana dashboards and prometheus alerts and didn't see anything broken.  So I think it is safe to default to v1.0.0.