### PR TITLE
[kube-prometheus] Update to Grafana 4.5.2 in template

### DIFF
--- a/contrib/kube-prometheus/hack/grafana-dashboards-configmap-generator/templates/grafana-deployment-template.yaml
+++ b/contrib/kube-prometheus/hack/grafana-dashboards-configmap-generator/templates/grafana-deployment-template.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: grafana/grafana:4.4.1
+        image: grafana/grafana:4.5.2
         env:
         - name: GF_AUTH_BASIC_ENABLED
           value: "true"


### PR DESCRIPTION
In the generated manifest for the grafana deployment at /contrib/kube-prometheus/manifests/grafana/grafana-deployment.yaml the version was bumped to 4.5.2 but seems it was overlooked in this templated version of the file.