### PR TITLE
Generate ExternalLabels deterministically

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -42,9 +42,15 @@ func configMapRuleFileFolder(configMapNumber int) string {
 
 func stringMapToMapSlice(m map[string]string) yaml.MapSlice {
 	res := yaml.MapSlice{}
+	ks := make([]string, 0)
 
-	for k, v := range m {
-		res = append(res, yaml.MapItem{Key: k, Value: v})
+	for k, _ := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+
+	for _, k := range ks {
+		res = append(res, yaml.MapItem{Key: k, Value: m[k]})
 	}
 
 	return res

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -64,6 +64,10 @@ func generateTestConfig(version string) ([]byte, error) {
 						},
 					},
 				},
+				ExternalLabels: map[string]string{
+					"label1": "value1",
+					"label2": "value2",
+				},
 				Version:  version,
 				Replicas: &replicas,
 				ServiceMonitorSelector: &metav1.LabelSelector{


### PR DESCRIPTION
ExternalLabels now have a stable ordering in the generated ConfigMap prometheus.yaml file.