### PR TITLE
Added prometheusArgs param

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -163,6 +163,7 @@ Specification of the desired behavior of the Prometheus cluster. More info: http
 | secrets | Secrets is a list of Secrets in the same namespace as the Prometheus object, which shall be mounted into the Prometheus Pods. The Secrets are mounted into /etc/prometheus/secrets/<secret-name>. Secrets changes after initial creation of a Prometheus object are not reflected in the running Pods. To change the secrets mounted into the Prometheus Pods, the object must be deleted and recreated with the new list of secrets. | []string | false |
 | affinity | If specified, the pod's scheduling constraints. | *v1.Affinity | false |
 | tolerations | If specified, the pod's tolerations. | []v1.Toleration | false |
+| prometheusArgs | PrometheusArgs is a list of arguments that should be added or overridden in the prometheus command. Each arguments must include a leading dash and appear exactly as they will on the cli (eg `-storage.local.target-heap-size=751619276` | []string | false |
 
 ## PrometheusStatus
 

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -81,6 +81,9 @@ type PrometheusSpec struct {
 	// necessary to generate correct URLs. This is necessary if Prometheus is not
 	// served from root of a DNS name.
 	ExternalURL string `json:"externalUrl,omitempty"`
+	// PrometheusArgs is a string of arguments that will be passed to the Prometheus instance.
+	// Arguments specified here will be given precedence over the normally calculated arguments.
+	PrometheusArgs []string `json:"prometheusArgs,omitempty"`
 	// The route prefix Prometheus registers HTTP handlers for. This is useful,
 	// if using ExternalURL and a proxy is rewriting HTTP routes of a request,
 	// and the actual ExternalURL is still true, but the server serves requests

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -342,6 +342,29 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMaps []
 	}
 	promArgs = append(promArgs, "-web.route-prefix="+webRoutePrefix)
 
+	// Override any args that were explicitly provided
+	if p.Spec.PrometheusArgs != nil {
+		newArgs := []string{}
+
+Overrides:
+		for _,newArg :=  range p.Spec.PrometheusArgs {
+			// This assumes each param is specified at most once
+			parts := strings.Split(newArg, "=")
+			for i,arg := range promArgs {
+				if strings.HasPrefix(arg, parts[0]+"=") {
+					// newArg is an override
+					promArgs[i] = newArg
+					continue Overrides
+				}
+			}
+			// newArg isn't overriding so we'll append it
+			newArgs = append(newArgs, newArg)
+		}
+		for _,arg := range newArgs {
+			promArgs = append(promArgs, arg)
+		}
+	}
+
 	if version.Major == 2 {
 		for i, a := range promArgs {
 			promArgs[i] = "-" + a
@@ -445,6 +468,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMaps []
 	}
 	podLabels["app"] = "prometheus"
 	podLabels["prometheus"] = p.Name
+
 	return &v1beta1.StatefulSetSpec{
 		ServiceName:         governingServiceName,
 		Replicas:            p.Spec.Replicas,


### PR DESCRIPTION
Allows users to selectively add or override cli params for a given prometheus
instance.

We've run into a few use cases where hand-tuning of certain cli params (particularly related to memory, queries, and storage) have been essential to our ability to use the operator. 

Fixes #426