### PR TITLE
Make RBAC global

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -3,7 +3,7 @@
 ```
 helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 helm install coreos/prometheus-operator --name prometheus-operator --namespace monitoring
-helm install coreos/kube-prometheus --name kube-prometheus --set rbacEnable=true --namespace monitoring
+helm install coreos/kube-prometheus --name kube-prometheus --set global.rbacEnable=true --namespace monitoring
 ````
 
 # How to contribue?

--- a/helm/exporter-kube-state/Chart.yaml
+++ b/helm/exporter-kube-state/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-state
-version: 0.1.7
+version: 0.1.8
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kube-state/templates/clusterrole.yaml
+++ b/helm/exporter-kube-state/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}

--- a/helm/exporter-kube-state/templates/clusterrolebinding.yaml
+++ b/helm/exporter-kube-state/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}

--- a/helm/exporter-kube-state/templates/deployment.yaml
+++ b/helm/exporter-kube-state/templates/deployment.yaml
@@ -69,6 +69,6 @@ spec:
           - --deployment={{ template "exporter-kube-state.fullname" . }}
         resources:
 {{ toYaml .Values.addon_resizer.resources | indent 12 }}
-    {{- if .Values.rbacEnable }}
+    {{- if .Values.global.rbacEnable }}
       serviceAccountName: {{ template "exporter-kube-state.fullname" . }}
     {{- end }}

--- a/helm/exporter-kube-state/templates/role.yaml
+++ b/helm/exporter-kube-state/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}

--- a/helm/exporter-kube-state/templates/rolebinding.yaml
+++ b/helm/exporter-kube-state/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}

--- a/helm/exporter-kube-state/templates/serviceaccount.yaml
+++ b/helm/exporter-kube-state/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/exporter-kube-state/values.yaml
+++ b/helm/exporter-kube-state/values.yaml
@@ -2,7 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
-rbacEnable: true
+
+## If true, create & use RBAC resources
+##
+global:
+  rbacEnable: true
+
 kube_state_metrics:
   image:
     repository: gcr.io/google_containers/kube-state-metrics

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.17
+version: 0.0.18

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: prometheus
-    version: 0.0.13
+    version: 0.0.14
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
@@ -30,7 +30,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-state
-    version: 0.1.7
+    version: 0.1.8
     #e2e-repository: file://../exporter-kube-state
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -4,6 +4,11 @@ deployExporterNode: True
 # Grafana
 deployGrafana: True
 
+## If true, create & use RBAC resources
+##
+global:
+  rbacEnable: true
+
 alertmanager:
   ## Alertmanager configuration directives
   ## Ref: https://prometheus.io/docs/alerting/configuration/
@@ -122,10 +127,6 @@ alertmanager:
   #     requests:
   #       storage: 2Gi
   #   selector: {}
-
-## If true, create & use RBAC resources
-##
-rbacEnable: true
 
 prometheus:
   ## Alertmanagers to which alerts will be sent

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.13
+version: 0.0.14

--- a/helm/prometheus/templates/clusterrole.yaml
+++ b/helm/prometheus/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}

--- a/helm/prometheus/templates/clusterrolebinding.yaml
+++ b/helm/prometheus/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -52,7 +52,7 @@ spec:
   secrets:
 {{ toYaml .Values.secrets | indent 4 }}
 {{- end }}
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
   serviceAccountName: {{ template "prometheus.fullname" . }}
 {{- end }}
 {{ if and .Values.config.specifiedInValues .Values.config.value }}

--- a/helm/prometheus/templates/serviceaccount.yaml
+++ b/helm/prometheus/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -73,7 +73,8 @@ paused: false
 
 ## If true, create & use RBAC resources
 ##
-rbacEnable: true
+global:
+  rbacEnable: true
 
 ## Number of Prometheus replicas desired
 ##


### PR DESCRIPTION
At present, you can't deploy this chart to a cluster that does __Not__ have `RBAC` enabled without knowing which sub-charts have `RBAC` resources included.

The docs state that one can toggle `RBAC` when deploying the `kube-prometheus` Parent-chart by providing the `--set rbacEnable` flag.  Correct me if I am wrong but that flag is a __no-op__ (It essentially does nothing).

Both the `prometheus` and `exporter-kube-state` charts include `RBAC` resources.  Therefore, one must namespace the argument like `--set exporter-kube-state.rbacEnable <BOOLEAN>` to override the default.

I'm assuming these charts will typically be deployed together, so modifying `RBAC` to be set globally makes sense, while still allowing the sub-charts to be configured on a standalone basis. 

For example running  `helm install coreos/kube-prometheus --name kube-prometheus --set global.rbacEnable=false --namespace monitoring` will toggle `rbacEnable` to false for the `prometheus` and `exporter-kube-state` charts.

I also removed the `rbacEnable` value from the `alertmanager` chart.  At present, I cannot see where it's  being used.