### PR TITLE
Create prometheus-k8s-scheduler-service.yaml

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-scheduler-service.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-scheduler-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: kube-scheduler
+  name: kube-scheduler
+  namespace: kube-system
+spec:
+  ports:
+  - name: http-metrics
+    port: 10251
+    targetPort: 10251
+  selector:
+    k8s-app: kube-scheduler


### PR DESCRIPTION
[ kube-prometheus ] Kubernetes scheduler and controller manager pods have no service which match the related kube-prometheus servicemonitor #583