### PR TITLE
A stub of a README for the Helm chart with vital bootstrap info

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,7 @@
+# TL;DR
+
+```
+helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+helm install coreos/prometheus-operator --name prometheus-operator
+helm install coreos/kube-prometheus --name kube-prometheus --set rbacEnable=true
+````


### PR DESCRIPTION
As discussed in #861. It's not detailed, but it is 100% better that current non-existent README :-)

It provide the vital info that you need to install `prometheus-operator` first, and then `kube-prometheus` second.