### PR TITLE
Fix merging of -datasource.json files

### DIFF
--- a/contrib/kube-prometheus/hack/grafana-dashboards-configmap-generator/bin/grafana_dashboards_generate.sh
+++ b/contrib/kube-prometheus/hack/grafana-dashboards-configmap-generator/bin/grafana_dashboards_generate.sh
@@ -199,6 +199,7 @@ addArrayToConfigMap() {
 
     # Dashboard foot
     test "$type" = "dashboard" && cat $DASHBOARD_FOOT_FILE
+    [ "$(tail -c 1 "$file")" ] && echo
   done
   echo "---"
 


### PR DESCRIPTION
The merge was missing a new line at the end of the merge, so only
the first datasource was being put into the ConfigMap.