### PR TITLE
helm/exporter-kubelets: Add option to use the http-metrics port inste…

### DIFF
--- a/helm/exporter-kubelets/Chart.yaml
+++ b/helm/exporter-kubelets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-kubelets
-version: 0.1.3
+version: 0.2.0
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kubelets/templates/servicemonitor.yaml
+++ b/helm/exporter-kubelets/templates/servicemonitor.yaml
@@ -17,8 +17,9 @@ spec:
     matchNames:
       - "kube-system"
   endpoints:
-  - port: https-metrics
-    interval: 15s
+  - interval: 15s
+    {{- if .Values.https }}
+    port: https-metrics
     scheme: https
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -26,6 +27,9 @@ spec:
       # for the kubelet on API server nodes fail.
       insecureSkipVerify: true
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- else }}
+    port: http-metrics
+    {{- end }}
   - port: cadvisor
     interval: 30s
     honorLabels: true

--- a/helm/exporter-kubelets/values.yaml
+++ b/helm/exporter-kubelets/values.yaml
@@ -1,2 +1,5 @@
+# Set to false for GKE
+https: true
+
 # default rules are in templates/kubelet.rules.yaml
 # prometheusRules: {}

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -35,7 +35,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kubelets
-    version: 0.1.3
+    version: 0.2.0
     #e2e-repository: file://../exporter-kubelets
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 


### PR DESCRIPTION
…ad of the https-metrics port

Needed for GKE due to the issue with kubelet serviceaccount token auth. Port 10255 (http-metrics) is open on GKE.

Fixes #902

Related: #485, #773