### PR TITLE
Fix link to RBAC manifest

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -146,7 +146,7 @@ spec:
         app: example-app
     spec:
       containers:
-      - name: example-app 
+      - name: example-app
         image: fabxc/instrumented_app
         ports:
         - name: web
@@ -259,7 +259,7 @@ spec:
     requests:
       memory: 400Mi
 ```
-> If you have RBAC authorization activated, use the RBAC aware [*Prometheus* manifest](../../example/rbac/prometheus/prometheus-cluster-role-binding.yaml) instead.
+> If you have RBAC authorization activated, use the RBAC aware [*Prometheus* manifest](../../example/rbac/prometheus/) instead.
 
 
 This way the frontend team can create new `ServiceMonitor`s and `Service`s resulting in `Prometheus` to be dynamically reconfigured.

--- a/example/user-guides/getting-started/example-app-deployment.yaml
+++ b/example/user-guides/getting-started/example-app-deployment.yaml
@@ -10,7 +10,7 @@ spec:
         app: example-app
     spec:
       containers:
-      - name: example-app 
+      - name: example-app
         image: fabxc/instrumented_app
         ports:
         - name: web


### PR DESCRIPTION
The current link only links to one of the manifests you need, so I thought changing it to the folder made more sense.