### PR TITLE
kube-prometheus: exclude pod log subresource from latency alerts

### DIFF
--- a/contrib/kube-prometheus/assets/prometheus/rules/kube-apiserver.rules
+++ b/contrib/kube-prometheus/assets/prometheus/rules/kube-apiserver.rules
@@ -16,7 +16,7 @@ ALERT K8SApiserverDown
 ALERT K8SApiServerLatency
   IF histogram_quantile(
       0.99,
-      sum without (instance,resource) (apiserver_request_latencies_bucket{verb!~"CONNECT|WATCHLIST|WATCH|PROXY"})
+      sum without (instance,resource) (apiserver_request_latencies_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY"})
     ) / 1e6 > 1.0
   FOR 10m
   LABELS {

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -304,7 +304,7 @@ data:
     ALERT K8SApiServerLatency
       IF histogram_quantile(
           0.99,
-          sum without (instance,resource) (apiserver_request_latencies_bucket{verb!~"CONNECT|WATCHLIST|WATCH|PROXY"})
+          sum without (instance,resource) (apiserver_request_latencies_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY"})
         ) / 1e6 > 1.0
       FOR 10m
       LABELS {


### PR DESCRIPTION
Fixes #560

@fabxc 

/cc @eedugon @dmcnaught 