### PR TITLE
for glog, re-using flag.Commandline instead of a new flagset

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -43,7 +43,7 @@ var (
 
 func init() {
 	cfg.CrdKinds = monitoringv1.DefaultCrdKinds
-	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	flagset := flag.CommandLine
 	flagset.StringVar(&cfg.Host, "apiserver", "", "API Server addr, e.g. ' - NOT RECOMMENDED FOR PRODUCTION - http://127.0.0.1:8080'. Omit parameter to run in on-cluster mode and utilize the service account token.")
 	flagset.StringVar(&cfg.TLSConfig.CertFile, "cert-file", "", " - NOT RECOMMENDED FOR PRODUCTION - Path to public TLS certificate file.")
 	flagset.StringVar(&cfg.TLSConfig.KeyFile, "key-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to private TLS certificate file.")


### PR DESCRIPTION
Pull request for https://github.com/coreos/prometheus-operator/issues/823