### PR TITLE
Bump node-exporter to a stable version

### DIFF
--- a/helm/kube-prometheus/charts/exporter-node/values.yaml
+++ b/helm/kube-prometheus/charts/exporter-node/values.yaml
@@ -3,7 +3,7 @@
 replicaCount: 1
 image:
   repository: quay.io/prometheus/node-exporter
-  tag: v0.13.0
+  tag: v0.14.0
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP


### PR DESCRIPTION
When bootstraping node-exporter with the kube-prometheus helm chart I got an error 

```
time="2017-08-14T13:05:51Z" level=error msg="ERROR: hwmon collector failed after 0.000024s: open /host/sys/class/hwmon: no such file or directory" source="node_exporter.go:91" 
```

Node-exporter already fixed this [issue](https://github.com/prometheus/node_exporter/issues/430) on v0.14