### PR TITLE
*: scope list watching to configurable namespace

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/errgroup"
+	kapi "k8s.io/client-go/pkg/api"
 
 	"github.com/coreos/prometheus-operator/pkg/alertmanager"
 	"github.com/coreos/prometheus-operator/pkg/api"
@@ -54,6 +55,7 @@ func init() {
 	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "quay.io/coreos/configmap-reload:v0.0.1", "Reload Image")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", "quay.io/prometheus/alertmanager", "Alertmanager default base image")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", "quay.io/prometheus/prometheus", "Prometheus default base image")
+	flagset.StringVar(&cfg.Namespace, "namespace", kapi.NamespaceAll, "Namespace to scope the interaction of the Prometheus Operator and the apiserver.")
 
 	flagset.Parse(os.Args[1:])
 }


### PR DESCRIPTION
An empty value means the Prometheus Operator will continue to list watch
against all namsepaces, therefore this is a non-breaking, backward
compatible change.

@fabxc @ant31