### PR TITLE
tests: Make sure to delete folders created by root

### DIFF
--- a/scripts/jenkins/post-e2e-tests.sh
+++ b/scripts/jenkins/post-e2e-tests.sh
@@ -15,6 +15,7 @@ TF_VAR_tectonic_cluster_name="${CLUSTER}"
 TF_VAR_tectonic_dns_name="${CLUSTER}"
 TECTONIC_INSTALLER_DIR=/go/src/github.com/coreos/tectonic-installer
 
+# Destroy cluster
 docker run \
        --rm \
        -v $PWD/build/:$TECTONIC_INSTALLER_DIR/build/ \
@@ -29,5 +30,8 @@ docker run \
        -e TF_VAR_tectonic_dns_name=${TF_VAR_tectonic_dns_name} \
        quay.io/coreos/tectonic-installer:master \
        /bin/bash -c "make destroy || make destroy || make destroy"
+
+# Cleanup folders created by docker (root)
+sudo rm -rf build .build
 
 docker rmi quay.io/coreos/prometheus-operator-dev:$BUILD_ID


### PR DESCRIPTION
In our Jenkinsfile we include the `wsCleanup()` step. This does not fail
the build even though it was not able to successfully clean up the
workspace.

In addition, with this patch we make sure ourself that the workspace is
cleaned up after the test execution.