### PR TITLE
Update KOPSonAWS.md

### DIFF
--- a/contrib/kube-prometheus/docs/KOPSonAWS.md
+++ b/contrib/kube-prometheus/docs/KOPSonAWS.md
@@ -5,22 +5,8 @@
 
 A running Kubernetes cluster created with [KOPS](https://github.com/kubernetes/kops).
  
-These instructions have currently been tested with  **topology=public** on AWS with KOPS 1.5.1 and Kubernetes 1.5.x
+These instructions have currently been tested with  **topology=public** on AWS with KOPS 1.7.1 and Kubernetes 1.7.x
 
-## Open AWS Security Groups:
-1. Open port 9100 on the masters security group to the nodes security group
-1. Open ports 10250-10252 on the masters security group to the nodes security group.
-
-Example script below requires $AWS\_DEFAULT_PROFILE and [$NAME](https://github.com/kubernetes/kops/blob/master/docs/aws.md#prepare-local-environment)
-
-```bash
-MASTER_SG=$(aws --profile ${AWS_DEFAULT_PROFILE} ec2 describe-security-groups --filters "Name=tag:Name,Values=masters.$NAME" --query "SecurityGroups[*].GroupId[]" --output=text)
-NODES_SG=$(aws --profile ${AWS_DEFAULT_PROFILE} ec2 describe-security-groups --filters "Name=tag:Name,Values=nodes.$NAME" --query "SecurityGroups[*].GroupId[]" --output=text)
-aws --profile ${AWS_DEFAULT_PROFILE} ec2 authorize-security-group-ingress --group-id $MASTER_SG --protocol tcp --port 9100 --source-group $NODES_SG
-aws --profile ${AWS_DEFAULT_PROFILE} ec2 authorize-security-group-ingress --group-id $MASTER_SG --protocol tcp --port 10250-10252 --source-group $NODES_SG
-```
-
-## Adding kube-prometheus
 Following the instructions in the [README](https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/README.md):
 
 Example:


### PR DESCRIPTION
The AWS CLI SG commands are not necessary, kops creates an SG with these ports open to the correct SG by default.

You may want to consider deleting this file altogether