### PR TITLE
Helm review

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,14 @@ jobs:
     script: ./scripts/travis-e2e.sh
   - stage: E2e helm
     script: ./scripts/travis-e2e-helm.sh
-  - stage: helm update
-    script: 'if [ "$TRAVIS_BRANCH" == "master" ]; then make helm-packages; fi'
+
+deploy:
+  provider: script
+  script: helm/hack/helm-package.sh "alertmanager grafana prometheus prometheus-operator exporter-kube-api \
+                exporter-kube-dns exporter-kube-scheduler exporter-kubelets exporter-node \
+                exporter-kube-controller-manager exporter-kube-etcd exporter-kube-state exporter-kubernetes" && \
+        helm/hack/sync-repo.sh && \
+        helm/hack/helm-package.sh kube-prometheus && \
+        helm/hack/sync-repo.sh
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
 - 1.9
 services:
 - docker
+before_install:
+  - pip install --user awscli
+  - export PATH=$PATH:$HOME/.local/bin
 jobs:
   include:
   - stage: Check generated contents are up to date and code is formatted.
@@ -18,3 +21,5 @@ jobs:
     script: ./scripts/travis-e2e.sh
   - stage: E2e helm
     script: ./scripts/travis-e2e-helm.sh
+  - stage: helm update
+    script: 'if [ "$TRAVIS_BRANCH" == "master" ]; then make helm-packages; fi'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ PROMU := $(GOPATH)/bin/promu
 PREFIX ?= $(shell pwd)
 
 pkgs = $(shell go list ./... | grep -v /vendor/ | grep -v /test/)
-HELM_BUCKET_NAME=coreos-charts
 
 all: check-license format build test
 
@@ -77,16 +76,14 @@ jsonnet:
 jsonnet-docker:
 	docker build -f scripts/jsonnet/Dockerfile -t po-jsonnet .
 
-helm-package:
-	mkdir -p /tmp/helm
-	(cd $(CURDIR)/helm && helm package $(HELM_PACKAGES)  -d /tmp/helm && cd -)
-	helm repo index /tmp/helm --url https://s3-eu-west-1.amazonaws.com/$(HELM_BUCKET_NAME)/stable/ --debug
-	aws s3 sync --acl public-read /tmp/helm/ s3://$(HELM_BUCKET_NAME)/stable/
 
 helm-packages:
-	make helm-package HELM_PACKAGES=exporter-*
-	make helm-package HELM_PACKAGES="alertmanager grafana prometheus prometheus-operator"
-	(cd $(CURDIR)/helm/'kube-prometheus' && helm dep update && cd -)
-	make helm-package HELM_PACKAGES='kube-prometheus'
+
+	helm/hack/helm-package.sh "alertmanager grafana prometheus prometheus-operator exporter-kube-api \
+		exporter-kube-dns exporter-kube-scheduler exporter-kubelets exporter-node \
+		exporter-kube-controller-manager exporter-kube-etcd exporter-kube-state exporter-kubernetes"
+	helm/hack/sync-repo.sh
+	helm/hack/helm-package.sh kube-prometheus
+	helm/hack/sync-repo.sh
 
 .PHONY: all build crossbuild test format check-license container e2e-test e2e-status e2e clean-e2e embedmd apidocgen docs

--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,4 @@ jsonnet-docker:
 	docker build -f scripts/jsonnet/Dockerfile -t po-jsonnet .
 
 
-helm-packages:
-
-	helm/hack/helm-package.sh "alertmanager grafana prometheus prometheus-operator exporter-kube-api \
-		exporter-kube-dns exporter-kube-scheduler exporter-kubelets exporter-node \
-		exporter-kube-controller-manager exporter-kube-etcd exporter-kube-state exporter-kubernetes"
-	helm/hack/sync-repo.sh
-	helm/hack/helm-package.sh kube-prometheus
-	helm/hack/sync-repo.sh
-
 .PHONY: all build crossbuild test format check-license container e2e-test e2e-status e2e clean-e2e embedmd apidocgen docs

--- a/helm/hack/e2e-test.sh
+++ b/helm/hack/e2e-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+#// TODO move this test and dependencies to a docker container
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/helm/hack/helm-package.sh
+++ b/helm/hack/helm-package.sh
@@ -15,13 +15,14 @@ HELM_CHARTS_PACKAGED_DIR=${3:-"/tmp/helm-packaged"}
 
 wget -q ${HELM_URL}/${HELM_TARBALL}
 tar xzfv ${HELM_TARBALL}
-export PATH=${PATH}:$(pwd)/linux-amd64/helm
+export PATH=${PATH}:$(pwd)/linux-amd64/
 
 # Clean up tarball
 rm -f ${HELM_TARBALL}
 
 # Package helm and dependencies
 mkdir -p ${HELM_CHARTS_PACKAGED_DIR}
+helm init --client-only
 
 # check if charts has dependencies,
 for chart in ${HELM_PACKAGES}

--- a/helm/hack/helm-package.sh
+++ b/helm/hack/helm-package.sh
@@ -37,3 +37,4 @@ do
 done
 
 helm repo index ${HELM_CHARTS_PACKAGED_DIR} --url https://s3-eu-west-1.amazonaws.com/${HELM_BUCKET_NAME}/stable/ --debug
+

--- a/helm/hack/sync-repo.sh
+++ b/helm/hack/sync-repo.sh
@@ -7,4 +7,21 @@ set -o xtrace
 
 HELM_BUCKET_NAME="coreos-charts"
 HELM_CHARTS_PACKAGED_DIR=${1:-"/tmp/helm-packaged"}
+AWS_REGION=${2:-"us-west-2"}
+
+aws configure set region ${AWS_REGION}
+
+#Check if the current chart has the same hash from the remote one
+for tgz in $(ls ${HELM_CHARTS_PACKAGED_DIR})
+do
+  cur_hash=$(cat ${HELM_CHARTS_PACKAGED_DIR}/${tgz}|md5sum)
+  remote_hash=$(aws s3api head-object --bucket ${HELM_BUCKET_NAME} --key stable/${tgz} | jq '.ETag' -r| tr -d '"')
+  if [ "$cur_hash" != "$remote_hash" ]
+  then
+    echo "Current hash should be the same as the remote hash. Please bump the version of chart {$tgz}."
+    exit 1
+   fi
+done
+
+# sync charts
 aws s3 sync --acl public-read ${HELM_CHARTS_PACKAGED_DIR} s3://${HELM_BUCKET_NAME}/stable/

--- a/helm/hack/sync-repo.sh
+++ b/helm/hack/sync-repo.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+HELM_BUCKET_NAME="coreos-charts"
+HELM_CHARTS_PACKAGED_DIR=${1:-"/tmp/helm-packaged"}
+aws s3 sync --acl public-read ${HELM_CHARTS_PACKAGED_DIR} s3://${HELM_BUCKET_NAME}/stable/

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -4,6 +4,14 @@ dependencies:
     #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
+  - name: prometheus-operator
+    version: 0.0.7
+    repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+    
+  - name: grafana
+    version: 0.0.4
+    repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+    
   - name: prometheus
     version: 0.0.5
     #e2e-repository: file://../prometheus

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,10 +6,12 @@ dependencies:
 
   - name: prometheus-operator
     version: 0.0.7
+    #e2e-repository: file://../prometheus-operator
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     
   - name: grafana
     version: 0.0.4
+    #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     
   - name: prometheus


### PR DESCRIPTION
Automatically package helm charts after a PR
Add prometheus-operator and grafana as requirement for kube-prometheus
Avoid chart overriding, comparing the generated hash and the hash in the server

Before merge this PR it's required to configure the aws credentials on travis ci.