### PR TITLE
Fix cluster:container_cpu_usage:ratio rule

### DIFF
--- a/contrib/kube-prometheus/assets/prometheus/rules/kubernetes.rules.yaml
+++ b/contrib/kube-prometheus/assets/prometheus/rules/kubernetes.rules.yaml
@@ -25,7 +25,7 @@ groups:
     expr: sum(container_spec_cpu_shares{container_name!="POD",pod_name!=""}) / 1000
       / sum(machine_cpu_cores)
   - record: cluster:container_cpu_usage:ratio
-    expr: rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[5m])
+    expr: sum(rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[5m]))
       / sum(machine_cpu_cores)
   - record: apiserver_latency_seconds:quantile
     expr: histogram_quantile(0.99, rate(apiserver_request_latencies_bucket[5m])) /

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -406,7 +406,7 @@ data:
         expr: sum(container_spec_cpu_shares{container_name!="POD",pod_name!=""}) / 1000
           / sum(machine_cpu_cores)
       - record: cluster:container_cpu_usage:ratio
-        expr: rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[5m])
+        expr: sum(rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[5m]))
           / sum(machine_cpu_cores)
       - record: apiserver_latency_seconds:quantile
         expr: histogram_quantile(0.99, rate(apiserver_request_latencies_bucket[5m])) /


### PR DESCRIPTION
Hi! :)

This small PR fixes `cluster:container_cpu_usage:ratio` rule for K8s metrics rules.