### PR TITLE
Bump helm charts 

### DIFF
--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.9
+version: 0.0.8

--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.8
+version: 0.0.9

--- a/helm/exporter-kube-state/Chart.yaml
+++ b/helm/exporter-kube-state/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-state
-version: 0.1.6
+version: 0.1.7
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.5
+version: 0.0.6

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
   
   - name: prometheus
-    version: 0.0.11
+    version: 0.0.12
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
  
@@ -30,7 +30,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-state
-    version: 0.1.6
+    version: 0.1.7
     #e2e-repository: file://../exporter-kube-state
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -51,7 +51,7 @@ dependencies:
     condition: deployExporterNode
 
   - name: grafana
-    version: 0.0.5
+    version: 0.0.6
     #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.11
+version: 0.0.12


### PR DESCRIPTION
This PR is intended to bump helm charts that haven't have the version bumped, after that the travis build history should be green again.