### PR TITLE
kube-prometheus: add tolerations to node-exporter chart

### DIFF
--- a/helm/kube-prometheus/charts/exporter-node/templates/deamonset.yaml
+++ b/helm/kube-prometheus/charts/exporter-node/templates/deamonset.yaml
@@ -36,6 +36,9 @@ spec:
             - name: sys
               mountPath: /host/sys
               readOnly: true
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       hostNetwork: true
       hostPID: true
       volumes:


### PR DESCRIPTION
* add tolerations to allow node-exporter running on all nodes
* Sync from e87acbd88b57fe2cf8dfcb7e403a68e3eb3444d5