### PR TITLE
support prometheus-operator below v0.12.0 (eg: for k8s 1.6)

### DIFF
--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.6
+version: 0.0.7

--- a/helm/alertmanager/templates/_helpers.tpl
+++ b/helm/alertmanager/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "alertmanager.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "alertmanager.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/alertmanager/templates/alertmanager.yaml
+++ b/helm/alertmanager/templates/alertmanager.yaml
@@ -1,9 +1,9 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: Alertmanager
 metadata:
   labels:
     alertmanager: {{ .Release.Name }}
-    app: {{ template "name" . }}
+    app: {{ template "alertmanager.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -18,7 +18,7 @@ spec:
 {{- else if .Values.ingress.fqdn }}
   externalUrl: http://{{ .Values.ingress.fqdn }}{{ .Values.routePrefix }}
 {{- else }}
-  externalUrl: http://{{ template "fullname" . }}.{{ .Release.Namespace }}:9093
+  externalUrl: http://{{ template "alertmanager.fullname" . }}.{{ .Release.Namespace }}:9093
 {{- end }}
 {{- if .Values.nodeSelector }}
   nodeSelector:

--- a/helm/alertmanager/templates/configmap.yaml
+++ b/helm/alertmanager/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "alertmanager.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/alertmanager/templates/configmap.yaml
+++ b/helm/alertmanager/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "alertmanager.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/alertmanager/templates/ingress.yaml
+++ b/helm/alertmanager/templates/ingress.yaml
@@ -8,14 +8,14 @@ metadata:
 {{- end }}
   labels:
     alertmanager: {{ .Release.Name }}
-    app: {{ template "name" . }}
+    app: {{ template "alertmanager.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
-  name: {{ template "fullname" . }}
+  name: {{ template "alertmanager.fullname" . }}
 spec:
   rules:
     - host: "{{ .Values.ingress.fqdn }}"
@@ -23,7 +23,7 @@ spec:
         paths:
           - path: "{{ .Values.routePrefix }}"
             backend:
-              serviceName: {{ template "fullname" . }}
+              serviceName: {{ template "alertmanager.fullname" . }}
               servicePort: 9093
 {{- if .Values.ingress.tls }}
   tls:

--- a/helm/alertmanager/templates/secret.yaml
+++ b/helm/alertmanager/templates/secret.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   labels:
     alertmanager: {{ .Release.Name }}
-    app: {{ template "name" . }}
+    app: {{ template "alertmanager.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/helm/alertmanager/templates/service.yaml
+++ b/helm/alertmanager/templates/service.yaml
@@ -7,14 +7,14 @@ metadata:
 {{- end }}
   labels:
     alertmanager: {{ .Release.Name }}
-    app: {{ template "name" . }}
+    app: {{ template "alertmanager.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
-  name: {{ template "fullname" . }}
+  name: {{ template "alertmanager.fullname" . }}
 spec:
   clusterIP: "{{ .Values.service.clusterIP }}"
 {{- if .Values.service.externalIPs }}
@@ -38,5 +38,5 @@ spec:
       protocol: TCP
   selector:
     alertmanager: {{ .Release.Name }}
-    app: {{ template "name" . }}
+    app: {{ template "alertmanager.name" . }}
   type: "{{ .Values.service.type }}"

--- a/helm/alertmanager/templates/servicemonitor.yaml
+++ b/helm/alertmanager/templates/servicemonitor.yaml
@@ -1,21 +1,21 @@
 {{- if .Values.selfServiceMonitor }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "alertmanager.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: alertmanager
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "alertmanager.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "alertmanager.fullname" . }}
   selector:
     matchLabels:
       alertmanager: {{ .Release.Name }}
-      app: {{ template "name" . }}
+      app: {{ template "alertmanager.name" . }}
       chart: {{ .Chart.Name }}-{{ .Chart.Version }}
   namespaceSelector:
     matchNames:

--- a/helm/exporter-kube-controller-manager/Chart.yaml
+++ b/helm/exporter-kube-controller-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-kube-controller-manager
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kube-controller-manager/templates/_helpers.tpl
+++ b/helm/exporter-kube-controller-manager/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "exporter-kube-controller-manager.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "exporter-kube-controller-manager.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/exporter-kube-controller-manager/templates/configmap.yaml
+++ b/helm/exporter-kube-controller-manager/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-controller-manager.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/exporter-kube-controller-manager/templates/configmap.yaml
+++ b/helm/exporter-kube-controller-manager/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "exporter-kube-controller-manager.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/exporter-kube-controller-manager/templates/kube-controller-manager.rules.yaml
+++ b/helm/exporter-kube-controller-manager/templates/kube-controller-manager.rules.yaml
@@ -3,7 +3,7 @@ groups:
 - name: kube-controller-manager.rules
   rules:
   - alert: K8SControllerManagerDown
-    expr: absent(up{job="{{ template "fullname" .  }}"} == 1)
+    expr: absent(up{job="{{ template "exporter-kube-controller-manager.fullname" .  }}"} == 1)
     for: 5m
     labels:
       severity: critical

--- a/helm/exporter-kube-controller-manager/templates/service.yaml
+++ b/helm/exporter-kube-controller-manager/templates/service.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-controller-manager.name" . }}
     component: kube-controller-manager
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-controller-manager.fullname" . }}
   namespace: kube-system
 spec:
   clusterIP: None

--- a/helm/exporter-kube-controller-manager/templates/servicemonitor.yaml
+++ b/helm/exporter-kube-controller-manager/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
@@ -7,12 +7,12 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-controller-manager.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "exporter-kube-controller-manager.fullname" . }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "exporter-kube-controller-manager.name" . }}
       component: kube-controller-manager
   namespaceSelector:
     matchNames:

--- a/helm/exporter-kube-dns/Chart.yaml
+++ b/helm/exporter-kube-dns/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-dns
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kube-dns/templates/_helpers.tpl
+++ b/helm/exporter-kube-dns/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "exporter-kube-dns.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "exporter-kube-dns.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/exporter-kube-dns/templates/service.yaml
+++ b/helm/exporter-kube-dns/templates/service.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-dns.name" . }}
     component: kube-dns
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-dns.fullname" . }}
   namespace: kube-system
 spec:
   clusterIP: None

--- a/helm/exporter-kube-dns/templates/servicemonitor.yaml
+++ b/helm/exporter-kube-dns/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
@@ -7,12 +7,12 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-dns.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "exporter-kube-dns.fullname" . }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "exporter-kube-dns.name" . }}
       component: kube-dns
   namespaceSelector:
     matchNames:

--- a/helm/exporter-kube-etcd/Chart.yaml
+++ b/helm/exporter-kube-etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-kube-etcd
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kube-etcd/templates/_helpers.tpl
+++ b/helm/exporter-kube-etcd/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "exporter-kube-etcd.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "exporter-kube-etcd.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/exporter-kube-etcd/templates/configmap.yaml
+++ b/helm/exporter-kube-etcd/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-etcd.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/exporter-kube-etcd/templates/configmap.yaml
+++ b/helm/exporter-kube-etcd/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "exporter-kube-etcd.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/exporter-kube-etcd/templates/etcd3.rules.yaml
+++ b/helm/exporter-kube-etcd/templates/etcd3.rules.yaml
@@ -3,7 +3,7 @@ groups:
 - name: ./etcd3.rules
   rules:
   - alert: InsufficientMembers
-    expr: count(up{job="{{ template "fullname" .  }}"} == 0) > (count(up{job="{{ template "fullname" .  }}"}) / 2 - 1)
+    expr: count(up{job="{{ template "exporter-kube-etcd.fullname" .  }}"} == 0) > (count(up{job="{{ template "exporter-kube-etcd.fullname" .  }}"}) / 2 - 1)
     for: 3m
     labels:
       severity: critical
@@ -11,7 +11,7 @@ groups:
       description: If one more etcd member goes down the cluster will be unavailable
       summary: etcd cluster insufficient members
   - alert: NoLeader
-    expr: etcd_server_has_leader{job="{{ template "fullname" .  }}"} == 0
+    expr: etcd_server_has_leader{job="{{ template "exporter-kube-etcd.fullname" .  }}"} == 0
     for: 1m
     labels:
       severity: critical
@@ -19,7 +19,7 @@ groups:
       description: etcd member {{`{{ $labels.instance }}`}} has no leader
       summary: etcd member has no leader
   - alert: HighNumberOfLeaderChanges
-    expr: increase(etcd_server_leader_changes_seen_total{job="{{ template "fullname" .  }}"}[1h]) > 3
+    expr: increase(etcd_server_leader_changes_seen_total{job="{{ template "exporter-kube-etcd.fullname" .  }}"}[1h]) > 3
     labels:
       severity: warning
     annotations:
@@ -27,8 +27,8 @@ groups:
         changes within the last hour
       summary: a high number of leader changes within the etcd cluster are happening
   - alert: HighNumberOfFailedGRPCRequests
-    expr: sum(rate(grpc_server_handled_total{grpc_code!="OK",job="{{ template "fullname" .  }}"}[5m])) BY (grpc_service, grpc_method)
-      / sum(rate(grpc_server_handled_total{job="{{ template "fullname" .  }}"}[5m])) BY (grpc_service, grpc_method) > 0.01
+    expr: sum(rate(grpc_server_handled_total{grpc_code!="OK",job="{{ template "exporter-kube-etcd.fullname" .  }}"}[5m])) BY (grpc_service, grpc_method)
+      / sum(rate(grpc_server_handled_total{job="{{ template "exporter-kube-etcd.fullname" .  }}"}[5m])) BY (grpc_service, grpc_method) > 0.01
     for: 10m
     labels:
       severity: warning
@@ -37,8 +37,8 @@ groups:
         on etcd instance {{`{{ $labels.instance }}`}}'
       summary: a high number of gRPC requests are failing
   - alert: HighNumberOfFailedGRPCRequests
-    expr: sum(rate(grpc_server_handled_total{grpc_code!="OK",job="{{ template "fullname" .  }}"}[5m])) BY (grpc_service, grpc_method)
-      / sum(rate(grpc_server_handled_total{job="{{ template "fullname" .  }}"}[5m])) BY (grpc_service, grpc_method) > 0.05
+    expr: sum(rate(grpc_server_handled_total{grpc_code!="OK",job="{{ template "exporter-kube-etcd.fullname" .  }}"}[5m])) BY (grpc_service, grpc_method)
+      / sum(rate(grpc_server_handled_total{job="{{ template "exporter-kube-etcd.fullname" .  }}"}[5m])) BY (grpc_service, grpc_method) > 0.05
     for: 5m
     labels:
       severity: critical
@@ -47,7 +47,7 @@ groups:
         on etcd instance {{`{{ $labels.instance }}`}}'
       summary: a high number of gRPC requests are failing
   - alert: GRPCRequestsSlow
-    expr: histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="{{ template "fullname" .  }}",grpc_type="unary"}[5m])) by (grpc_service, grpc_method, le))
+    expr: histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="{{ template "exporter-kube-etcd.fullname" .  }}",grpc_type="unary"}[5m])) by (grpc_service, grpc_method, le))
       > 0.15
     for: 10m
     labels:
@@ -57,7 +57,7 @@ groups:
         }}`}} are slow
       summary: slow gRPC requests
   - alert: HighNumberOfFailedHTTPRequests
-    expr: sum(rate(etcd_http_failed_total{job="{{ template "fullname" .  }}"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job="{{ template "fullname" .  }}"}[5m]))
+    expr: sum(rate(etcd_http_failed_total{job="{{ template "exporter-kube-etcd.fullname" .  }}"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job="{{ template "exporter-kube-etcd.fullname" .  }}"}[5m]))
       BY (method) > 0.01
     for: 10m
     labels:
@@ -67,7 +67,7 @@ groups:
         instance {{`{{ $labels.instance }}`}}'
       summary: a high number of HTTP requests are failing
   - alert: HighNumberOfFailedHTTPRequests
-    expr: sum(rate(etcd_http_failed_total{job="{{ template "fullname" .  }}"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job="{{ template "fullname" .  }}"}[5m]))
+    expr: sum(rate(etcd_http_failed_total{job="{{ template "exporter-kube-etcd.fullname" .  }}"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job="{{ template "exporter-kube-etcd.fullname" .  }}"}[5m]))
       BY (method) > 0.05
     for: 5m
     labels:
@@ -97,7 +97,7 @@ groups:
         {{`{{ $labels.To }}`}} is slow
       summary: etcd member communication is slow
   - alert: HighNumberOfFailedProposals
-    expr: increase(etcd_server_proposals_failed_total{job="{{ template "fullname" .  }}"}[1h]) > 5
+    expr: increase(etcd_server_proposals_failed_total{job="{{ template "exporter-kube-etcd.fullname" .  }}"}[1h]) > 5
     labels:
       severity: warning
     annotations:

--- a/helm/exporter-kube-etcd/templates/service.yaml
+++ b/helm/exporter-kube-etcd/templates/service.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-etcd.name" . }}
     component: kube-etcd
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-etcd.fullname" . }}
   namespace: kube-system
 spec:
   clusterIP: None

--- a/helm/exporter-kube-etcd/templates/servicemonitor.yaml
+++ b/helm/exporter-kube-etcd/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
@@ -7,12 +7,12 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-etcd.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "exporter-kube-etcd.fullname" . }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "exporter-kube-etcd.name" . }}
       component: kube-etcd
   namespaceSelector:
     matchNames:

--- a/helm/exporter-kube-scheduler/Chart.yaml
+++ b/helm/exporter-kube-scheduler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-scheduler
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kube-scheduler/templates/_helpers.tpl
+++ b/helm/exporter-kube-scheduler/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "exporter-kube-scheduler.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "exporter-kube-scheduler.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/exporter-kube-scheduler/templates/configmap.yaml
+++ b/helm/exporter-kube-scheduler/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-scheduler.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/exporter-kube-scheduler/templates/configmap.yaml
+++ b/helm/exporter-kube-scheduler/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "exporter-kube-scheduler.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/exporter-kube-scheduler/templates/kube-scheduler.rules.yaml
+++ b/helm/exporter-kube-scheduler/templates/kube-scheduler.rules.yaml
@@ -48,7 +48,7 @@ groups:
     labels:
       quantile: "0.5"
   - alert: K8SSchedulerDown
-    expr: absent(up{job="{{ template "fullname" .  }}"} == 1)
+    expr: absent(up{job="{{ template "exporter-kube-scheduler.fullname" .  }}"} == 1)
     for: 5m
     labels:
       severity: critical

--- a/helm/exporter-kube-scheduler/templates/service.yaml
+++ b/helm/exporter-kube-scheduler/templates/service.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-scheduler.name" . }}
     component: kube-scheduler
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-scheduler.fullname" . }}
   namespace: kube-system
 spec:
   clusterIP: None

--- a/helm/exporter-kube-scheduler/templates/servicemonitor.yaml
+++ b/helm/exporter-kube-scheduler/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
@@ -7,12 +7,12 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-scheduler.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "exporter-kube-scheduler.fullname" . }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "exporter-kube-scheduler.name" . }}
       component: kube-scheduler
   namespaceSelector:
     matchNames:

--- a/helm/exporter-kube-state/Chart.yaml
+++ b/helm/exporter-kube-state/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-state
-version: 0.1.4
+version: 0.1.5
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kube-state/templates/_helpers.tpl
+++ b/helm/exporter-kube-state/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "exporter-kube-state.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "exporter-kube-state.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/exporter-kube-state/templates/clusterrole.yaml
+++ b/helm/exporter-kube-state/templates/clusterrole.yaml
@@ -7,11 +7,11 @@ apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-state.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 rules:
 - apiGroups: [""]
   resources:

--- a/helm/exporter-kube-state/templates/clusterrolebinding.yaml
+++ b/helm/exporter-kube-state/templates/clusterrolebinding.yaml
@@ -7,17 +7,17 @@ apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-state.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "fullname" . }}
+    name: {{ template "exporter-kube-state.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/helm/exporter-kube-state/templates/configmap.yaml
+++ b/helm/exporter-kube-state/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/exporter-kube-state/templates/configmap.yaml
+++ b/helm/exporter-kube-state/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "exporter-kube-state.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/exporter-kube-state/templates/deployment.yaml
+++ b/helm/exporter-kube-state/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-state.name" . }}
     component: kube-state
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -19,11 +19,11 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "exporter-kube-state.fullname" . }}
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "exporter-kube-state.fullname" . }}
         component: kube-state
         release: {{ .Release.Name }}
         version: "{{ .Values.kube_state_metrics.image.tag }}"
@@ -66,9 +66,9 @@ spec:
           - --memory=100Mi
           - --extra-memory=2Mi
           - --threshold=5
-          - --deployment={{ template "fullname" . }}
+          - --deployment={{ template "exporter-kube-state.fullname" . }}
         resources:
 {{ toYaml .Values.addon_resizer.resources | indent 12 }}
     {{- if .Values.rbacEnable }}
-      serviceAccountName: {{ template "fullname" . }}
+      serviceAccountName: {{ template "exporter-kube-state.fullname" . }}
     {{- end }}

--- a/helm/exporter-kube-state/templates/role.yaml
+++ b/helm/exporter-kube-state/templates/role.yaml
@@ -7,17 +7,17 @@ apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-state.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get"]
 - apiGroups: ["extensions"]
   resources: ["deployments"]
-  resourceNames: [{{ template "fullname" . }}]
+  resourceNames: [{{ template "exporter-kube-state.fullname" . }}]
   verbs: ["get", "update"]
 {{- end }}

--- a/helm/exporter-kube-state/templates/rolebinding.yaml
+++ b/helm/exporter-kube-state/templates/rolebinding.yaml
@@ -7,16 +7,16 @@ apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: RoleBinding
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-state.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 {{- end }}

--- a/helm/exporter-kube-state/templates/service.yaml
+++ b/helm/exporter-kube-state/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-state.name" . }}
     component: kube-state
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -16,6 +16,6 @@ spec:
     protocol: TCP
     name: {{ .Values.kube_state_metrics.service.name }}
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "exporter-kube-state.fullname" . }}
     component: kube-state
     release: {{ .Release.Name }}

--- a/helm/exporter-kube-state/templates/serviceaccount.yaml
+++ b/helm/exporter-kube-state/templates/serviceaccount.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-kube-state.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 {{- end }}

--- a/helm/exporter-kube-state/templates/servicemonitor.yaml
+++ b/helm/exporter-kube-state/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
@@ -7,12 +7,12 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kube-state.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "exporter-kube-state.fullname" . }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "exporter-kube-state.name" . }}
       component: kube-state
   namespaceSelector:
     matchNames:

--- a/helm/exporter-kubelets/Chart.yaml
+++ b/helm/exporter-kubelets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-kubelets
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kubelets/templates/_helpers.tpl
+++ b/helm/exporter-kubelets/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "exporter-kubelets.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "exporter-kubelets.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/exporter-kubelets/templates/configmap.yaml
+++ b/helm/exporter-kubelets/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kubelets.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/exporter-kubelets/templates/configmap.yaml
+++ b/helm/exporter-kubelets/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "exporter-kubelets.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/exporter-kubelets/templates/servicemonitor.yaml
+++ b/helm/exporter-kubelets/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
@@ -7,9 +7,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kubelets.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "exporter-kubelets.fullname" . }}
   selector:
     matchLabels:
       k8s-app: kubelet

--- a/helm/exporter-kubernetes/Chart.yaml
+++ b/helm/exporter-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-kubernetes
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kubernetes/templates/_helpers.tpl
+++ b/helm/exporter-kubernetes/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "exporter-kubernetes.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "exporter-kubernetes.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/exporter-kubernetes/templates/configmap.yaml
+++ b/helm/exporter-kubernetes/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "exporter-kubernetes.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/exporter-kubernetes/templates/configmap.yaml
+++ b/helm/exporter-kubernetes/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kubernetes.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/exporter-kubernetes/templates/servicemonitor.yaml
+++ b/helm/exporter-kubernetes/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
@@ -7,9 +7,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-kubernetes.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "exporter-kubernetes.fullname" . }}
   selector:
     matchLabels:
       component: apiserver

--- a/helm/exporter-node/Chart.yaml
+++ b/helm/exporter-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-node
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-node/templates/NOTES.txt
+++ b/helm/exporter-node/templates/NOTES.txt
@@ -1,15 +1,15 @@
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "exporter-node.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/login
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ template "exporter-node.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "exporter-node.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "exporter-node.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
 {{- end }}

--- a/helm/exporter-node/templates/_helpers.tpl
+++ b/helm/exporter-node/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "exporter-node.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "exporter-node.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/exporter-node/templates/configmap.yaml
+++ b/helm/exporter-node/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-node.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/exporter-node/templates/configmap.yaml
+++ b/helm/exporter-node/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "exporter-node.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/exporter-node/templates/deamonset.yaml
+++ b/helm/exporter-node/templates/deamonset.yaml
@@ -2,17 +2,17 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-node.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: node-exporter
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-node.fullname" . }}
 spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "exporter-node.fullname" . }}
         component: node-exporter
         release: {{ .Release.Name }}
     spec:

--- a/helm/exporter-node/templates/node.rules.yaml
+++ b/helm/exporter-node/templates/node.rules.yaml
@@ -20,7 +20,7 @@ groups:
   - record: cluster:node_cpu:ratio
     expr: cluster:node_cpu:rate5m / count(sum(node_cpu) BY (instance, cpu))
   - alert: NodeExporterDown
-    expr: absent(up{job="{{ template "fullname" .  }}"} == 1)
+    expr: absent(up{job="{{ template "exporter-node.fullname" .  }}"} == 1)
     for: 10m
     labels:
       severity: warning

--- a/helm/exporter-node/templates/service.yaml
+++ b/helm/exporter-node/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-node.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "exporter-node.name" . }}
     component: node-exporter
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -16,6 +16,6 @@ spec:
     targetPort: metrics
     protocol: TCP
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "exporter-node.fullname" . }}
     component: node-exporter
     release: {{ .Release.Name }}

--- a/helm/exporter-node/templates/servicemonitor.yaml
+++ b/helm/exporter-node/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
@@ -7,12 +7,12 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "exporter-node.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "exporter-node.fullname" . }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "exporter-node.name" . }}
       component: node-exporter
   namespaceSelector:
     matchNames:

--- a/helm/hack/sync_kube_prometheus.py
+++ b/helm/hack/sync_kube_prometheus.py
@@ -14,21 +14,21 @@ def get_header(file_name):
 ####
 charts = [
 {'source':'contrib/kube-prometheus/assets/prometheus/rules/alertmanager.rules.yaml',
-'destination': 'helm/alertmanager/', 'job_replace_by': '{{ template \"fullname\" .  }}'},
+'destination': 'helm/alertmanager/', 'job_replace_by': '{{ template \"alertmanager.fullname\" .  }}'},
 {'source': 'contrib/kube-prometheus/assets/prometheus/rules/kube-controller-manager.rules.yaml',
-'destination': 'helm/exporter-kube-controller-manager/', 'job_replace_by': '{{ template \"fullname\" .  }}'},
+'destination': 'helm/exporter-kube-controller-manager/', 'job_replace_by': '{{ template \"exporter-kube-controller-manager.fullname\" .  }}'},
 {'source':'contrib/kube-prometheus/assets/prometheus/rules/kube-scheduler.rules.yaml',
-'destination': 'helm/exporter-kube-scheduler/', 'job_replace_by': '{{ template \"fullname\" .  }}'},
+'destination': 'helm/exporter-kube-scheduler/', 'job_replace_by': '{{ template \"exporter-kube-scheduler.fullname\" .  }}'},
 {'source':'contrib/kube-prometheus/assets/prometheus/rules/kube-state-metrics.rules.yaml',
-'destination': 'helm/exporter-kube-state/', 'job_replace_by': '{{ template \"fullname\" .  }}'},
+'destination': 'helm/exporter-kube-state/', 'job_replace_by': '{{ template \"exporter-kube-state.fullname\" .  }}'},
 {'source':'contrib/kube-prometheus/assets/prometheus/rules/node.rules.yaml',
-'destination': 'helm/exporter-node/', 'job_replace_by': '{{ template \"fullname\" .  }}'},
+'destination': 'helm/exporter-node/', 'job_replace_by': '{{ template \"exporter-node.fullname\" .  }}'},
 {'source':'contrib/kube-prometheus/assets/prometheus/rules/prometheus.rules.yaml', 
-'destination': 'helm/prometheus/', 'job_replace_by': '{{ template \"fullname\" .  }}'},
+'destination': 'helm/prometheus/', 'job_replace_by': '{{ template \"prometheus.fullname\" .  }}'},
 {'source':'contrib/kube-prometheus/assets/prometheus/rules/etcd3.rules.yaml', 
-'destination': 'helm/exporter-kube-etcd/', 'job_replace_by': '{{ template \"fullname\" .  }}'},
+'destination': 'helm/exporter-kube-etcd/', 'job_replace_by': '{{ template \"exporter-kube-etcd.fullname\" .  }}'},
 {'source':'contrib/kube-prometheus/assets/prometheus/rules/general.rules.yaml', 
-'destination': 'helm/kube-prometheus/', 'job_replace_by': '{{ template \"fullname\" .  }}'},
+'destination': 'helm/kube-prometheus/', 'job_replace_by': '{{ template \"kube-prometheus.fullname\" .  }}'},
 {'source':'contrib/kube-prometheus/assets/prometheus/rules/kubelet.rules.yaml', 
 'destination': 'helm/exporter-kubelets/', 'job_replace_by': 'kubelet'},
 {'source':'contrib/kube-prometheus/assets/prometheus/rules/kubernetes.rules.yaml', 
@@ -65,7 +65,7 @@ with open('contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml', '
 # prometheus datasource it's not required now 
 del data['prometheus-datasource.json']
 
-data_s = get_header("grafana-dashboards.yaml.tpl")
+data_s = get_header("grafana-dashboards.yaml")
 data_s += escape(yaml.dump(data, Dumper=yaml.RoundTripDumper))
 data_s += "{{ end }}" # footer
 

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -1,51 +1,51 @@
 dependencies:
   - name: alertmanager
-    version: 0.0.6
+    version: 0.0.7
     #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
   
   - name: prometheus
-    version: 0.0.8
+    version: 0.0.9
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
  
   - name: exporter-kube-controller-manager
-    version: 0.1.2
+    version: 0.1.3
     #e2e-repository: file://../exporter-kube-controller-manager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-dns
-    version: 0.1.2
+    version: 0.1.3
     #e2e-repository: file://../exporter-kube-dns
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-etcd
-    version: 0.1.2
+    version: 0.1.3
     #e2e-repository: file://../exporter-kube-etcd
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-scheduler
-    version: 0.1.2
+    version: 0.1.3
     #e2e-repository: file://../exporter-kube-scheduler
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-state
-    version: 0.1.4
+    version: 0.1.5
     #e2e-repository: file://../exporter-kube-state
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kubelets
-    version: 0.1.2
+    version: 0.1.3
     #e2e-repository: file://../exporter-kubelets
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kubernetes
-    version: 0.1.2
+    version: 0.1.3
     #e2e-repository: file://../exporter-kubernetes
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-node
-    version: 0.1.2
+    version: 0.1.3
     #e2e-repository: file://../exporter-node
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployExporterNode

--- a/helm/kube-prometheus/templates/_helpers.tpl
+++ b/helm/kube-prometheus/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "kube-prometheus.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "kube-prometheus.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/kube-prometheus/templates/configmap.yaml
+++ b/helm/kube-prometheus/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "kube-prometheus.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/kube-prometheus/templates/configmap.yaml
+++ b/helm/kube-prometheus/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "kube-prometheus.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.8
+version: 0.0.9

--- a/helm/prometheus-operator/templates/NOTES.txt
+++ b/helm/prometheus-operator/templates/NOTES.txt
@@ -1,5 +1,5 @@
 The Prometheus Operator has been installed. Check its status by running:
-  kubectl --namespace {{ .Release.Namespace }} get pods -l "app={{ template "name" . }},release={{ .Release.Name }}"
+  kubectl --namespace {{ .Release.Namespace }} get pods -l "app={{ template "prometheus-operator.name" . }},release={{ .Release.Name }}"
 
 Visit https://github.com/coreos/prometheus-operator for instructions on how
 to create & configure Alertmanager and Prometheus instances using the Operator.

--- a/helm/prometheus-operator/templates/_helpers.tpl
+++ b/helm/prometheus-operator/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "prometheus-operator.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "prometheus-operator.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if lt .Values.image.tag "v0.12.0" }}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/prometheus-operator/templates/clusterrole.yaml
+++ b/helm/prometheus-operator/templates/clusterrole.yaml
@@ -7,11 +7,11 @@ apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus-operator.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus-operator.fullname" . }}
 rules:
 - apiGroups:
   - extensions
@@ -28,8 +28,11 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resources:
+  - alertmanager
   - alertmanagers
+  - prometheus
   - prometheuses
+  - service-monitor
   - servicemonitors
   verbs:
   - "*"

--- a/helm/prometheus-operator/templates/clusterrolebinding.yaml
+++ b/helm/prometheus-operator/templates/clusterrolebinding.yaml
@@ -7,18 +7,18 @@ apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus-operator.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus-operator.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus-operator.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "fullname" . }}
+    name: {{ template "prometheus-operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
 

--- a/helm/prometheus-operator/templates/create-servicemonitor-job.yaml
+++ b/helm/prometheus-operator/templates/create-servicemonitor-job.yaml
@@ -5,18 +5,18 @@ metadata:
     helm.sh/hook: post-install
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus-operator.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}-create-sm-job
+  name: {{ template "prometheus-operator.fullname" . }}-create-sm-job
 spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "prometheus-operator.name" . }}
         release: {{ .Release.Name }}
-      name: {{ template "fullname" . }}-create-sm-job
+      name: {{ template "prometheus-operator.fullname" . }}-create-sm-job
     spec:
       containers:
         - name: hyperkube
@@ -33,8 +33,8 @@ spec:
       volumes:
         - name: tmp-configmap-servicemonitor
           configMap:
-            name: {{ template "fullname" . }}
+            name: {{ template "prometheus-operator.fullname" . }}
       restartPolicy: OnFailure
       {{- if .Values.rbacEnable }}
-      serviceAccountName: {{ template "fullname" . }}
+      serviceAccountName: {{ template "prometheus-operator.fullname" . }}
       {{- end }}

--- a/helm/prometheus-operator/templates/deployment.yaml
+++ b/helm/prometheus-operator/templates/deployment.yaml
@@ -2,23 +2,23 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus-operator.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     operator: prometheus
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus-operator.fullname" . }}
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "prometheus-operator.name" . }}
         operator: prometheus
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ template "name" . }}
+        - name: {{ template "prometheus-operator.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
@@ -27,6 +27,9 @@ spec:
           {{- end }}
             - --prometheus-config-reloader={{ .Values.prometheusConfigReloader.repository }}:{{ .Values.prometheusConfigReloader.tag }}
             - --config-reloader-image={{ .Values.configmapReload.repository }}:{{ .Values.configmapReload.tag }}
+          {{- if lt .Values.image.tag "v0.13.0" }}
+            - --analytics=false
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http
@@ -37,5 +40,5 @@ spec:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
     {{- if .Values.rbacEnable }}
-      serviceAccountName: {{ template "fullname" . }}
+      serviceAccountName: {{ template "prometheus-operator.fullname" . }}
     {{- end }}

--- a/helm/prometheus-operator/templates/get-crd-job.yaml
+++ b/helm/prometheus-operator/templates/get-crd-job.yaml
@@ -5,18 +5,18 @@ metadata:
     helm.sh/hook: post-install
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus-operator.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}-get-crd
+  name: {{ template "prometheus-operator.fullname" . }}-get-crd
 spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "prometheus-operator.name" . }}
         release: {{ .Release.Name }}
-      name: {{ template "fullname" . }}-get-crd
+      name: {{ template "prometheus-operator.fullname" . }}-get-crd
     spec:
       containers:
         - name: hyperkube
@@ -25,13 +25,21 @@ spec:
           command:
             - ./kubectl
             - get
+            {{- $apiVersion := include "prometheus-operator.apiVersion" . }}
+            {{ if eq $apiVersion "monitoring.coreos.com/v1alpha1" }}
+            - thirdpartyresources
+            - alertmanager.monitoring.coreos.com
+            - prometheus.monitoring.coreos.com
+            - service-monitor.monitoring.coreos.com
+            {{- else -}}
             - customresourcedefinitions
             - alertmanagers.monitoring.coreos.com
             - prometheuses.monitoring.coreos.com
             - servicemonitors.monitoring.coreos.com
+            {{- end }}
       restartPolicy: OnFailure
     {{- if .Values.rbacEnable }}
-      serviceAccountName: {{ template "fullname" . }}
+      serviceAccountName: {{ template "prometheus-operator.fullname" . }}
     {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/helm/prometheus-operator/templates/serviceaccount.yaml
+++ b/helm/prometheus-operator/templates/serviceaccount.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus-operator.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus-operator.fullname" . }}
 {{- end }}

--- a/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
+++ b/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
@@ -1,21 +1,21 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus-operator.fullname" . }}
 data:
   servicemonitor-operator.yaml: |-
-      apiVersion: monitoring.coreos.com/v1
+      apiVersion: {{ template "prometheus-operator.apiVersion" . }}
       kind: ServiceMonitor
       metadata:
         labels:
-          app: {{ template "name" . }}
+          app: {{ template "prometheus-operator.name" . }}
           chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
           heritage: "{{ .Release.Service }}"
           release: "{{ .Release.Name }}"
           prometheus: {{ .Release.Name }}
         name: {{ .Values.jobLabel }}
       spec:
-        jobLabel: {{ template "name" . }}
+        jobLabel: {{ template "prometheus-operator.name" . }}
         selector:
           matchLabels:
         selector:

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.8
+version: 0.0.9

--- a/helm/prometheus/templates/_helpers.tpl
+++ b/helm/prometheus/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "prometheus.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,18 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "prometheus.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
 {{- end -}}

--- a/helm/prometheus/templates/clusterrole.yaml
+++ b/helm/prometheus/templates/clusterrole.yaml
@@ -7,11 +7,11 @@ apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus.fullname" . }}
 rules:
 - apiGroups: [""]
   resources:

--- a/helm/prometheus/templates/clusterrolebinding.yaml
+++ b/helm/prometheus/templates/clusterrolebinding.yaml
@@ -7,18 +7,18 @@ apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "fullname" . }}
+    name: {{ template "prometheus.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
 

--- a/helm/prometheus/templates/configmap.yaml
+++ b/helm/prometheus/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}

--- a/helm/prometheus/templates/configmap.yaml
+++ b/helm/prometheus/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+    role: alert-rules
   name: {{ template "prometheus.fullname" . }}
 data:
 {{- if .Values.prometheusRules }}

--- a/helm/prometheus/templates/ingress.yaml
+++ b/helm/prometheus/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
@@ -15,7 +15,7 @@ metadata:
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus.fullname" . }}
 spec:
   rules:
     - host: "{{ .Values.ingress.fqdn }}"
@@ -23,7 +23,7 @@ spec:
         paths:
           - path: "{{ .Values.routePrefix }}"
             backend:
-              serviceName: {{ template "fullname" . }}
+              serviceName: {{ template "prometheus.fullname" . }}
               servicePort: 9090
 {{- if .Values.ingress.tls }}
   tls:

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -69,7 +69,7 @@ spec:
 {{- else }}
   ruleSelector:
     matchLabels:
-      app: {{ template "prometheus.name" . }}
+      role: alert-rules
       prometheus: {{ .Release.Name }}
 {{- end }}
 {{- if .Values.storageSpec }}

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -1,8 +1,8 @@
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: Prometheus
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
@@ -33,7 +33,7 @@ spec:
 {{- else if .Values.ingress.fqdn }}
   externalUrl: http://{{ .Values.ingress.fqdn }}{{ .Values.routePrefix }}
 {{- else }}
-  externalUrl: http://{{ template "fullname" . }}.{{ .Release.Namespace }}:9090
+  externalUrl: http://{{ template "prometheus.fullname" . }}.{{ .Release.Namespace }}:9090
 {{- end }}
 {{- if .Values.nodeSelector }}
   nodeSelector:
@@ -52,7 +52,7 @@ spec:
 {{ toYaml .Values.secrets | indent 4 }}
 {{- end }}
 {{- if .Values.rbacEnable }}
-  serviceAccountName: {{ template "fullname" . }}
+  serviceAccountName: {{ template "prometheus.fullname" . }}
 {{- end }}
 {{- if .Values.serviceMonitorsSelector }}
   serviceMonitorSelector:
@@ -69,7 +69,7 @@ spec:
 {{- else }}
   ruleSelector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "prometheus.name" . }}
       prometheus: {{ .Release.Name }}
 {{- end }}
 {{- if .Values.storageSpec }}

--- a/helm/prometheus/templates/rules.yaml
+++ b/helm/prometheus/templates/rules.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}

--- a/helm/prometheus/templates/secret.yaml
+++ b/helm/prometheus/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}

--- a/helm/prometheus/templates/service.yaml
+++ b/helm/prometheus/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
@@ -14,7 +14,7 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus.fullname" . }}
 spec:
   clusterIP: "{{ .Values.service.clusterIP }}"
 {{- if .Values.service.externalIPs }}
@@ -37,6 +37,6 @@ spec:
       targetPort: 9090
       protocol: TCP
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     prometheus: {{ .Release.Name }}
   type: "{{ .Values.service.type }}"

--- a/helm/prometheus/templates/serviceaccount.yaml
+++ b/helm/prometheus/templates/serviceaccount.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus.fullname" . }}
 {{- end }}

--- a/helm/prometheus/templates/servicemonitor-prometheus.yaml
+++ b/helm/prometheus/templates/servicemonitor-prometheus.yaml
@@ -1,19 +1,19 @@
 {{- if .Values.selfServiceMonitor }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
 kind: ServiceMonitor
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
     prometheus: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus.fullname" . }}
 spec:
-  jobLabel: {{ template "fullname" . }}
+  jobLabel: {{ template "prometheus.fullname" . }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "prometheus.name" . }}
       prometheus: {{ .Release.Name }}
       chart: {{ .Chart.Name }}-{{ .Chart.Version }}
   namespaceSelector:

--- a/helm/prometheus/templates/servicemonitors.yaml
+++ b/helm/prometheus/templates/servicemonitors.yaml
@@ -1,4 +1,4 @@
-{{- $app := include "name" . -}}
+{{- $app := include "prometheus.name" . -}}
 {{- $releaseName := .Release.Name -}}
 {{- $chartName := .Chart.Name -}}
 {{- $chartVersion := .Chart.Version -}}


### PR DESCRIPTION
This PR solves 2 issues:

- prometheus-operator has started using CRDs instead of TPRs from v0.12.0. While allowing to specify the operator's image tag to use, the charts in the helm/ directory of this repository were forcing the use of CRDs, thus preventing users of kubernetes 1.6.x from using it. 

- When using kube-prometheus with ```rbacEnable``` set to ```false```, the value was not propagated to the dependencies. This was preventing us from installing the chart in clusters without rbac (the dependencies would try to install rbac resources, and fail doing so).

Please note that this PR breaks backward compatibility in the sense that ```rbacEnable``` has been moved to the global scope in all the charts having such a value