### PR TITLE
Add manifests for kubeadm setup tool

### DIFF
--- a/contrib/kube-prometheus/manifests/k8s/kubeadm/kube-controller-manager.yaml
+++ b/contrib/kube-prometheus/manifests/k8s/kubeadm/kube-controller-manager.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  name: kube-controller-manager-prometheus-discovery
+  labels:
+    k8s-app: kube-controller-manager
+spec:
+  selector:
+    component: kube-controller-manager
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 10252
+    targetPort: 10252
+    protocol: TCP

--- a/contrib/kube-prometheus/manifests/k8s/kubeadm/kube-scheduler.yaml
+++ b/contrib/kube-prometheus/manifests/k8s/kubeadm/kube-scheduler.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  name: kube-scheduler-prometheus-discovery
+  labels:
+    k8s-app: kube-scheduler
+spec:
+  selector:
+    component: kube-scheduler
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 10251
+    targetPort: 10251
+    protocol: TCP


### PR DESCRIPTION
Fix issue [618](https://github.com/coreos/prometheus-operator/issues/618)
Add two manifests for kube-scheduler & kube-controller-manager discovered by prometheus-operator, which are set up by kubeadm. 
For me, it works well.