### PR TITLE
Omit static compute resource requests and limits from deployment

### DIFF
--- a/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -22,13 +22,6 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
-        resources:
-          requests:
-            memory: 100Mi
-            cpu: 100m
-          limits:
-            memory: 200Mi
-            cpu: 200m
       - name: addon-resizer
         image: gcr.io/google_containers/addon-resizer:1.0
         resources:

--- a/helm/kube-prometheus/charts/exporter-kube-state/templates/deployment.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-state/templates/deployment.yaml
@@ -47,8 +47,6 @@ spec:
             port: {{ .Values.kube_state_metrics.service.internalPort }}
           initialDelaySeconds: 30
           timeoutSeconds: 5
-        resources:
-{{ toYaml .Values.kube_state_metrics.resources | indent 12 }}
       - name: {{ .Chart.Name }}-addon-resizer
         image: "{{ .Values.addon_resizer.image.repository }}:{{ .Values.addon_resizer.image.tag }}"
         env:

--- a/helm/kube-prometheus/charts/exporter-kube-state/values.yaml
+++ b/helm/kube-prometheus/charts/exporter-kube-state/values.yaml
@@ -13,13 +13,6 @@ kube_state_metrics:
     type: ClusterIP
     externalPort: 80
     internalPort: 8080
-  resources:
-    limits:
-      cpu: 100m
-      memory: 200Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi
 addon_resizer:
   image:
     repository: gcr.io/google_containers/addon-resizer


### PR DESCRIPTION
Do not specify static resource settings in the kubernetes-deployment to avoid
unnecessary replacement of pods when the manifest is reapplied (`kubectl
apply`).

The addon-resizer will dynamically set the pod compute resource values. If the
values are also set statically in the deployment configuration, reapplying the
configuration will result in the pods getting replaced. Without the static
resource, the deployment configuration can be reapplied, and the pods will not
be replaced.

This change was also made in the upstream kube-state-metrics example manifests.

https://github.com/kubernetes/kube-state-metrics/pull/285