### PR TITLE
helm/exporter-kubelets: Read cAdvisor metrics from secure Kubelet port

### DIFF
--- a/helm/exporter-kubelets/Chart.yaml
+++ b/helm/exporter-kubelets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-kubelets
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kubelets/templates/servicemonitor.yaml
+++ b/helm/exporter-kubelets/templates/servicemonitor.yaml
@@ -17,19 +17,25 @@ spec:
     matchNames:
       - "kube-system"
   endpoints:
-  - interval: 15s
-    {{- if .Values.https }}
-    port: https-metrics
+  {{- if .Values.https }}
+  - port: https-metrics
     scheme: https
+    interval: 15s
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      # Skip verification until we have resolved why the certificate validation
-      # for the kubelet on API server nodes fail.
       insecureSkipVerify: true
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    {{- else }}
-    port: http-metrics
-    {{- end }}
+  - port: https-metrics
+    scheme: https
+    path: /metrics/cadvisor
+    interval: 30s
+    honorLabels: true
+    tlsConfig:
+      insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  {{- else }}
+  - port: http-metrics
+    interval: 15s
   - port: cadvisor
     interval: 30s
     honorLabels: true
+  {{- end }}

--- a/helm/exporter-kubelets/templates/servicemonitor.yaml
+++ b/helm/exporter-kubelets/templates/servicemonitor.yaml
@@ -22,7 +22,10 @@ spec:
     scheme: https
     interval: 15s
     tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      {{- if .Values.insecureSkipVerify }}
       insecureSkipVerify: true
+      {{- end }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   - port: https-metrics
     scheme: https
@@ -30,7 +33,10 @@ spec:
     interval: 30s
     honorLabels: true
     tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      {{- if .Values.insecureSkipVerify }}
       insecureSkipVerify: true
+      {{- end }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   {{- else }}
   - port: http-metrics

--- a/helm/exporter-kubelets/values.yaml
+++ b/helm/exporter-kubelets/values.yaml
@@ -1,5 +1,7 @@
 # Set to false for GKE
 https: true
 
+insecureSkipVerify: false
+
 # default rules are in templates/kubelet.rules.yaml
 # prometheusRules: {}

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.10
+version: 0.0.11

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -35,7 +35,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kubelets
-    version: 0.2.0
+    version: 0.2.1
     #e2e-repository: file://../exporter-kubelets
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 


### PR DESCRIPTION
Read cAdvisor metrics from secure Kubelet port instead of cAdvisor port when using HTTPS

This is equivalent to what @brancz did for kube-prometheus in #908. See commit 8928e07

The required RBAC permissions for nodes/metrics are already included in helm/prometheus/templates/clusterrole.yaml as part of #901