### PR TITLE
Enable e2e tests on helm charts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ jobs:
     script: make test
   - stage: E2e tests
     script: ./scripts/travis-e2e.sh
+  - stage: E2e helm
+    script: ./scripts/travis-e2e-helm.sh

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ e2e:
 	$(MAKE) container
 	$(MAKE) e2e-test
 
+e2e-helm:
+	./helm/hack/e2e-test.sh
+
 clean-e2e:
 	kubectl -n $(NAMESPACE) delete prometheus,alertmanager,servicemonitor,statefulsets,deploy,svc,endpoints,pods,cm,secrets,replicationcontrollers --all
 	kubectl delete namespace $(NAMESPACE)

--- a/helm/hack/e2e-test.sh
+++ b/helm/hack/e2e-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# Install and initialize helm/tiller
+HELM_URL=https://storage.googleapis.com/kubernetes-helm
+HELM_TARBALL=helm-v2.7.2-linux-amd64.tar.gz
+NAMESPACE="helm-monitoring"
+CUR_DIR=$(dirname "$BASH_SOURCE")
+wget -q ${HELM_URL}/${HELM_TARBALL}
+tar xzfv ${HELM_TARBALL}
+
+# # Clean up tarball
+rm -f ${HELM_TARBALL}
+sudo mv linux-amd64/helm /usr/local/bin
+# setup tiller
+kubectl -n kube-system create sa tiller
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+helm init --service-account tiller --upgrade
+
+# wait until all minkube pods, including tiller, are in reading state
+$(dirname "$BASH_SOURCE")/wait-pods-running-state.sh kube-system 
+
+kubectl create ns ${NAMESPACE}
+
+# replace current http repository to the helm path
+sed -ie 's/    repository/#    repository/g' $(pwd)/helm/*/requirements.yaml
+sed -ie 's/#e2e-repository/repository/g' $(pwd)/helm/*/requirements.yaml
+
+# package charts and install all 
+$(dirname "$BASH_SOURCE")/helm-package.sh prometheus-operator
+$(dirname "$BASH_SOURCE")/helm-package.sh kube-prometheus
+
+helm install --namespace=${NAMESPACE} $(pwd)/helm/prometheus-operator --name prometheus-operator
+helm install --namespace=${NAMESPACE} $(pwd)/helm/kube-prometheus --name kube-prometheus
+
+# check if all pods are ready 
+$(dirname "$BASH_SOURCE")/wait-pods-running-state.sh ${NAMESPACE}
+
+# reset helm changes
+git reset --hard

--- a/helm/hack/helm-package.sh
+++ b/helm/hack/helm-package.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# Install and initialize helm/tiller
+HELM_URL=https://storage.googleapis.com/kubernetes-helm
+HELM_TARBALL=helm-v2.7.2-linux-amd64.tar.gz
+HELM_PACKAGES=${1}
+HELM_BUCKET_NAME="coreos-charts"
+HELM_CHARTS_DIRECTORY=${2:-"$(pwd)/helm"}
+HELM_CHARTS_PACKAGED_DIR=${3:-"/tmp/helm-packaged"}
+
+wget -q ${HELM_URL}/${HELM_TARBALL}
+tar xzfv ${HELM_TARBALL}
+export PATH=${PATH}:$(pwd)/linux-amd64/helm
+
+# Clean up tarball
+rm -f ${HELM_TARBALL}
+
+# Package helm and dependencies
+mkdir -p ${HELM_CHARTS_PACKAGED_DIR}
+
+# check if charts has dependencies,
+for chart in ${HELM_PACKAGES}
+do 
+    # #  update dependencies before package the chart
+    # if ls ${HELM_CHARTS_DIRECTORY}/${chart} 
+    # do
+        cd ${HELM_CHARTS_DIRECTORY}/${chart} 
+        helm dep update
+        helm package . -d ${HELM_CHARTS_PACKAGED_DIR} 
+        cd -
+    # done
+done
+
+helm repo index ${HELM_CHARTS_PACKAGED_DIR} --url https://s3-eu-west-1.amazonaws.com/${HELM_BUCKET_NAME}/stable/ --debug

--- a/helm/hack/wait-pods-running-state.sh
+++ b/helm/hack/wait-pods-running-state.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -xe
+###
+### Borrowed from https://github.com/kubernetes/charts/blob/master/test/verify-release.sh
+### 
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+NAMESPACE=$1
+
+# Ensure all pods in the namespace entered a Running state
+SUCCESS=0
+PODS_FOUND=0
+POD_RETRY_COUNT=0
+RETRY=60
+RETRY_DELAY=10
+while [ "$POD_RETRY_COUNT" -lt "$RETRY" ]; do
+  POD_RETRY_COUNT=$((POD_RETRY_COUNT+1))
+  POD_STATUS=`kubectl get pods --no-headers --namespace $NAMESPACE`
+  if [ -z "$POD_STATUS" ];then
+    echo "INFO: No pods found for this release, retrying after sleep"
+    POD_RETRY_COUNT=$((POD_RETRY_COUNT+1))
+    sleep $RETRY_DELAY
+    continue
+  else
+    PODS_FOUND=1
+    sleep $RETRY_DELAY
+  fi
+
+  if ! echo "$POD_STATUS" | grep -v Running;then
+    echo "INFO: All pods entered the Running state"
+
+    CONTAINER_RETRY_COUNT=0
+    while [ "$CONTAINER_RETRY_COUNT" -lt "$RETRY" ]; do
+      UNREADY_CONTAINERS=`kubectl get pods --namespace $NAMESPACE \
+        -o jsonpath="{.items[*].status.containerStatuses[?(@.ready!=true)].name}"`
+      if [ -n "$UNREADY_CONTAINERS" ];then
+        echo "INFO: Some containers are not yet ready; retrying after sleep"
+        CONTAINER_RETRY_COUNT=$((CONTAINER_RETRY_COUNT+1))
+  	sleep $RETRY_DELAY
+        continue
+      else
+        echo "INFO: All containers are ready"
+        exit 0
+      fi
+    done
+  fi
+done
+
+if [ "$PODS_FOUND" -eq 0 ];then
+  echo "WARN: No pods launched by this chart's default settings"
+  exit 0
+else
+  echo "ERROR: Some containers failed to reach the ready state"
+  exit 1
+fi

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -1,50 +1,62 @@
 dependencies:
   - name: alertmanager
     version: 0.0.5
+    #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: prometheus
     version: 0.0.5
+    #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-api
     version: 0.1.1
+    #e2e-repository: file://../exporter-kube-api
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-controller-manager
     version: 0.1.1
+    #e2e-repository: file://../exporter-kube-controller-manager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-dns
     version: 0.1.1
+    #e2e-repository: file://../exporter-kube-dns
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-etcd
     version: 0.1.1
+    #e2e-repository: file://../exporter-kube-etcd
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-scheduler
     version: 0.1.1
+    #e2e-repository: file://../exporter-kube-scheduler
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-state
     version: 0.1.3
+    #e2e-repository: file://../exporter-kube-state
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kubelets
     version: 0.1.1
+    #e2e-repository: file://../exporter-kubelets
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kubernetes
     version: 0.1.1
+    #e2e-repository: file://../exporter-kubernetes
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-node
     version: 0.1.1
+    #e2e-repository: file://../exporter-node
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployExporterNode
 
   - name: grafana
     version: 0.0.4
+    #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana

--- a/scripts/create-minikube.sh
+++ b/scripts/create-minikube.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+# print each command before executing it
+set -x
+
+export MINIKUBE_VERSION=v0.24.1
+export KUBERNETES_VERSION=v1.8.0
+
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
+    chmod +x kubectl &&  \
+    sudo mv kubectl /usr/local/bin/
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-amd64 && \
+    chmod +x minikube && \
+    sudo mv minikube /usr/local/bin/
+
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+export MINIKUBE_WANTREPORTERRORPROMPT=false
+export MINIKUBE_HOME=$HOME
+export CHANGE_MINIKUBE_NONE_USER=true
+mkdir $HOME/.kube || true
+touch $HOME/.kube/config
+
+export KUBECONFIG=$HOME/.kube/config
+minikube version
+sudo minikube start --vm-driver=none --kubernetes-version=$KUBERNETES_VERSION --extra-config=apiserver.Authorization.Mode=RBAC
+
+minikube update-context
+
+# waiting for node(s) to be ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
+kubectl apply -f scripts/minikube-rbac.yaml
+
+# waiting for kube-dns to be ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done

--- a/scripts/delete-minikube.sh
+++ b/scripts/delete-minikube.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+# print each command before executing it
+set -x
+
+export KUBECONFIG=$HOME/.kube/config
+
+minikube version
+sudo minikube stop
+sudo minikube delete

--- a/scripts/travis-e2e-helm.sh
+++ b/scripts/travis-e2e-helm.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+# print each command before executing it
+set -x
+
+$(dirname "$BASH_SOURCE")/create-minikube.sh
+
+# build nsenter
+# https://github.com/kubernetes/helm/issues/966
+sudo apt-get update
+sudo apt-get install libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool
+mkdir .tmp || true
+wget https://www.kernel.org/pub/linux/utils/util-linux/v2.30/util-linux-2.30.2.tar.gz -qO - | tar -xz -C .tmp/
+cd .tmp/util-linux-2.30.2 && ./autogen.sh && ./configure && make nsenter && sudo cp nsenter /usr/local/bin && cd -  
+
+make e2e-helm
+
+$(dirname "$BASH_SOURCE")/delete-minikube.sh

--- a/scripts/travis-e2e.sh
+++ b/scripts/travis-e2e.sh
@@ -8,36 +8,12 @@ set -u
 # print each command before executing it
 set -x
 
-export MINIKUBE_VERSION=v0.24.1
-export KUBERNETES_VERSION=v1.8.0
-
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
-    chmod +x kubectl &&  \
-    sudo mv kubectl /usr/local/bin/
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-amd64 && \
-    chmod +x minikube && \
-    sudo mv minikube /usr/local/bin/
-
-export MINIKUBE_WANTUPDATENOTIFICATION=false
-export MINIKUBE_WANTREPORTERRORPROMPT=false
-export MINIKUBE_HOME=$HOME
-export CHANGE_MINIKUBE_NONE_USER=true
-mkdir $HOME/.kube || true
-touch $HOME/.kube/config
-
-export KUBECONFIG=$HOME/.kube/config
-minikube version
-sudo minikube start --vm-driver=none --kubernetes-version=$KUBERNETES_VERSION --extra-config=apiserver.Authorization.Mode=RBAC
-
-minikube update-context
-
-# waiting for node(s) to be ready
-JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
-
-kubectl apply -f scripts/minikube-rbac.yaml
+$(dirname "$BASH_SOURCE")/create-minikube.sh
 
 # waiting for kube-dns to be ready
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 
 make crossbuild
 make e2e
+
+$(dirname "$BASH_SOURCE")/delete-minikube.sh


### PR DESCRIPTION
This PR will enable e2e tests on the helm charts. It will setup kube-prometheus and prometheus-operator and wait until all the pods/containers are in ready state. 