### PR TITLE
Allow templating for alertmanager

### DIFF
--- a/helm/alertmanager/templates/secret.yaml
+++ b/helm/alertmanager/templates/secret.yaml
@@ -10,3 +10,6 @@ metadata:
   name: alertmanager-{{ .Release.Name }}
 data:
   alertmanager.yaml: {{ toYaml .Values.config | b64enc | quote }}
+{{- range $key, $val := .Values.templateFiles }}
+  {{ $key }}: {{ $val | b64enc | quote }}
+{{- end }}

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -17,6 +17,10 @@ config:
     receiver: webhook
     repeat_interval: 12h
 
+## Alertmanager template files to include
+#
+templateFiles: {}
+
 ## External URL at which Alertmanager will be reachable
 ##
 externalUrl: ""

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -20,6 +20,22 @@ config:
 ## Alertmanager template files to include
 #
 templateFiles: {}
+#
+# An example template:
+#   template_1.tmpl: |-
+#       {{ define "cluster" }}{{ .ExternalURL | reReplaceAll ".*alertmanager\\.(.*)" "$1" }}{{ end }}
+#
+#       {{ define "slack.myorg.text" }}
+#       {{- $root := . -}}
+#       {{ range .Alerts }}
+#         *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
+#         *Cluster:*  {{ template "cluster" $root }}
+#         *Description:* {{ .Annotations.description }}
+#         *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:>
+#         *Runbook:* <{{ .Annotations.runbook }}|:spiral_note_pad:>
+#         *Details:*
+#           {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+#           {{ end }}
 
 ## External URL at which Alertmanager will be reachable
 ##


### PR DESCRIPTION
User can now specify custom templates (as described in [1]) in  `templateFiles` in `values.yaml`.
Eg.

```
templateFiles:
  template_1.tmpl: |-
    .... template file
```
Also has to add:
```
    templates:
    - '*.tmpl'
```
in `config` (the config that populates `alertmanager.yaml`).

[1] https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/alerting.md