### PR TITLE
PrometheusSpec: add ObjectMeta field that propagates labels and annotations to prometheus Pods.

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -134,6 +134,7 @@ Specification of the desired behavior of the Prometheus cluster. More info: http
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
+| podMetadata | Standard object’s metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | [metav1.ObjectMeta](https://kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
 | serviceMonitorSelector | ServiceMonitors to be selected for target discovery. | *[metav1.LabelSelector](https://kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | false |
 | version | Version of Prometheus to be deployed. | string | false |
 | paused | When a Prometheus deployment is paused, no actions except for deletion will be performed on the underlying objects. | bool | false |

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -49,6 +49,10 @@ type PrometheusList struct {
 // Specification of the desired behavior of the Prometheus cluster. More info:
 // http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status
 type PrometheusSpec struct {
+	// Standard object’s metadata. More info:
+	// http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+	// Metadata Labels and Annotations gets propagated to the prometheus pods.
+	PodMetadata metav1.ObjectMeta `json:"podMetadata,omitempty"`
 	// ServiceMonitors to be selected for target discovery.
 	ServiceMonitorSelector *metav1.LabelSelector `json:"serviceMonitorSelector,omitempty"`
 	// Version of Prometheus to be deployed.

--- a/pkg/client/monitoring/v1alpha1/types.go
+++ b/pkg/client/monitoring/v1alpha1/types.go
@@ -49,6 +49,10 @@ type PrometheusList struct {
 // Specification of the desired behavior of the Prometheus cluster. More info:
 // http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status
 type PrometheusSpec struct {
+	// Standard object’s metadata. More info:
+	// http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+	// Metadata Labels and Annotations gets propagated to the prometheus pods.
+	PodMetadata metav1.ObjectMeta `json:"podMetadata,omitempty"`
 	// ServiceMonitors to be selected for target discovery.
 	ServiceMonitorSelector *metav1.LabelSelector `json:"serviceMonitorSelector,omitempty"`
 	// Version of Prometheus to be deployed.

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -39,8 +39,7 @@ const (
 	governingServiceName = "prometheus-operated"
 	DefaultVersion       = "v1.7.1"
 	defaultRetention     = "24h"
-
-	configMapsFilename = "configmaps.json"
+	configMapsFilename   = "configmaps.json"
 )
 
 var (
@@ -440,7 +439,18 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMaps []
 			Port: intstr.FromString("web"),
 		},
 	}
-
+	podAnnotations := map[string]string{}
+	podLabels := map[string]string{}
+	for k, v := range p.Spec.PodMetadata.Labels {
+		// ToDo: define which labels can be set and sanitize them.
+		podLabels[k] = v
+	}
+	podLabels["app"] = "prometheus"
+	podLabels["prometheus"] = p.Name
+	for k, v := range p.Spec.PodMetadata.Annotations {
+		// ToDo: define which annotations can be set and sanitize them.
+		podAnnotations[k] = v
+	}
 	return &v1beta1.StatefulSetSpec{
 		ServiceName: governingServiceName,
 		Replicas:    p.Spec.Replicas,
@@ -449,10 +459,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMaps []
 		},
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"app":        "prometheus",
-					"prometheus": p.Name,
-				},
+				Labels:      podLabels,
+				Annotations: podAnnotations,
 			},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{


### PR DESCRIPTION
New field in PrometheusSpec IamRole will allow users to specify
IAM role to be used by the prometheus pod, this requires kube2iam
for the pod to be able to assume the IAM role.

Fixes #580