### PR TITLE
prometheus: Add ensure memory request is smaller or equal to limit

### DIFF
--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -15,13 +15,15 @@
 package prometheus
 
 import (
+	"reflect"
+	"testing"
+
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
-	"testing"
 )
 
 var (
@@ -245,6 +247,58 @@ func TestDeterministicRuleFileHashing(t *testing.T) {
 		if cmr.Checksum != testcmr.Checksum {
 			t.Fatalf("Non-deterministic rule file hash generation")
 		}
+	}
+}
+
+func TestMemoryRequestNotAdjustedWhenLimitLarger2Gi(t *testing.T) {
+	sset, err := makeStatefulSet(monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			Resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("3Gi"),
+				},
+			},
+		},
+	}, nil, defaultTestConfig, []*v1.ConfigMap{})
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	resourceRequest := sset.Spec.Template.Spec.Containers[0].Resources.Requests[v1.ResourceMemory]
+	requestString := resourceRequest.String()
+	resourceLimit := sset.Spec.Template.Spec.Containers[0].Resources.Limits[v1.ResourceMemory]
+	limitString := resourceLimit.String()
+	if requestString != "2Gi" {
+		t.Fatalf("Resource request is expected to be 1Gi, instead found %s", resourceRequest)
+	}
+	if limitString != "3Gi" {
+		t.Fatalf("Resource limit is expected to be 1Gi, instead found %s", resourceLimit)
+	}
+}
+
+func TestMemoryRequestAdjustedWhenOnlyLimitGiven(t *testing.T) {
+	sset, err := makeStatefulSet(monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			Resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}, nil, defaultTestConfig, []*v1.ConfigMap{})
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	resourceRequest := sset.Spec.Template.Spec.Containers[0].Resources.Requests[v1.ResourceMemory]
+	requestString := resourceRequest.String()
+	resourceLimit := sset.Spec.Template.Spec.Containers[0].Resources.Limits[v1.ResourceMemory]
+	limitString := resourceLimit.String()
+	if requestString != "1Gi" {
+		t.Fatalf("Resource request is expected to be 1Gi, instead found %s", resourceRequest)
+	}
+	if limitString != "1Gi" {
+		t.Fatalf("Resource limit is expected to be 1Gi, instead found %s", resourceLimit)
 	}
 }
 


### PR DESCRIPTION
Pods can potentially be unschedulable if a user only provides a limit, as the limit may be smaller than the default request we're setting. This PR makes sure, that we adjust the memory request if only a limit is given and it's smaller.

@ant31 