### PR TITLE
Remove port name of Grafana service for compatibility with kubectl proxy

### DIFF
--- a/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: grafana

--- a/contrib/kube-prometheus/manifests/grafana/grafana-service.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-service.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - name: web
-    port: 3000
+  - port: 3000
     protocol: TCP
     nodePort: 30902
+    targetPort: web
   selector:
     app: grafana


### PR DESCRIPTION
Remove the port name for the Grafana service so that you can access Kibana via `kubectl proxy` at http://localhost:8001/api/v1/proxy/namespaces/monitoring/services/grafana, without the `:web` suffix as is required if the port is named.