### PR TITLE
helm/prometheus: add expected label to templated ServiceMonitors so they are discovered by default

### DIFF
--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: prometheus
-    version: 0.0.14
+    version: 0.0.15
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.14
+version: 0.0.15

--- a/helm/prometheus/templates/servicemonitors.yaml
+++ b/helm/prometheus/templates/servicemonitors.yaml
@@ -15,6 +15,7 @@ items:
         app: {{ $app }}
         chart: {{ $chartName }}-{{ $chartVersion }}
         heritage: {{ $releaseService }}
+        prometheus: {{ $releaseName }}
         release: {{ $releaseName }}
         {{- if .serviceMonitorSelectorLabels }}
 {{ toYaml .serviceMonitorSelectorLabels | indent 8 }}


### PR DESCRIPTION
Adds the `prometheus` label to templated ServiceMonitors so the default serviceMonitorsSelector (`prometheus: {{ .Release.Name }}`) matches against any defined ServiceMonitors. Expected this to match by default -- I think it used to.