### PR TITLE
prometheus-operator ClusterRole should specify finalizer subresource

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -37,6 +37,7 @@ rules:
   resources:
   - alertmanagers
   - prometheuses
+  - prometheuses/finalizers
   - servicemonitors
   verbs:
   - "*"

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -48,6 +48,7 @@ rules:
   resources:
   - alertmanagers
   - prometheuses
+  - prometheuses/finalizers
   - servicemonitors
   verbs:
   - "*"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -33,6 +33,7 @@ rules:
   resources:
   - alertmanagers
   - prometheuses
+  - prometheuses/finalizers
   - servicemonitors
   verbs:
   - "*"

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -20,6 +20,7 @@ rules:
   resources:
   - alertmanagers
   - prometheuses
+  - prometheuses/finalizers
   - servicemonitors
   verbs:
   - "*"


### PR DESCRIPTION
OwnerReferencesPermissionEnforcement admission plugin is on by default
in OpenShift, and without this change, the operator cannot deploy.