### PR TITLE
Fixing #751 K8SApiServerLatency always triggering

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -227,8 +227,8 @@ data:
             disappeared from service discovery.
           summary: API server unreachable
       - alert: K8SApiServerLatency
-        expr: histogram_quantile(0.99, sum(apiserver_request_latencies_bucket{subresource!="log",verb!~"^(?:CONNECT|WATCHLIST|WATCH|PROXY)$"})
-          WITHOUT (instance, resource)) / 1e+06 > 1
+        expr: histogram_quantile(0.99, sum(rate(apiserver_request_latencies_bucket{subresource!="log",verb!~"^(?:CONNECT|WATCHLIST|WATCH|PROXY)$"}[10m])) 
+          by (le)) / 1e+06 > 1
         for: 10m
         labels:
           severity: warning


### PR DESCRIPTION
K8SApiServerLatency does not limit the timespan of the check. Adding rate() for 10m. 