### PR TITLE
Fix operator endpoint

### DIFF
--- a/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
+++ b/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
@@ -25,5 +25,5 @@ data:
           matchNames:
             - {{ .Release.Namespace | quote }}
         endpoints:
-        - port: web
+        - port: http
           interval: 30s


### PR DESCRIPTION
Correct me if I'm wrong but shouldn't it be `http` to match deployment manifest? 
https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/templates/deployment.yaml#L32