### PR TITLE
prometheus: ignore if pod management policy is updated

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -146,6 +146,9 @@ func makeStatefulSet(p monitoringv1.Prometheus, old *v1beta1.StatefulSet, config
 
 	if old != nil {
 		statefulset.Annotations = old.Annotations
+
+		// Updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden.
+		statefulset.Spec.PodManagementPolicy = old.Spec.PodManagementPolicy
 	}
 
 	return statefulset, nil


### PR DESCRIPTION
`v0.14.0` introduced using the `PodManagementPolicy`, however that field is not allowed to be mutated after creation and causes the Prometheus Operator to error out when updating the operator from `v0.13.0` as previously the statefulsets did not have this field set.

@ant31 @fabxc 