### PR TITLE
Set SecurityContext on Prometheus StatefulSet

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -277,6 +277,7 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 	}
 
 	var promArgs []string
+	var securityContext v1.PodSecurityContext
 
 	switch version.Major {
 	case 1:
@@ -311,6 +312,8 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 				"-storage.local.target-heap-size="+fmt.Sprintf("%d", reqMem.Value()/3*2),
 			)
 		}
+
+		securityContext = v1.PodSecurityContext{}
 	case 2:
 
 		// Prometheus 2.0 is in alpha and is highly experimental, and therefore
@@ -327,6 +330,15 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 			"-storage.tsdb.path=/var/prometheus/data",
 			"-storage.tsdb.retention="+p.Spec.Retention,
 		)
+
+		gid := int64(2000)
+		uid := int64(1000)
+		nr := true
+		securityContext = v1.PodSecurityContext{
+			FSGroup: &gid,
+			RunAsNonRoot: &nr,
+			RunAsUser: &uid,
+		}
 	default:
 		return nil, errors.Errorf("unsupported Prometheus major version %s", version)
 	}
@@ -427,15 +439,6 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 			Path: path.Clean(webRoutePrefix + "/status"),
 			Port: intstr.FromString("web"),
 		},
-	}
-
-	gid := int64(2000)
-	uid := int64(1000)
-	nr := true
-	securityContext := v1.PodSecurityContext{
-		FSGroup: &gid,
-		RunAsNonRoot: &nr,
-		RunAsUser: &uid,
 	}
 
 	return &v1beta1.StatefulSetSpec{

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -429,6 +429,15 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 		},
 	}
 
+	gid := int64(2000)
+	uid := int64(1000)
+	nr := true
+	securityContext := v1.PodSecurityContext{
+		FSGroup: &gid,
+		RunAsNonRoot: &nr,
+		RunAsUser: &uid,
+	}
+
 	return &v1beta1.StatefulSetSpec{
 		ServiceName: governingServiceName,
 		Replicas:    p.Spec.Replicas,
@@ -485,6 +494,7 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 						},
 					},
 				},
+				SecurityContext:               &securityContext,
 				ServiceAccountName:            p.Spec.ServiceAccountName,
 				NodeSelector:                  p.Spec.NodeSelector,
 				TerminationGracePeriodSeconds: &terminationGracePeriod,


### PR DESCRIPTION
Currently, when the Prometheus Operator is configured to use persistent storage on a cluster configured to use dynamic volume provisioning, pods on the Prometheus StatefulSet fail to launch due to a permissions error when accessing the storage mount point.

```
time="2017-08-04T16:56:37Z" level=info msg="Starting prometheus (version=2.0.0-beta.0, branch=master, revision=2b5d9159537cbd123219296121e05244e26c0940)" source="main.go:202" 
time="2017-08-04T16:56:37Z" level=info msg="Build context (go=go1.8.3, user=root@fc24486243df, date=20170712-12:21:13)" source="main.go:203" 
time="2017-08-04T16:56:37Z" level=info msg="Host details (Linux 4.11.11-coreos #1 SMP Tue Jul 18 23:06:59 UTC 2017 x86_64 prometheus-k8s-0 (none))" source="main.go:204" 
time="2017-08-04T16:56:37Z" level=info msg="Starting tsdb" source="main.go:216" 
time="2017-08-04T16:56:37Z" level=error msg="Opening storage failed: open DB in /var/prometheus/data: open /var/prometheus/data/969552713: permission denied" source="main.go:219"
```

Setting the following SecurityContext on the Prometheus StatefulSet allow the pods to access the storage mount point when using dynamically provisioned volumes:

```yaml
securityContext:
  fsGroup: 2000
  runAsUser: 1000
  runAsNonRoot: true
```
```
time="2017-08-07T19:49:45Z" level=info msg="Starting prometheus (version=2.0.0-beta.0, branch=master, revision=2b5d9159537cbd123219296121e05244e26c0940)" source="main.go:202" 
time="2017-08-07T19:49:45Z" level=info msg="Build context (go=go1.8.3, user=root@fc24486243df, date=20170712-12:21:13)" source="main.go:203" 
time="2017-08-07T19:49:45Z" level=info msg="Host details (Linux 4.11.11-coreos #1 SMP Tue Jul 18 23:06:59 UTC 2017 x86_64 prometheus-k8s-0 (none))" source="main.go:204" 
time="2017-08-07T19:49:45Z" level=info msg="Starting tsdb" source="main.go:216" 
time="2017-08-07T19:49:50Z" level=info msg="tsdb started" source="main.go:222
...
```
Fixes #541 