### PR TITLE
Fix docu concerning initial deployment

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -35,7 +35,7 @@ Simply run:
 
 ```bash
 export KUBECONFIG=<path> # defaults to "~/.kube/config"
-hack/cluster-monitoring/deploy
+prometheus-operator/contrib/kube-prometheus/hack/cluster-monitoring/deploy
 ```
 
 After all pods are ready, you can reach:

--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -35,7 +35,8 @@ Simply run:
 
 ```bash
 export KUBECONFIG=<path> # defaults to "~/.kube/config"
-prometheus-operator/contrib/kube-prometheus/hack/cluster-monitoring/deploy
+cd contrib/kube-prometheus/
+hack/cluster-monitoring/deploy
 ```
 
 After all pods are ready, you can reach:


### PR DESCRIPTION
After cloning the repo I wanted to deploy kube-prometheus into my running minikube. I did the steps mentioned in the docu which brought me to the following exception:

namespace "monitoring" created
error: the path "manifests/prometheus-operator" does not exist
Waiting for Operator to register custom resource definitions.................................................................................................................^C