### PR TITLE
Improvements for API docs

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -9,6 +9,26 @@ This Document documents the types introduced by the Prometheus Operator to be co
 
 > Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.
 
+## Table of Contents
+* [AlertingSpec](#alertingspec)
+* [Alertmanager](#alertmanager)
+* [AlertmanagerEndpoints](#alertmanagerendpoints)
+* [AlertmanagerList](#alertmanagerlist)
+* [AlertmanagerSpec](#alertmanagerspec)
+* [AlertmanagerStatus](#alertmanagerstatus)
+* [BasicAuth](#basicauth)
+* [Endpoint](#endpoint)
+* [NamespaceSelector](#namespaceselector)
+* [Prometheus](#prometheus)
+* [PrometheusList](#prometheuslist)
+* [PrometheusSpec](#prometheusspec)
+* [PrometheusStatus](#prometheusstatus)
+* [ServiceMonitor](#servicemonitor)
+* [ServiceMonitorList](#servicemonitorlist)
+* [ServiceMonitorSpec](#servicemonitorspec)
+* [StorageSpec](#storagespec)
+* [TLSConfig](#tlsconfig)
+
 ## AlertingSpec
 
 AlertingSpec defines parameters for alerting configuration of Prometheus servers.
@@ -17,15 +37,19 @@ AlertingSpec defines parameters for alerting configuration of Prometheus servers
 | ----- | ----------- | ------ | -------- |
 | alertmanagers | AlertmanagerEndpoints Prometheus should fire alerts against. | [][AlertmanagerEndpoints](#alertmanagerendpoints) | true |
 
+[Back to TOC](#table-of-contents)
+
 ## Alertmanager
 
 Describes an Alertmanager cluster.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| metadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ObjectMeta](https://kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
+| metadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ObjectMeta](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
 | spec | Specification of the desired behavior of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status | [AlertmanagerSpec](#alertmanagerspec) | true |
 | status | Most recent observed status of the Alertmanager cluster. Read-only. Not included when requesting from the apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status | *[AlertmanagerStatus](#alertmanagerstatus) | false |
+
+[Back to TOC](#table-of-contents)
 
 ## AlertmanagerEndpoints
 
@@ -39,14 +63,18 @@ AlertmanagerEndpoints defines a selection of a single Endpoints object containin
 | scheme | Scheme to use when firing alerts. | string | true |
 | pathPrefix | Prefix for the HTTP path alerts are pushed to. | string | true |
 
+[Back to TOC](#table-of-contents)
+
 ## AlertmanagerList
 
 A list of Alertmanagers.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| metadata | Standard list metadata More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ListMeta](https://kubernetes.io/docs/api-reference/v1.6/#listmeta-v1-meta) | false |
+| metadata | Standard list metadata More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ListMeta](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#listmeta-v1-meta) | false |
 | items | List of Alertmanagers | [][Alertmanager](#alertmanager) | true |
+
+[Back to TOC](#table-of-contents)
 
 ## AlertmanagerSpec
 
@@ -54,19 +82,21 @@ Specification of the desired behavior of the Alertmanager cluster. More info: ht
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| podMetadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | *[metav1.ObjectMeta](https://kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
+| podMetadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | *[metav1.ObjectMeta](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
 | version | Version the cluster should be on. | string | false |
 | baseImage | Base image that is used to deploy pods. | string | false |
-| imagePullSecrets | An optional list of references to secrets in the same namespace to use for pulling prometheus and alertmanager images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod | [][v1.LocalObjectReference](https://kubernetes.io/docs/api-reference/v1.6/#localobjectreference-v1-core) | false |
+| imagePullSecrets | An optional list of references to secrets in the same namespace to use for pulling prometheus and alertmanager images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod | [][v1.LocalObjectReference](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#localobjectreference-v1-core) | false |
 | replicas | Size is the expected size of the alertmanager cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | false |
 | storage | Storage is the definition of how storage will be used by the Alertmanager instances. | *[StorageSpec](#storagespec) | false |
 | externalUrl | The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name. | string | false |
 | routePrefix | The route prefix Alertmanager registers HTTP handlers for. This is useful, if using ExternalURL and a proxy is rewriting HTTP routes of a request, and the actual ExternalURL is still true, but the server serves requests under a different route prefix. For example for use with `kubectl proxy`. | string | false |
 | paused | If set to true all actions on the underlaying managed objects are not goint to be performed, except for delete actions. | bool | false |
 | nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
-| resources | Define resources requests and limits for single Pods. | [v1.ResourceRequirements](https://kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | false |
+| resources | Define resources requests and limits for single Pods. | [v1.ResourceRequirements](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | false |
 | affinity | If specified, the pod's scheduling constraints. | *v1.Affinity | false |
 | tolerations | If specified, the pod's tolerations. | []v1.Toleration | false |
+
+[Back to TOC](#table-of-contents)
 
 ## AlertmanagerStatus
 
@@ -80,14 +110,18 @@ Most recent observed status of the Alertmanager cluster. Read-only. Not included
 | availableReplicas | Total number of available pods (ready for at least minReadySeconds) targeted by this Alertmanager cluster. | int32 | true |
 | unavailableReplicas | Total number of unavailable pods targeted by this Alertmanager cluster. | int32 | true |
 
+[Back to TOC](#table-of-contents)
+
 ## BasicAuth
 
 BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| username | The secret that contains the username for authenticate | [v1.SecretKeySelector](https://kubernetes.io/docs/api-reference/v1.6/#secretkeyselector-v1-core) | false |
-| password | The secret that contains the password for authenticate | [v1.SecretKeySelector](https://kubernetes.io/docs/api-reference/v1.6/#secretkeyselector-v1-core) | false |
+| username | The secret that contains the username for authenticate | [v1.SecretKeySelector](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#secretkeyselector-v1-core) | false |
+| password | The secret that contains the password for authenticate | [v1.SecretKeySelector](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#secretkeyselector-v1-core) | false |
+
+[Back to TOC](#table-of-contents)
 
 ## Endpoint
 
@@ -107,6 +141,8 @@ Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 | honorLabels | HonorLabels chooses the metric's labels on collisions with target labels. | bool | false |
 | basicAuth | BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints | *[BasicAuth](#basicauth) | false |
 
+[Back to TOC](#table-of-contents)
+
 ## NamespaceSelector
 
 A selector for selecting namespaces either selecting all namespaces or a list of namespaces.
@@ -116,15 +152,19 @@ A selector for selecting namespaces either selecting all namespaces or a list of
 | any | Boolean describing whether all namespaces are selected in contrast to a list restricting them. | bool | false |
 | matchNames | List of namespace names. | []string | false |
 
+[Back to TOC](#table-of-contents)
+
 ## Prometheus
 
 Prometheus defines a Prometheus deployment.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| metadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ObjectMeta](https://kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
+| metadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ObjectMeta](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
 | spec | Specification of the desired behavior of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status | [PrometheusSpec](#prometheusspec) | true |
 | status | Most recent observed status of the Prometheus cluster. Read-only. Not included when requesting from the apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status | *[PrometheusStatus](#prometheusstatus) | false |
+
+[Back to TOC](#table-of-contents)
 
 ## PrometheusList
 
@@ -132,8 +172,10 @@ PrometheusList is a list of Prometheuses.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| metadata | Standard list metadata More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ListMeta](https://kubernetes.io/docs/api-reference/v1.6/#listmeta-v1-meta) | false |
+| metadata | Standard list metadata More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ListMeta](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#listmeta-v1-meta) | false |
 | items | List of Prometheuses | []*[Prometheus](#prometheus) | true |
+
+[Back to TOC](#table-of-contents)
 
 ## PrometheusSpec
 
@@ -141,12 +183,12 @@ Specification of the desired behavior of the Prometheus cluster. More info: http
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| podMetadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | *[metav1.ObjectMeta](https://kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
-| serviceMonitorSelector | ServiceMonitors to be selected for target discovery. | *[metav1.LabelSelector](https://kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | false |
+| podMetadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | *[metav1.ObjectMeta](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
+| serviceMonitorSelector | ServiceMonitors to be selected for target discovery. | *[metav1.LabelSelector](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | false |
 | version | Version of Prometheus to be deployed. | string | false |
 | paused | When a Prometheus deployment is paused, no actions except for deletion will be performed on the underlying objects. | bool | false |
 | baseImage | Base image to use for a Prometheus deployment. | string | false |
-| imagePullSecrets | An optional list of references to secrets in the same namespace to use for pulling prometheus and alertmanager images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod | [][v1.LocalObjectReference](https://kubernetes.io/docs/api-reference/v1.6/#localobjectreference-v1-core) | false |
+| imagePullSecrets | An optional list of references to secrets in the same namespace to use for pulling prometheus and alertmanager images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod | [][v1.LocalObjectReference](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#localobjectreference-v1-core) | false |
 | replicas | Number of instances to deploy for a Prometheus deployment. | *int32 | false |
 | retention | Time duration Prometheus shall retain data for. | string | false |
 | scrapeInterval | Interval between consecutive scrapes. | string | false |
@@ -155,14 +197,16 @@ Specification of the desired behavior of the Prometheus cluster. More info: http
 | externalUrl | The external URL the Prometheus instances will be available under. This is necessary to generate correct URLs. This is necessary if Prometheus is not served from root of a DNS name. | string | false |
 | routePrefix | The route prefix Prometheus registers HTTP handlers for. This is useful, if using ExternalURL and a proxy is rewriting HTTP routes of a request, and the actual ExternalURL is still true, but the server serves requests under a different route prefix. For example for use with `kubectl proxy`. | string | false |
 | storage | Storage spec to specify how storage shall be used. | *[StorageSpec](#storagespec) | false |
-| ruleSelector | A selector to select which ConfigMaps to mount for loading rule files from. | *[metav1.LabelSelector](https://kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | false |
+| ruleSelector | A selector to select which ConfigMaps to mount for loading rule files from. | *[metav1.LabelSelector](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | false |
 | alerting | Define details regarding alerting. | [AlertingSpec](#alertingspec) | false |
-| resources | Define resources requests and limits for single Pods. | [v1.ResourceRequirements](https://kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | false |
+| resources | Define resources requests and limits for single Pods. | [v1.ResourceRequirements](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | false |
 | nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
 | serviceAccountName | ServiceAccountName is the name of the ServiceAccount to use to run the Prometheus Pods. | string | false |
 | secrets | Secrets is a list of Secrets in the same namespace as the Prometheus object, which shall be mounted into the Prometheus Pods. The Secrets are mounted into /etc/prometheus/secrets/<secret-name>. Secrets changes after initial creation of a Prometheus object are not reflected in the running Pods. To change the secrets mounted into the Prometheus Pods, the object must be deleted and recreated with the new list of secrets. | []string | false |
 | affinity | If specified, the pod's scheduling constraints. | *v1.Affinity | false |
 | tolerations | If specified, the pod's tolerations. | []v1.Toleration | false |
+
+[Back to TOC](#table-of-contents)
 
 ## PrometheusStatus
 
@@ -176,14 +220,18 @@ Most recent observed status of the Prometheus cluster. Read-only. Not included w
 | availableReplicas | Total number of available pods (ready for at least minReadySeconds) targeted by this Prometheus deployment. | int32 | true |
 | unavailableReplicas | Total number of unavailable pods targeted by this Prometheus deployment. | int32 | true |
 
+[Back to TOC](#table-of-contents)
+
 ## ServiceMonitor
 
 ServiceMonitor defines monitoring for a set of services.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| metadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ObjectMeta](https://kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
+| metadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ObjectMeta](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
 | spec | Specification of desired Service selection for target discrovery by Prometheus. | [ServiceMonitorSpec](#servicemonitorspec) | true |
+
+[Back to TOC](#table-of-contents)
 
 ## ServiceMonitorList
 
@@ -191,8 +239,10 @@ A list of ServiceMonitors.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| metadata | Standard list metadata More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ListMeta](https://kubernetes.io/docs/api-reference/v1.6/#listmeta-v1-meta) | false |
+| metadata | Standard list metadata More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata | [metav1.ListMeta](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#listmeta-v1-meta) | false |
 | items | List of ServiceMonitors | []*[ServiceMonitor](#servicemonitor) | true |
+
+[Back to TOC](#table-of-contents)
 
 ## ServiceMonitorSpec
 
@@ -202,8 +252,10 @@ ServiceMonitorSpec contains specification parameters for a ServiceMonitor.
 | ----- | ----------- | ------ | -------- |
 | jobLabel | The label to use to retrieve the job name from. | string | false |
 | endpoints | A list of endpoints allowed as part of this ServiceMonitor. | [][Endpoint](#endpoint) | true |
-| selector | Selector to select Endpoints objects. | [metav1.LabelSelector](https://kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | true |
+| selector | Selector to select Endpoints objects. | [metav1.LabelSelector](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | true |
 | namespaceSelector | Selector to select which namespaces the Endpoints objects are discovered from. | [NamespaceSelector](#namespaceselector) | false |
+
+[Back to TOC](#table-of-contents)
 
 ## StorageSpec
 
@@ -212,9 +264,11 @@ StorageSpec defines the configured storage for a group Prometheus servers.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | class | Name of the StorageClass to use when requesting storage provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses DEPRECATED | string | true |
-| selector | A label query over volumes to consider for binding. DEPRECATED | *[metav1.LabelSelector](https://kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | true |
-| resources | Resources represents the minimum resources the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources DEPRECATED | [v1.ResourceRequirements](https://kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | true |
-| volumeClaimTemplate | A PVC spec to be used by the Prometheus StatefulSets. | [v1.PersistentVolumeClaim](https://kubernetes.io/docs/api-reference/v1.6/#persistentvolumeclaim-v1-core) | false |
+| selector | A label query over volumes to consider for binding. DEPRECATED | *[metav1.LabelSelector](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta) | true |
+| resources | Resources represents the minimum resources the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources DEPRECATED | [v1.ResourceRequirements](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | true |
+| volumeClaimTemplate | A PVC spec to be used by the Prometheus StatefulSets. | [v1.PersistentVolumeClaim](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#persistentvolumeclaim-v1-core) | false |
+
+[Back to TOC](#table-of-contents)
 
 ## TLSConfig
 
@@ -227,3 +281,5 @@ TLSConfig specifies TLS configuration parameters.
 | keyFile | The client key file for the targets. | string | false |
 | serverName | Used to verify the hostname for the targets. | string | false |
 | insecureSkipVerify | Disable target certificate validation. | bool | false |
+
+[Back to TOC](#table-of-contents)

--- a/cmd/po-docgen/api.go
+++ b/cmd/po-docgen/api.go
@@ -40,17 +40,31 @@ This Document documents the types introduced by the Prometheus Operator to be co
 
 var (
 	links = map[string]string{
-		"metav1.ObjectMeta":        "https://kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta",
-		"metav1.ListMeta":          "https://kubernetes.io/docs/api-reference/v1.6/#listmeta-v1-meta",
-		"metav1.LabelSelector":     "https://kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta",
-		"v1.ResourceRequirements":  "https://kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core",
-		"v1.LocalObjectReference":  "https://kubernetes.io/docs/api-reference/v1.6/#localobjectreference-v1-core",
-		"v1.SecretKeySelector":     "https://kubernetes.io/docs/api-reference/v1.6/#secretkeyselector-v1-core",
-		"v1.PersistentVolumeClaim": "https://kubernetes.io/docs/api-reference/v1.6/#persistentvolumeclaim-v1-core",
+		"metav1.ObjectMeta":        "https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta",
+		"metav1.ListMeta":          "https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#listmeta-v1-meta",
+		"metav1.LabelSelector":     "https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#labelselector-v1-meta",
+		"v1.ResourceRequirements":  "https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core",
+		"v1.LocalObjectReference":  "https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#localobjectreference-v1-core",
+		"v1.SecretKeySelector":     "https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#secretkeyselector-v1-core",
+		"v1.PersistentVolumeClaim": "https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#persistentvolumeclaim-v1-core",
 	}
 
 	selfLinks = map[string]string{}
 )
+
+func toSectionLink(name string) string {
+	name = strings.ToLower(name)
+	name = strings.Replace(name, " ", "-", -1)
+	return name
+}
+
+func printTOC(types []KubeTypes) {
+	fmt.Printf("\n## Table of Contents\n")
+	for _, t := range types {
+		strukt := t[0]
+		fmt.Printf("* [%s](#%s)\n", strukt.Name, toSectionLink(strukt.Name))
+	}
+}
 
 func printAPIDocs(path string) {
 	fmt.Println(firstParagraph)
@@ -64,6 +78,8 @@ func printAPIDocs(path string) {
 	// we need to parse once more to now add the self links
 	types = ParseDocumentationFrom(path)
 
+	printTOC(types)
+
 	for _, t := range types {
 		strukt := t[0]
 		fmt.Printf("\n## %s\n\n%s\n\n", strukt.Name, strukt.Doc)
@@ -74,6 +90,8 @@ func printAPIDocs(path string) {
 		for _, f := range fields {
 			fmt.Println("|", f.Name, "|", f.Doc, "|", f.Type, "|", f.Mandatory, "|")
 		}
+		fmt.Println("")
+		fmt.Println("[Back to TOC](#table-of-contents)")
 	}
 }
 


### PR DESCRIPTION
- Fix broken links of Kubernetes API Objects.
  https://kubernetes.io/docs/api-reference/v1.6/ are not available, moved to https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/.
- Add TOC section for api docs and back-to-toc links.

`po-docgen` tool is very handy. I use it in some projects I participate. To help readers navigate on github website, I added TOC support.