### PR TITLE
charts: Allow custom labels on prometheus and alertmanager

### DIFF
--- a/helm/alertmanager/templates/alertmanager.yaml
+++ b/helm/alertmanager/templates/alertmanager.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
   name: {{ .Release.Name }}
 spec:
   baseImage: "{{ .Values.image.repository }}"

--- a/helm/alertmanager/templates/ingress.yaml
+++ b/helm/alertmanager/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
   name: {{ template "fullname" . }}
 spec:
   rules:

--- a/helm/alertmanager/templates/service.yaml
+++ b/helm/alertmanager/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
   name: {{ template "fullname" . }}
 spec:
   clusterIP: "{{ .Values.service.clusterIP }}"

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -27,6 +27,10 @@ image:
   repository: quay.io/prometheus/alertmanager
   tag: v0.7.1
 
+## Labels to be added to the Alertmanager
+##
+labels: {}
+
 ingress:
   ## If true, Alertmanager Ingress will be created
   ##
@@ -37,6 +41,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+
+  ## Labels to be added to the Ingress
+  ##
+  labels: {}
 
   fqdn: ""
 
@@ -80,6 +88,10 @@ service:
   ## List of external IP addresses at which the Alertmanager Service will be available
   ##
   externalIPs: []
+
+  ## Labels to be added to the Service
+  ##
+  labels: {}
 
   ## External IP address to assign to Alertmanager Service
   ## Only used if service.type is 'LoadBalancer' and supported by cloud provider

--- a/helm/prometheus/templates/ingress.yaml
+++ b/helm/prometheus/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
   name: {{ template "fullname" . }}
 spec:
   rules:

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -7,6 +7,9 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
   name: {{ .Release.Name }}
 spec:
 {{- if .Values.alertingEndpoints }}

--- a/helm/prometheus/templates/service.yaml
+++ b/helm/prometheus/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
   name: {{ template "fullname" . }}
 spec:
   clusterIP: "{{ .Values.service.clusterIP }}"

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -29,6 +29,10 @@ image:
   repository: quay.io/prometheus/prometheus
   tag: v1.7.1
 
+## Labels to be added to the Prometheus
+##
+labels: {}
+
 ingress:
   ## If true, Prometheus Ingress will be created
   ##
@@ -39,6 +43,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+
+  ## Labels to be added to the Ingress
+  ##
+  labels: {}
 
   fqdn: ""
 
@@ -114,6 +122,10 @@ service:
   ## List of external IP addresses at which the Prometheus Service will be available
   ##
   externalIPs: []
+
+  ## Labels to be added to the Service
+  ##
+  labels: {}
 
   ## External IP address to assign to Prometheus Service
   ## Only used if service.type is 'LoadBalancer' and supported by cloud provider


### PR DESCRIPTION
* Allows the user to specify labels on the following resources: service, ingress, alertmanager and prometheus

For me personally came from the need to add `dns: route53` to the service of both alertmanager and prometheus.