### PR TITLE
Helm Chart - Add support to node-exporter >= 0.15.0

### DIFF
--- a/helm/kube-prometheus/charts/exporter-node/templates/deamonset.yaml
+++ b/helm/kube-prometheus/charts/exporter-node/templates/deamonset.yaml
@@ -21,8 +21,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
+          {{ if lt .Values.image.tag "1.15.0" }}
             - --collector.procfs=/host/proc
             - --collector.sysfs=/host/sys
+          {{ else }}
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+          {{ end }}
           ports:
             - name: metrics
               containerPort: 9100

--- a/helm/kube-prometheus/charts/exporter-node/templates/deamonset.yaml
+++ b/helm/kube-prometheus/charts/exporter-node/templates/deamonset.yaml
@@ -21,7 +21,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
-          {{ if lt .Values.image.tag "1.15.0" }}
+          {{ if lt .Values.image.tag "0.15.0" }}
             - --collector.procfs=/host/proc
             - --collector.sysfs=/host/sys
           {{ else }}


### PR DESCRIPTION
Some flags have been renamed in 0.15.0
Keeping back-compatibility with if