### PR TITLE
Configurable node exporter

### DIFF
--- a/helm/kube-prometheus/charts/exporter-node/templates/deamonset.yaml
+++ b/helm/kube-prometheus/charts/exporter-node/templates/deamonset.yaml
@@ -28,10 +28,11 @@ spec:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
           {{ end }}
+            - --web.listen-address=0.0.0.0:{{ .Values.service.containerPort }}
           ports:
             - name: metrics
-              containerPort: 9100
-              hostPort: 9100
+              containerPort: {{ .Values.service.containerPort }}
+              hostPort: {{ .Values.service.containerPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/helm/kube-prometheus/charts/exporter-node/templates/service.yaml
+++ b/helm/kube-prometheus/charts/exporter-node/templates/service.yaml
@@ -13,6 +13,7 @@ spec:
   ports:
   - name: metrics
     port: {{ .Values.service.externalPort }}
+    targetPort: metrics
     protocol: TCP
   selector:
     app: {{ template "fullname" . }}

--- a/helm/kube-prometheus/charts/exporter-node/values.yaml
+++ b/helm/kube-prometheus/charts/exporter-node/values.yaml
@@ -8,6 +8,7 @@ image:
 service:
   type: ClusterIP
   externalPort: 9100
+  containerPort: 9100
 resources:
   limits:
     cpu: 200m

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -42,3 +42,4 @@ dependencies:
   - name: exporter-node
     version: 0.1.0
     repository: https://charts.cloudposse.com/incubator
+    condition: deployExporterNode

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -1,3 +1,6 @@
+# exporter-node configuration
+deployExporterNode: True
+
 alertmanager:
   ## Alertmanager configuration directives
   ## Ref: https://prometheus.io/docs/alerting/configuration/


### PR DESCRIPTION
Allows you to:
* omit `node-exporter` deployment by setting `deployExporterNode` to `False`.
* listen on a different port (so 2 versions of node exporter can coexist, eg testing out a new version)