### PR TITLE
kube-prometheus: fix multiple series error in grafana dashboard

### DIFF
--- a/contrib/kube-prometheus/assets/grafana/kubernetes-control-plane-status-dashboard.json
+++ b/contrib/kube-prometheus/assets/grafana/kubernetes-control-plane-status-dashboard.json
@@ -333,7 +333,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "topk(1, (sum by(instance) (rate(apiserver_request_count{code=~\"5..\"}[5m])) / sum by(instance) (rate(apiserver_request_count[5m]))) * 100)",
+              "expr": "max(sum by(instance) (rate(apiserver_request_count{code=~\"5..\"}[5m])) / sum by(instance) (rate(apiserver_request_count[5m]))) * 100",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",

--- a/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
@@ -3886,7 +3886,7 @@ data:
               "tableColumn": "",
               "targets": [
                 {
-                  "expr": "topk(1, (sum by(instance) (rate(apiserver_request_count{code=~\"5..\"}[5m])) / sum by(instance) (rate(apiserver_request_count[5m]))) * 100)",
+                  "expr": "max(sum by(instance) (rate(apiserver_request_count{code=~\"5..\"}[5m])) / sum by(instance) (rate(apiserver_request_count[5m]))) * 100",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "",


### PR DESCRIPTION
If a cluster is HA, then topk returns the top 1 max api error rate for _each_ apiserver peer. As the displayed graph is a singlestat, this results in a multiseries error as Grafana expects a scalar for each point in time, not a scalar. We're making sure of this by using max over all api error rates.

@fabxc @ant31 