### PR TITLE
Add cert expiration rule

### DIFF
--- a/contrib/kube-prometheus/assets/prometheus/rules/kubernetes.rules.yaml
+++ b/contrib/kube-prometheus/assets/prometheus/rules/kubernetes.rules.yaml
@@ -84,3 +84,17 @@ groups:
     annotations:
       description: No API servers are reachable or all have disappeared from service
         discovery
+
+  - alert: K8sCertificateExpirationNotice
+    labels:
+      severity: warning
+    annotations:
+      description: Kubernetes API Certificate is expiring soon (less than 7 days)
+    expr: sum(apiserver_client_certificate_expiration_seconds_bucket{le="604800"}) > 0
+
+  - alert: K8sCertificateExpirationNotice
+    labels:
+      severity: critical
+    annotations:
+      description: Kubernetes API Certificate is expiring in less than 1 day
+    expr: sum(apiserver_client_certificate_expiration_seconds_bucket{le="86400"}) > 0

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -469,6 +469,20 @@ data:
         annotations:
           description: No API servers are reachable or all have disappeared from service
             discovery
+    
+      - alert: K8sCertificateExpirationNotice
+        labels:
+          severity: warning
+        annotations:
+          description: Kubernetes API Certificate is expiring soon (less than 7 days)
+        expr: sum(apiserver_client_certificate_expiration_seconds_bucket{le="604800"}) > 0
+    
+      - alert: K8sCertificateExpirationNotice
+        labels:
+          severity: critical
+        annotations:
+          description: Kubernetes API Certificate is expiring in less than 1 day
+        expr: sum(apiserver_client_certificate_expiration_seconds_bucket{le="86400"}) > 0
   node.rules.yaml: |+
     groups:
     - name: node.rules


### PR DESCRIPTION
if there's more than 1 certs that's going to expire on a bucket, sum is > 0 and fires an alert. 
Send a warning for 7 days, 1 day, and critical if expired.
(We can remove the 1 day if it's redundant)
