### PR TITLE
kube-prometheus/hack: Add generation for grafana dashboard source file

### DIFF
--- a/contrib/kube-prometheus/hack/grafana-dashboards-configmap-generator/templates/grafana-dashboards-template.yaml
+++ b/contrib/kube-prometheus/hack/grafana-dashboards-configmap-generator/templates/grafana-dashboards-template.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+data:
+  dashboards.yaml: |+
+XXX_DASHBOARDS_XXX

--- a/contrib/kube-prometheus/hack/scripts/generate-manifests.sh
+++ b/contrib/kube-prometheus/hack/scripts/generate-manifests.sh
@@ -13,9 +13,10 @@ hack/scripts/generate-dashboards-configmap.sh > manifests/grafana/grafana-dashbo
 # Input dir: assets/grafana
 # output file: manifests/grafana/grafana-dashboards.yaml
 # grafana deployment output file: manifests/grafana/grafana-deployment.yaml
-test -f manifests/grafana/grafana-dashboards.yaml && rm -f manifests/grafana/grafana-dashboard-definitions.yaml
+test -f manifests/grafana/grafana-dashboard-definitions.yaml && rm -f manifests/grafana/grafana-dashboard-definitions.yaml
 test -f manifests/grafana/grafana-deployment.yaml && rm -f manifests/grafana/grafana-deployment.yaml
-hack/grafana-dashboards-configmap-generator/bin/grafana_dashboards_generate.sh -s 240000 -i assets/grafana/generated -o manifests/grafana/grafana-dashboard-definitions.yaml -g manifests/grafana/grafana-deployment.yaml
+test -f manifests/grafana/grafana-dashboards.yaml && rm -f manifests/grafana/grafana-dashboards.yaml
+hack/grafana-dashboards-configmap-generator/bin/grafana_dashboards_generate.sh -s 240000 -i assets/grafana/generated -o manifests/grafana/grafana-dashboard-definitions.yaml -g manifests/grafana/grafana-deployment.yaml -d manifests/grafana/grafana-dashboards.yaml
 
 # Generate Grafana Credentials Secret
 hack/scripts/generate-grafana-credentials-secret.sh admin admin > manifests/grafana/grafana-credentials.yaml

--- a/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
@@ -4,7 +4,7 @@ metadata:
   name: grafana-dashboards
 data:
   dashboards.yaml: |+
-    - name: 'default'
+    - name: '0'
       org_id: 1
       folder: ''
       type: file


### PR DESCRIPTION
#968 introduced using Grafana v5, which also provisions dashboards from disk. This however also requires declaring the dashboard sources in a file. This declaration was static in #968, whereas it depends on the number of configmaps generated.

@ant31 @fabxc 