### PR TITLE
kube-prometheus: remove app label from servicemonitors

### DIFF
--- a/helm/kube-prometheus/charts/exporter-kube-api/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-api/templates/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: kube-api
     heritage: "{{ .Release.Service }}"

--- a/helm/kube-prometheus/charts/exporter-kube-controller-manager/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-controller-manager/templates/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: kube-controller-manager
     heritage: "{{ .Release.Service }}"

--- a/helm/kube-prometheus/charts/exporter-kube-dns/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-dns/templates/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: kube-dns
     heritage: "{{ .Release.Service }}"

--- a/helm/kube-prometheus/charts/exporter-kube-etcd/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-etcd/templates/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: kube-etcd
     heritage: "{{ .Release.Service }}"

--- a/helm/kube-prometheus/charts/exporter-kube-scheduler/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-scheduler/templates/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: kube-scheduler
     heritage: "{{ .Release.Service }}"

--- a/helm/kube-prometheus/charts/exporter-kube-state/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-state/templates/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: kube-state
     heritage: "{{ .Release.Service }}"

--- a/helm/kube-prometheus/charts/exporter-kubelets/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-kubelets/templates/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: kubelets
     heritage: "{{ .Release.Service }}"
@@ -30,4 +29,3 @@ spec:
   - port: cadvisor
     interval: 30s
     honorLabels: true
-        

--- a/helm/kube-prometheus/charts/exporter-kubernetes/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-kubernetes/templates/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: kubelets
     heritage: "{{ .Release.Service }}"

--- a/helm/kube-prometheus/charts/exporter-node/templates/servicemonitor.yaml
+++ b/helm/kube-prometheus/charts/exporter-node/templates/servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: node-exporter
     heritage: "{{ .Release.Service }}"

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -60,7 +60,6 @@ spec:
 {{- else }}
   serviceMonitorSelector:
     matchLabels:
-      app: {{ template "name" . }}
       prometheus: {{ .Release.Name }}
 {{- end }}
 {{- if .Values.rulesSelector }}


### PR DESCRIPTION
* Removes `app=prometheus` from servicemonitor objects
* Also removes it from the serviceMonitor slector for prometheus
* This allows alertmanager servicemonitor to be selected
note: app on alertmanager is set to alertmanager