### PR TITLE
Use whole numbers in replica graphs

### DIFF
--- a/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
@@ -639,6 +639,7 @@ data:
                   "format": "none",
                   "label": "",
                   "logBase": 1,
+                  "decimals":0,
                   "show": true
                 },
                 {
@@ -7379,6 +7380,7 @@ data:
                   "format": "none",
                   "label": "",
                   "logBase": 1,
+                  "decimals":0,
                   "show": true
                 },
                 {


### PR DESCRIPTION
No need to have decimals on the axes showing the number of replicas