### PR TITLE
helm/prometheus: support not having a serviceMonitorSelector

### DIFF
--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
   
   - name: prometheus
-    version: 0.0.9
+    version: 0.0.10
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
  

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.9
+version: 0.0.10

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -54,7 +54,8 @@ spec:
 {{- if .Values.rbacEnable }}
   serviceAccountName: {{ template "prometheus.fullname" . }}
 {{- end }}
-{{- if .Values.serviceMonitorsSelector }}
+{{ if and .Values.config.specifiedInValues .Values.config.value }}
+{{- else if .Values.serviceMonitorsSelector }}
   serviceMonitorSelector:
 {{ toYaml .Values.serviceMonitorsSelector | indent 4 }}
 {{- else }}


### PR DESCRIPTION
The prometheus helm chart supports passing in a static config, but because the serviceMonitorsSelector is defined by default, it is not usable. If a config is defined, the serviceMonitorsSelector shouldn't be set.