### PR TITLE
contrib: namespace warning to kube-prometheus

### DIFF
--- a/contrib/kube-prometheus/hack/cluster-monitoring/deploy
+++ b/contrib/kube-prometheus/hack/cluster-monitoring/deploy
@@ -4,6 +4,9 @@ if [ -z "${KUBECONFIG}" ]; then
     export KUBECONFIG=~/.kube/config
 fi
 
+# CAUTION - setting NAMESPACE will deploy most components to the given namespace
+# however some are hardcoded to 'monitoring'. Only use if you have reviewed all manifests.
+
 if [ -z "${NAMESPACE}" ]; then
     NAMESPACE=monitoring
 fi

--- a/contrib/kube-prometheus/hack/cluster-monitoring/teardown
+++ b/contrib/kube-prometheus/hack/cluster-monitoring/teardown
@@ -4,6 +4,9 @@ if [ -z "${KUBECONFIG}" ]; then
     export KUBECONFIG=~/.kube/config
 fi
 
+# CAUTION - NAMESPACE must match its value when deploy script was run.
+# Some resources are always deployed to the monitoring namespace. 
+
 if [ -z "${NAMESPACE}" ]; then
     NAMESPACE=monitoring
 fi


### PR DESCRIPTION
NAMESPACE feature in scripts implies it works. Warning ensures
that users are aware that its use requires further changes.

Alleviates #765