### PR TITLE
Remove deprecated StorageSpec examples

### DIFF
--- a/example/storage/persisted-prometheus.yaml
+++ b/example/storage/persisted-prometheus.yaml
@@ -4,7 +4,10 @@ metadata:
   name: persisted
 spec:
   storage:
-    class: ssd
-    resources:
-      requests:
-        storage: 40Gi
+    volumeClaimTemplate:
+      metadata:
+        volume.beta.kubernetes.io/storage-class: ssd
+      spec:
+        resources:
+          requests:
+            storage: 40Gi

--- a/example/storage/persisted-prometheus.yaml
+++ b/example/storage/persisted-prometheus.yaml
@@ -5,9 +5,8 @@ metadata:
 spec:
   storage:
     volumeClaimTemplate:
-      metadata:
-        volume.beta.kubernetes.io/storage-class: ssd
       spec:
+        storageClassName: ssd
         resources:
           requests:
             storage: 40Gi

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -117,11 +117,12 @@ alertmanager:
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
   ##
   storageSpec: {}
-  #   class: default
-  #   resources:
-  #     requests:
-  #       storage: 2Gi
-  #   selector: {}
+  #  volumeClaimTemplate:
+  #    spec:
+  #      resources:
+  #        requests:
+  #          storage: 50Gi
+  #  selector: {}
 
 ## If true, create & use RBAC resources
 ##
@@ -344,11 +345,12 @@ prometheus:
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
   ##
   storageSpec: {}
-  #   class: default
-  #   resources:
-  #     requests:
-  #       storage: 16Gi
-  #   selector: {}
+  #  volumeClaimTemplate:
+  #    spec:
+  #      resources:
+  #        requests:
+  #          storage: 50Gi
+  #  selector: {}
 
 # default rules are in templates/general.rules.yaml
 # prometheusRules: {}


### PR DESCRIPTION
There are still some examples showing the deprecated StorageSpec fields.  This updates the `persisted-prometheus.yaml` example and the`values.yaml` in the kube-prometheus helm chart.