### PR TITLE
ServiceMonitor and Prometheus Namespaces Shouldn't Have to Match

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1000,9 +1000,8 @@ func (c *Operator) selectServiceMonitors(p *monitoringv1.Prometheus) (map[string
 		return nil, err
 	}
 
-	// Only service monitors within the same namespace as the Prometheus
-	// object can belong to it.
-	cache.ListAllByNamespace(c.smonInf.GetIndexer(), p.Namespace, selector, func(obj interface{}) {
+	// Use specified namespace for ServiceMonitor scope (default v1.NamespaceAll)
+	cache.ListAllByNamespace(c.smonInf.GetIndexer(), c.config.Namespace, selector, func(obj interface{}) {
 		k, ok := c.keyFunc(obj)
 		if ok {
 			res[k] = obj.(*monitoringv1.ServiceMonitor)


### PR DESCRIPTION
To match functionality with PR (https://github.com/coreos/prometheus-operator/pull/687), making it so that ServiceMonitor namespaces don't have to match Prometheus cluster namespace.