### PR TITLE
Fix link to cluster-monitoring document

### DIFF
--- a/Documentation/user-guides/running-exporters.md
+++ b/Documentation/user-guides/running-exporters.md
@@ -60,7 +60,7 @@ spec:
   - port: http-metrics
     interval: 15s
 ```
-(A better example for monitoring Kubernetes cluster components can be found [User Guide "Cluster Monitoring"](user-guides/cluster-monitoring.md))
+(A better example for monitoring Kubernetes cluster components can be found [User Guide "Cluster Monitoring"](cluster-monitoring.md))
 This ServiceMonitor targets **all** Services with the label `k8s-app` (`spec.selector`) any value, in the namespaces `kube-system` and `monitoring` (`spec.namespaceSelector`).
 
 ## Troubleshooting


### PR DESCRIPTION
Linking to `user-guides/cluster-monitoring.md` results in a link to `https://coreos.com/operators/prometheus/docs/latest/user-guides/user-guides/cluster-monitoring.html` (duplicated `user-guides`) in the [Create a Matching ServiceMonitor](https://coreos.com/operators/prometheus/docs/latest/user-guides/running-exporters.html#create-a-matching-servicemonitor) doc.