### PR TITLE
Scrapes cadvisor port metrics

### DIFF
--- a/helm/kube-prometheus/charts/exporter-kubelets/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-kubelets/templates/servicemonitor.yaml
@@ -27,3 +27,7 @@ spec:
       # for the kubelet on API server nodes fail.
       insecureSkipVerify: true
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  - port: cadvisor
+    interval: 30s
+    honorLabels: true
+        


### PR DESCRIPTION
#477 didn't applied the same rules for the kube-prometheus chart