### PR TITLE
Update 'fullname' helper function to current version that avoids double-named deployments

### DIFF
--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.9
+version: 0.0.10

--- a/helm/prometheus-operator/templates/_helpers.tpl
+++ b/helm/prometheus-operator/templates/_helpers.tpl
@@ -9,10 +9,15 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "prometheus-operator.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
The change avoids `prometheus-operator` being deployed as `prometheus-operator-prometheus-operator-1234567890-abcde`. The newer function will avoid the duplication and deploy as `prometheus-operator-1234567890-abcde`.

This updates the Helm chart to follow newer best practice for helper functions, where the fullname template avoids doubling up on the release/chart name:
https://github.com/kubernetes/helm/blob/7c79d1c76534074d5708eae2c5ef88ae044941db/pkg/chartutil/create.go#L237-L249