### PR TITLE
allow params to be set for metrics endpoints

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -91,7 +91,7 @@ Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 | targetPort | Name or number of the target port of the endpoint. Mutually exclusive with port. | intstr.IntOrString | false |
 | path | HTTP path to scrape for metrics. | string | false |
 | scheme | HTTP scheme to use for scraping. | string | false |
-| params | Optional HTTP URL parameters | map[string]\[]string | false |
+| params | Optional HTTP URL parameters | map[string][]string | false |
 | interval | Interval at which metrics should be scraped | string | false |
 | scrapeTimeout | Timeout after which the scrape is ended | string | false |
 | tlsConfig | TLS configuration to use when scraping the endpoint | *[TLSConfig](#tlsconfig) | false |

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -91,6 +91,7 @@ Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 | targetPort | Name or number of the target port of the endpoint. Mutually exclusive with port. | intstr.IntOrString | false |
 | path | HTTP path to scrape for metrics. | string | false |
 | scheme | HTTP scheme to use for scraping. | string | false |
+| params | Optional HTTP URL parameters | map[string]\[]string | false |
 | interval | Interval at which metrics should be scraped | string | false |
 | scrapeTimeout | Timeout after which the scrape is ended | string | false |
 | tlsConfig | TLS configuration to use when scraping the endpoint | *[TLSConfig](#tlsconfig) | false |

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -198,6 +198,8 @@ type Endpoint struct {
 	Path string `json:"path,omitempty"`
 	// HTTP scheme to use for scraping.
 	Scheme string `json:"scheme,omitempty"`
+	// Optional HTTP URL parameters
+	Params map[string][]string `json:"params,omitempty"`
 	// Interval at which metrics should be scraped
 	Interval string `json:"interval,omitempty"`
 	// Timeout after which the scrape is ended

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -159,6 +159,9 @@ func generateServiceMonitorConfig(version semver.Version, m *v1.ServiceMonitor, 
 	if ep.Path != "" {
 		cfg = append(cfg, yaml.MapItem{Key: "metrics_path", Value: ep.Path})
 	}
+	if ep.Params != nil {
+		cfg = append(cfg, yaml.MapItem{Key: "params", Value: ep.Params})
+	}
 	if ep.Scheme != "" {
 		cfg = append(cfg, yaml.MapItem{Key: "scheme", Value: ep.Scheme})
 	}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -139,5 +139,31 @@ func makeServiceMonitors() map[string]*monitoringv1.ServiceMonitor {
 		},
 	}
 
+	res["servicemonitor3"] = &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testservicemonitor3",
+			Namespace: "default",
+			Labels: map[string]string{
+				"group": "group4",
+			},
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"group":  "group4",
+					"group3": "group5",
+				},
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				monitoringv1.Endpoint{
+					Port:     "web",
+					Interval: "30s",
+					Path:     "/federate",
+					Params:   map[string][]string{"metrics[]": []string{"{__name__=~\"job:.*\"}"}},
+				},
+			},
+		},
+	}
+
 	return res
 }


### PR DESCRIPTION
On [the prometheus configuration page](https://prometheus.io/docs/operating/configuration/), there is a config for setting HTTP GET params. This is required if one wants to federate prometheuses _(promethei?)_. I had tried just making the ServiceMonitor's path like `/federate?match[]={__name__=~".+"}`, but it looked as if it was getting URL encoded, unless I'm doing this wrong somehow.

With this PR, then it'd be just setting up a `ServiceMonitor` to federate another prometheus and grab all metrics like so

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: k8s-prometheus
  labels:
    team: infra
spec:
  selector:
    matchLabels:
      prometheus: k8s
  namespaceSelector:
    matchNames:
    - kube-public
  endpoints:
  - port: web
    interval: 30s
    path: '/federate'
    params:
      'match[]':
      - '{__name__=~".+"}'      
    honorLabels: true
```
Not that I'm a fan of prom's `params` syntax, but that's how it could be done.
