### PR TITLE
kube-prometheus: bump kube-state-metrics to v1.0.1 release

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -207,10 +207,16 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.0.0
+        image: quay.io/coreos/kube-state-metrics:v1.0.1
         ports:
         - name: metrics
           containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
         resources:
           requests:
             memory: 100Mi
@@ -218,7 +224,33 @@ spec:
           limits:
             memory: 200Mi
             cpu: 200m
-
+      - name: addon-resizer
+        image: gcr.io/google_containers/addon-resizer:1.0
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 30Mi
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+          - /pod_nanny
+          - --container=kube-state-metrics
+          - --cpu=100m
+          - --extra-cpu=1m
+          - --memory=100Mi
+          - --extra-memory=2Mi
+          - --threshold=5
+          - --deployment=kube-state-metrics
 ```
 
 > Make sure that the `ServiceAccount` called `kube-state-metrics` exists and if using RBAC, is bound to the correct role. See the kube-state-metrics [repository for RBAC requirements](https://github.com/kubernetes/kube-state-metrics/tree/master/kubernetes).

--- a/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -12,10 +12,16 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.0.0
+        image: quay.io/coreos/kube-state-metrics:v1.0.1
         ports:
         - name: metrics
           containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
         resources:
           requests:
             memory: 100Mi
@@ -23,4 +29,30 @@ spec:
           limits:
             memory: 200Mi
             cpu: 200m
-
+      - name: addon-resizer
+        image: gcr.io/google_containers/addon-resizer:1.0
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 30Mi
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+          - /pod_nanny
+          - --container=kube-state-metrics
+          - --cpu=100m
+          - --extra-cpu=1m
+          - --memory=100Mi
+          - --extra-memory=2Mi
+          - --threshold=5
+          - --deployment=kube-state-metrics

--- a/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-role-binding.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-state-metrics-resizer
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+

--- a/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-role.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: kube-state-metrics-resizer
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get"]
+- apiGroups: ["extensions"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
+


### PR DESCRIPTION
This bumps kube-state-metrics to the latest release as well as introduced the addon-resizer for it.

@fabxc 