### PR TITLE
Promtool appends .yml, not .yaml

### DIFF
--- a/contrib/kube-prometheus/hack/scripts/generate-rules-configmap.sh
+++ b/contrib/kube-prometheus/hack/scripts/generate-rules-configmap.sh
@@ -11,7 +11,7 @@ metadata:
 data:
 EOF
 
-for f in assets/prometheus/rules/*.rules.yaml
+for f in assets/prometheus/rules/*.rules.y*ml
 do
   echo "  $(basename $f): |+"
   cat $f | sed "s/^/    /g"


### PR DESCRIPTION
but for backwards compatibility, lets allow both