### PR TITLE
tests: Reduce amount of kept builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ job('po-tests-pr') {
     concurrentBuild()
 
     // logRotator(daysToKeep, numberToKeep)
-    logRotator(10, 10)
+    logRotator(30, 10)
 
     parameters {
         stringParam('sha1')
@@ -82,7 +82,7 @@ job('po-tests-master') {
     concurrentBuild()
 
     // logRotator(daysToKeep, numberToKeep)
-    logRotator(30, 30)
+    logRotator(30, 5)
 
     scm {
         git {


### PR DESCRIPTION
This PR reduces the amount of builds again. In addition it keeps all PR
builds for at least one month, so long running community PRs don't loose
their test logs.

@brancz Let me know if these numbers are still ok for you?