### PR TITLE
tests: Fix password variable definition

### DIFF
--- a/scripts/jenkins/kubernetes-vanilla.tfvars
+++ b/scripts/jenkins/kubernetes-vanilla.tfvars
@@ -7,7 +7,7 @@ tectonic_admin_email = "monitoring@coreos.com"
 // Use the bcrypt-hash tool (https://github.com/coreos/bcrypt-tool/releases/tag/v1.0.0) to generate it.
 // 
 // Note: This field MUST be set manually prior to creating the cluster.
-tectonic_admin_password_hash = ""
+tectonic_admin_password = ""
 
 // (optional) Extra AWS tags to be applied to created autoscaling group resources.
 // This is a list of maps having the keys `key`, `value` and `propagate_at_launch`.


### PR DESCRIPTION
The installer changed the tectonic_admin_password_hash variable to
tectonic_admin_password.