### PR TITLE
Add role rules permissions to get metrics from kubelet

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-roles.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-roles.yaml
@@ -47,5 +47,9 @@ kind: ClusterRole
 metadata:
   name: prometheus-k8s
 rules:
+- apiGroups: [""]
+  resources:
+  - nodes/metrics
+  verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]

--- a/helm/prometheus/templates/clusterrole.yaml
+++ b/helm/prometheus/templates/clusterrole.yaml
@@ -24,6 +24,10 @@ rules:
   resources:
   - configmaps
   verbs: ["get"]
+- apiGroups: [""]
+  resources:
+  - nodes/metrics
+  verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 {{- end }}


### PR DESCRIPTION
Fixes https://github.com/coreos/prometheus-operator/issues/867