### PR TITLE
Bump kube-prometheus version

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.3
+version: 0.0.4


### PR DESCRIPTION
My previous PR synced with s3 and overwrite the kube-prometheus chart so the hash comparison is failing, time to bump the kube-prometheus version 🍺.  

## travis-ci output
``` 
+cur_hash=($(md5sum ${HELM_CHARTS_PACKAGED_DIR}/${tgz}))
++md5sum /tmp/helm-packaged/kube-prometheus-0.0.3.tgz
++tr -d '"'
++jq .ETag -r
++aws s3api head-object --bucket coreos-charts --key stable/kube-prometheus-0.0.3.tgz
+remote_hash=e7060a65a706c35df8e6dc537077e425
+'[' kube-prometheus-0.0.3.tgz '!=' index.yaml ']'
+'[' ac658a06e34db8d7cbafaf87e41b40ab '!=' e7060a65a706c35df8e6dc537077e425 ']'
+echo 'ERROR: Current hash should be the same as the remote hash. Please bump the version of chart {kube-prometheus-0.0.3.tgz}.'
ERROR: Current hash should be the same as the remote hash. Please bump the version of chart {kube-prometheus-0.0.3.tgz}.
+exit 0
```