### PR TITLE
Add node hostname label to pod's metrics.

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -331,6 +331,10 @@ func generateServiceMonitorConfig(version semver.Version, m *v1.ServiceMonitor, 
 			{Key: "target_label", Value: "pod"},
 		},
 		yaml.MapSlice{
+			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_node_name"}},
+			{Key: "target_label", Value: "node"},
+		},
+		yaml.MapSlice{
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_service_name"}},
 			{Key: "target_label", Value: "service"},
 		},


### PR DESCRIPTION
In our case, we need get node hostname from pod's metrics exported by kube-state-metrics (like `kube_pod_container_status_ready` `kube_pod_container_info `, etc.) since we can easily join with node's metrics and display it in alerting messages or grafana dashboards. 

Exporting node label of pod objects is necessary in many cases. This PR simply adds node label by relabeling `__meta_kubernetes_pod_node_name` to `node`. `pod_node_name` would be a useful label as `pod_name`.
