### PR TITLE
grafana-watcher: access grafana at 127.0.0.1

### DIFF
--- a/helm/grafana/templates/grafana-deployment.yaml
+++ b/helm/grafana/templates/grafana-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         image: {{ .Values.grafanaWatcher.repository }}:{{ .Values.grafanaWatcher.tag }}
         args:
           - '--watch-dir=/var/grafana-dashboards'
-          - '--grafana-url=http://localhost:3000'
+          - '--grafana-url=http://127.0.0.1:3000'
         env:
         - name: GRAFANA_USER
           valueFrom:


### PR DESCRIPTION
In some clusters, using "localhost" as the grafana
url for grafana-watcher, doesn't resolve to
127.0.0.1 or the correct container IP, but to some
unrelated IP.

This workaround just skips DNS resolution by directly
using localhost's IP. It doesn't fix the underlying issue,
which is unknown atm.

Fixes #875.

Signed-off-by: Daniel Mohr <daniel.mohr@supercrunch.io>