### PR TITLE
tests: Don't archive Tectonic installer build folder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,11 +69,6 @@ job('po-tests-pr') {
             onlyIfBuildSucceeds(false)
             onlyIfBuildFails(false)
         }
-        postBuildScripts {
-            archiveArtifacts('build/**/*')
-            onlyIfBuildSucceeds(false)
-            onlyIfBuildFails(false)
-        }
         wsCleanup()
     }
 }
@@ -134,11 +129,6 @@ job('po-tests-master') {
             steps {
                 shell('./scripts/jenkins/post-e2e-tests.sh')
             }
-            onlyIfBuildSucceeds(false)
-            onlyIfBuildFails(false)
-        }
-        postBuildScripts {
-            archiveArtifacts('build/**/*')
             onlyIfBuildSucceeds(false)
             onlyIfBuildFails(false)
         }


### PR DESCRIPTION
Archiving the /build folder served the purpose of better cleaning up
clusters in case the cleanup steps fail. On the downside it takes a lot
of space and it is difficult to manage.

This patch removes the archive steps.