### PR TITLE
Creates proper whitespace and sets id to null for dashboards

### DIFF
--- a/contrib/kube-prometheus/hack/scripts/wrap-dashboard.sh
+++ b/contrib/kube-prometheus/hack/scripts/wrap-dashboard.sh
@@ -21,7 +21,8 @@ if [ "$#" -ne 1 ]; then
 fi
 
 dashboardjson=$1
-
+sed -i -e 's/^/    /' $dashboardjson
+sed -i '0,/"id":.*,/s//"id": null,/' $dashboardjson
 cat <<EOF
 {
   "dashboard":


### PR DESCRIPTION
Fixes #786 

Wrapper.sh currently creates improper YAML.
```YAML
{
  "dashboard":
  {
  "annotations": {
    "list": []
  },
```
should be
```YAML
{
  "dashboard": {
    "annotations": {
      "list": []
     },
```

Also if you save your dashboard per the docs, the dashboards don't show up because the id is not null per the grafana docs. http://docs.grafana.org/http_api/dashboard/

also in the future might want to switch grafana watcher to use the `/api/dashboards/db` endpoint? The grafana devs are insisting on it over the `/import` currently being used.