### PR TITLE
tests: Add cleanup job to remove old docker images periodically

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,3 +153,29 @@ job('po-tests-master') {
         wsCleanup()
     }
 }
+
+job('cleanup') {
+    // logRotator(daysToKeep, numberToKeep)
+    logRotator(30, 2)
+
+    triggers {
+        cron('@weekly')
+    }
+
+    steps {
+        shell('docker system prune -a -f')
+        shell('docker system df')
+    }
+
+    publishers {
+        slackNotifier {
+            room('#team-monitoring')
+            teamDomain('coreos')
+            authTokenCredentialId('team-monitoring-slack-jenkins')
+            notifyFailure(true)
+            notifyRegression(true)
+            notifyRepeatedFailure(true)
+        }
+        wsCleanup()
+    }
+}


### PR DESCRIPTION
As our Jenkins worker is running out of disk space quickly, we should remove all unneeded docker images periodically.

@bison Thanks for the hint!