### PR TITLE
A few fixes for kube-prometheus chart

### DIFF
--- a/helm/kube-prometheus/charts/exporter-kube-api/templates/configmap.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-api/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
     ALERT K8SApiServerLatency
       IF histogram_quantile(
           0.99,
-          sum without (instance,node,resource) (apiserver_request_latencies_bucket{verb!~"CONNECT|WATCHLIST|WATCH"})
+          sum without (instance,node,resource) (apiserver_request_latencies_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH"})
         ) / 1e6 > 1.0
       FOR 10m
       LABELS {
@@ -99,4 +99,3 @@ data:
         summary = "{{`{{ $labels.job }}`}} has too many open file descriptors",
         description = "{{`{{ $labels.node }}`}} is using {{`{{ $value }}`}}% of the available file/socket descriptors.",
       }
-

--- a/helm/kube-prometheus/charts/exporter-kube-state/templates/deployment.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-state/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+        component: kube-state
+        release: {{ .Release.Name }}
         version: "{{ .Values.image.tag }}"
     spec:
       containers:

--- a/helm/kube-prometheus/charts/exporter-kube-state/templates/service.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-state/templates/service.yaml
@@ -16,4 +16,6 @@ spec:
     protocol: TCP
     name: {{ .Values.service.name }}
   selector:
-    app: {{ .Chart.Name }}
+    app: {{ template "fullname" . }}
+    component: kube-state
+    release: {{ .Release.Name }}

--- a/helm/kube-prometheus/charts/exporter-node/templates/configmap.yaml
+++ b/helm/kube-prometheus/charts/exporter-node/templates/configmap.yaml
@@ -66,3 +66,36 @@ data:
         summary = "Node does not have the correct conntrack tunings",
         description = "Nodes keep un-setting the correct tunings, investigate when it happens.",
       }
+
+    ALERT K8SNodeOutOfDisk
+      IF kube_node_status_condition{condition="OutOfDisk", status="true"} == 1
+      LABELS {
+        service = "k8s",
+        severity = "critical"
+      }
+      ANNOTATIONS {
+        summary = "Node ran out of disk space.",
+        description = "{{`{{ $labels.node }}`}} has run out of disk space.",
+      }
+
+    ALERT K8SNodeMemoryPressure
+      IF kube_node_status_condition{condition="MemoryPressure", status="true"} == 1
+      LABELS {
+        service = "k8s",
+        severity = "warning"
+      }
+      ANNOTATIONS {
+        summary = "Node is under memory pressure.",
+        description = "{{`{{ $labels.node }}`}} is under memory pressure.",
+      }
+
+    ALERT K8SNodeDiskPressure
+      IF kube_node_status_condition{condition="DiskPressure", status="true"} == 1
+      LABELS {
+        service = "k8s",
+        severity = "warning"
+      }
+      ANNOTATIONS {
+        summary = "Node is under disk pressure.",
+        description = "{{`{{ $labels.node }}`}} is under disk pressure.",
+      }


### PR DESCRIPTION
* Synced the K8SApiServerLatency ALERT with 858fa3e44d8c50d4d74dcba38a63afce601cbc75 so it ignores "log" subresource
* Fixed labels and selectors on the kube-state subchart
* Synced a few more node alerts from ae861894ba8765a1798cb1c9d4b910fd70506626 / edb7b932ffacc3332c1b0927348386c5d02150a6