### PR TITLE
helm/prometheus: allow for configuration of PrometheusSpec secrets

### DIFF
--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -59,6 +59,7 @@ Parameter | Description | Default
 `retention` | How long to retain metrics | `24h`
 `routePrefix` | Prefix used to register routes, overriding externalUrl route | `/`
 `rules` | Prometheus alerting & recording rules | `{}`
+`secrets` | List of Secrets in the same namespace as the Prometheus object, which shall be mounted into the Prometheus Pods. | `{}`
 `service.annotations` | Annotations to be added to the Prometheus Service | `{}`
 `service.clusterIP` | Cluster-internal IP address for Prometheus Service | `""`
 `service.externalIPs` | List of external IP addresses at which the Prometheus Service will be available | `[]`

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -44,6 +44,10 @@ spec:
 {{- if .Values.routePrefix }}
   routePrefix: "{{ .Values.routePrefix }}"
 {{- end }}
+{{- if .Values.secrets }}
+  secrets:
+{{ toYaml .Values.secrets | indent 4 }}
+{{- end }}
 {{- if .Values.rbacEnable }}
   serviceAccountName: {{ template "fullname" . }}
 {{- end }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -96,6 +96,12 @@ rules:
   specifiedInValues: true
   value: {}
 
+## List of Secrets in the same namespace as the Prometheus
+## object, which shall be mounted into the Prometheus Pods.
+## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+##
+secrets: {}
+
 service:
   ## Annotations to be added to the Service
   ##


### PR DESCRIPTION
Adds `secrets` configuration to the prometheus chart