### PR TITLE
Changed TPR to CRD in Documentation

### DIFF
--- a/Documentation/design.md
+++ b/Documentation/design.md
@@ -17,9 +17,9 @@ The custom resources that the Prometheus Operator introduces are:
 
 The `Prometheus` custom resource definition (CRD) declaratively defines a desired Prometheus setup to run in a Kubernetes cluster. It provides options to configure replication, persistent storage, and Alertmanagers to which the deployed Prometheus instances send alerts to.
 
-For each `Prometheus` TPR, the Operator deploys a properly configured `StatefulSet` in the same namespace. The Prometheus `Pod`s are configured to mount a `Secret` called `<prometheus-name>` containing the configuration for Prometheus.
+For each `Prometheus` resource, the Operator deploys a properly configured `StatefulSet` in the same namespace. The Prometheus `Pod`s are configured to mount a `Secret` called `<prometheus-name>` containing the configuration for Prometheus.
 
-The TPR allows to specify which `ServiceMonitor`s should be covered by the deployed Prometheus instances based on label selection. The Operator then generates a configuration based on the included `ServiceMonitor`s and updates it in the `Secret` containing the configuration. It continuously does so for all changes that are made to `ServiceMonitor`s or the `Prometheus` TPR itself.
+The CRD specifies which `ServiceMonitor`s should be covered by the deployed Prometheus instances based on label selection. The Operator then generates a configuration based on the included `ServiceMonitor`s and updates it in the `Secret` containing the configuration. It continuously does so for all changes that are made to `ServiceMonitor`s or the `Prometheus` resource itself.
 
 If no selection of `ServiceMonitor`s is provided, the Operator leaves management of the `Secret` to the user, which allows to provide custom configurations while still benefiting from the Operator's capabilities of managing Prometheus setups.
 
@@ -35,14 +35,14 @@ The `ServiceMonitor` object introduced by the Prometheus Operator in turn discov
 
 The `endpoints` section of the `ServiceMonitorSpec`, is used to configure which ports of these `Endpoints` are going to be scraped for metrics, and with which parameters. For advanced use cases one may want to monitor ports of backing `Pod`s, which are not directly part of the service endpoints. Therefore when specifying an endpoint in the `endpoints` section, they are strictly used.
 
-> Note: `endpoints` (lowercase) is the TPR field, while `Endpoints` (capitalized) is the Kubernetes object kind.
+> Note: `endpoints` (lowercase) is the field in the `ServiceMonitor` CRD, while `Endpoints` (capitalized) is the Kubernetes object kind.
 
-While `ServiceMonitor`s must live in the same namespace as the `Prometheus` TPR, discovered targets may come from any namespace. This is important to allow cross-namespace monitoring use cases, e.g. for meta-monitoring. Using the `namespaceSelector` of the `ServiceMonitorSpec`, one can restrict the namespaces the `Endpoints` objects are allowed to be discovered from.
+While `ServiceMonitor`s must live in the same namespace as the `Prometheus` resource, discovered targets may come from any namespace. This is important to allow cross-namespace monitoring use cases, e.g. for meta-monitoring. Using the `namespaceSelector` of the `ServiceMonitorSpec`, one can restrict the namespaces the `Endpoints` objects are allowed to be discovered from.
 
 ## Alertmanager
 
 The `Alertmanager` custom resource definition (CRD) declaratively defines a desired Alertmanager setup to run in a Kubernetes cluster. It provides options to configure replication and persistent storage.
 
-For each `Alertmanager` TPR, the Operator deploys a properly configured `StatefulSet` in the same namespace. The Alertmanager pods are configured to include a `Secret` called `<alertmanager-name>` which holds the used configuration file in the key `alertmanager.yaml`.
+For each `Alertmanager` resource, the Operator deploys a properly configured `StatefulSet` in the same namespace. The Alertmanager pods are configured to include a `Secret` called `<alertmanager-name>` which holds the used configuration file in the key `alertmanager.yaml`.
 
 When there are two or more configured replicas the operator runs the Alertmanager instances in high availability mode.

--- a/Documentation/user-guides/running-exporters.md
+++ b/Documentation/user-guides/running-exporters.md
@@ -67,7 +67,7 @@ This ServiceMonitor targets **all** Services with the label `k8s-app` (`spec.sel
 ### Namespace "limits"/things to keep in mind
 See the ServiceMonitor Documentation:
 > While `ServiceMonitor`s must live in the same namespace as the `Prometheus`
-TPR, discovered targets may come from any namespace. This is important to allow
+resource, discovered targets may come from any namespace. This is important to allow
 cross-namespace monitoring use cases, e.g. for meta-monitoring. Using the
 `namespaceSelector` of the `ServiceMonitorSpec`, one can restrict the
 namespaces the `Endpoints` objects are allowed to be discovered from.

--- a/Documentation/user-guides/storage.md
+++ b/Documentation/user-guides/storage.md
@@ -58,7 +58,7 @@ When now creating the `Prometheus` object a `PersistentVolumeClaim` is used for 
 
 ## Manual storage provisioning
 
-The Prometheus TPR specification allows you to support arbitrary storage, via a PersistentVolumeClaim.
+The Prometheus CRD specification allows you to support arbitrary storage, via a PersistentVolumeClaim.
 
 The easiest way to use a volume that cannot be automatically provisioned (for whatever reason) is to use a label selector alongside a manually created PersistentVolume.
 

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -239,7 +239,7 @@ prometheus:
   ##
   serviceMonitorsSelector: {}
 
-  ## ServiceMonitor TPRs to create & be scraped by the Prometheus instance.
+  ## ServiceMonitor CRDs to create & be scraped by the Prometheus instance.
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/service-monitor.md
   ##
   serviceMonitors: []

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -139,7 +139,7 @@ service:
 ##
 serviceMonitorsSelector: {}
 
-## ServiceMonitor TPRs to create & be scraped by the Prometheus instance.
+## ServiceMonitor CRDs to create & be scraped by the Prometheus instance.
 ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/service-monitor.md
 ##
 serviceMonitors: []


### PR DESCRIPTION
I noticed that most references to TPR in the design doc had been updated to CRD, but not all of them.

This PR replaces TPR with CRD or resource throughout the documentation.