### PR TITLE
Create prometheus-k8s-controller-service.yaml

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-controller-service.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-controller-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: kube-controller-manager
+  name: kube-controller-manager
+  namespace: kube-system
+spec:
+  ports:
+  - name: http-metrics
+    port: 10252
+    targetPort: 10252
+  selector:
+    k8s-app: kube-controller


### PR DESCRIPTION
[ kube-prometheus ] Kubernetes scheduler and controller manager pods have no service which match the related kube-prometheus servicemonitor #583