### PR TITLE
helm/prometheus, helm/alertmanager: add support for pod anti-affinity

### DIFF
--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.7
+version: 0.0.8

--- a/helm/alertmanager/README.md
+++ b/helm/alertmanager/README.md
@@ -53,6 +53,7 @@ Parameter | Description | Default
 `ingress.tls` | TLS configuration for Alertmanager Ingress | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `paused` | If true, the Operator won't process any Alertmanager configuration changes | `false`
+`podAntiAffinity` | If "soft", the scheduler attempts to place Alertmanager replicas on different nodes. If "hard" the scheduler is required to place them on different nodes. If "" (empty) then no anti-affinity rules will be configured. | `soft`
 `prometheusRules` | Prometheus rules | `[templates/alertmanager.rules.yaml](templates/alertmanager.rules.yaml)`
 `replicaCount` | Number of Alertmanager replicas desired | `1`
 `resources` | Pod resource requests & limits | `{}`

--- a/helm/alertmanager/templates/alertmanager.yaml
+++ b/helm/alertmanager/templates/alertmanager.yaml
@@ -33,3 +33,24 @@ spec:
 {{ toYaml .Values.storageSpec | indent 4 }}
 {{- end }}
   version: "{{ .Values.image.tag }}"
+{{- if eq .Values.podAntiAffinity "hard" }}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchLabels:
+            app: {{ template "alertmanager.name" . }}
+            alertmanager: {{ .Release.Name }}
+{{- else if eq .Values.podAntiAffinity "soft" }}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app: {{ template "alertmanager.name" . }}
+              alertmanager: {{ .Release.Name }}
+{{- end }}

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -93,6 +93,12 @@ paused: false
 ##
 replicaCount: 1
 
+## Pod anti-affinity can prevent the scheduler from placing Alertmanager replicas on the same node.
+## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+podAntiAffinity: "soft"
+
 ## Resource limits & requests
 ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ##

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.7
+version: 0.0.8

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -1,11 +1,11 @@
 dependencies:
   - name: alertmanager
-    version: 0.0.7
+    version: 0.0.8
     #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
   
   - name: prometheus
-    version: 0.0.10
+    version: 0.0.11
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
  

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -68,6 +68,12 @@ alertmanager:
   ##
   replicaCount: 1
 
+  ## Pod anti-affinity can prevent the scheduler from placing Alertmanager replicas on the same node.
+  ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+  ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+  ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+  podAntiAffinity: "soft"
+
   ## Resource limits & requests
   ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -182,6 +188,12 @@ prometheus:
   ## Number of Prometheus replicas desired
   ##
   replicaCount: 1
+
+  ## Pod anti-affinity can prevent the scheduler from placing Prometheus replicas on the same node.
+  ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+  ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+  ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+  podAntiAffinity: "soft"
 
   ## Resource limits & requests
   ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.10
+version: 0.0.11

--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -55,6 +55,7 @@ Parameter | Description | Default
 `ingress.tls` | TLS configuration for Prometheus Ingress | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `paused` | If true, the Operator won't process any Prometheus configuration changes | `false`
+`podAntiAffinity` | If "soft", the scheduler attempts to place Prometheus replicas on different nodes. If "hard" the scheduler is required to place them on different nodes. If "" (empty) then no anti-affinity rules will be configured. | `soft`
 `prometheusRules` | Prometheus rules | `[templates/prometheus.rules.yaml](templates/prometheus.rules.yaml)`
 `replicaCount` | Number of Prometheus replicas desired | `1`
 `resources` | Pod resource requests & limits | `{}`

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -78,3 +78,24 @@ spec:
 {{ toYaml .Values.storageSpec | indent 4 }}
 {{- end }}
   version: "{{ .Values.image.tag }}"
+{{- if eq .Values.podAntiAffinity "hard" }}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchLabels:
+            app: {{ template "prometheus.name" . }}
+            prometheus: {{ .Release.Name }}
+{{- else if eq .Values.podAntiAffinity "soft" }}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app: {{ template "prometheus.name" . }}
+              prometheus: {{ .Release.Name }}
+{{- end }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -79,6 +79,12 @@ rbacEnable: true
 ##
 replicaCount: 1
 
+## Pod anti-affinity can prevent the scheduler from placing Prometheus replicas on the same node.
+## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+podAntiAffinity: "soft"
+
 ## Resource limits & requests
 ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
When running multiple instances of either Alertmanager or Prometheus it is better from a high availability point of view that the pods are not co-located. This commit introduces the usage of pod anti-affinity with a default setting of “soft” for both Alertmanager and Prometheus meaning the scheduler should make a best-effort to place replica pods on different nodes. The setting “hard” makes it required and “” disables the usage of pod anti-affinity.