### PR TITLE
fixing a small typo on the OutOfDisk condition

### DIFF
--- a/contrib/kube-prometheus/assets/prometheus/rules/node.rules
+++ b/contrib/kube-prometheus/assets/prometheus/rules/node.rules
@@ -9,7 +9,7 @@ ALERT NodeExporterDown
     description = "Prometheus could not scrape a node-exporter for more than 10m, or node-exporters have disappeared from discovery.",
   }
 ALERT K8SNodeOutOfDisk
-  IF kube_node_status_condition{condition"OutOfDisk", status="true"} == 1
+  IF kube_node_status_condition{condition="OutOfDisk", status="true"} == 1
   LABELS {
     service = "k8s",
     severity = "critical"


### PR DESCRIPTION
Faced some errors generating the rules for the k8s configmap, found an small typo on the conditional
```
curl -X POST http://ingress.mycluster/metrics/-/reload
failed to reload config: one or more errors occurred while applying the new configuration (-config.file=/etc/prometheus/config/prometheus.yaml)
```
After change this, rules are loaded correctly