### PR TITLE
Enable Lifecycle API on Prometheus 2.0.0-beta.0 and up

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -327,13 +327,6 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 			"-storage.tsdb.path=/var/prometheus/data",
 			"-storage.tsdb.retention="+p.Spec.Retention,
 		)
-
-		if len(version.Pre) > 0 && version.Pre[0].VersionStr == "alpha" {
-			break
-		}
-		promArgs = append(promArgs,
-			"-web.enable-lifecycle",
-		)
 	default:
 		return nil, errors.Errorf("unsupported Prometheus major version %s", version)
 	}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -485,6 +485,7 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 						},
 					},
 				},
+				HostPID:                       true,
 				ServiceAccountName:            p.Spec.ServiceAccountName,
 				NodeSelector:                  p.Spec.NodeSelector,
 				TerminationGracePeriodSeconds: &terminationGracePeriod,

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -327,6 +327,13 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 			"-storage.tsdb.path=/var/prometheus/data",
 			"-storage.tsdb.retention="+p.Spec.Retention,
 		)
+
+		if len(version.Pre) > 0 && version.Pre[0].VersionStr == "alpha" {
+			break
+		}
+		promArgs = append(promArgs,
+			"-web.enable-lifecycle",
+		)
 	default:
 		return nil, errors.Errorf("unsupported Prometheus major version %s", version)
 	}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -65,7 +65,6 @@ var (
 		"v1.6.3",
 		"v1.7.0",
 		"v1.7.1",
-		"v2.0.0-alpha.3",
 		"v2.0.0-beta.0",
 	}
 )
@@ -326,12 +325,6 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 			"-config.file=/etc/prometheus/config/prometheus.yaml",
 			"-storage.tsdb.path=/var/prometheus/data",
 			"-storage.tsdb.retention="+p.Spec.Retention,
-		)
-
-		if len(version.Pre) > 0 && version.Pre[0].VersionStr == "alpha" {
-			break
-		}
-		promArgs = append(promArgs,
 			"-web.enable-lifecycle",
 		)
 	default:

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -327,6 +327,13 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 			"-storage.tsdb.path=/var/prometheus/data",
 			"-storage.tsdb.retention="+p.Spec.Retention,
 		)
+
+		if len(version.Pre) > 0 && version.Pre[0].VersionStr == "alpha" {
+			break
+		}
+		promArgs = append(promArgs,
+			"-web.enable-lifecycle",
+		)
 	default:
 		return nil, errors.Errorf("unsupported Prometheus major version %s", version)
 	}
@@ -485,7 +492,6 @@ func makeStatefulSetSpec(p v1alpha1.Prometheus, c *Config, ruleConfigMaps []*v1.
 						},
 					},
 				},
-				HostPID:                       true,
 				ServiceAccountName:            p.Spec.ServiceAccountName,
 				NodeSelector:                  p.Spec.NodeSelector,
 				TerminationGracePeriodSeconds: &terminationGracePeriod,


### PR DESCRIPTION
The Lifecycle API is disabled by default starting with Prometheus v2.0.0-beta.0, causing the config reloader to error out:

```
ts=2017-08-15T19:12:35Z caller=main.go:214 component=volume-watcher msg="Reloading Prometheus temporarily failed." err="Received response code %!s(int=403), expected 200" next-retry=25.169469033s
```

This PR adds a flag to Prometheus to enable the Lifecycle API on v2.0.0-beta.0 and higher, allowing the config reloader to work correctly:

```
ts=2017-08-16T15:59:20Z caller=main.go:219 component=volume-watcher msg="Prometheus successfully reloaded."
```