### PR TITLE
Add missing resource to operator role

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -20,6 +20,7 @@ rules:
   resources:
   - alertmanagers
   - prometheuses
+  - prometheuses/finalizers
   - servicemonitors
   verbs:
   - "*"


### PR DESCRIPTION
Add a missing 'prometheuses/finalizers' resource to the operator cluster role.
Without this role, the operator will fail to create a default secret for a
Prometheus instance in the absence of any service monitors.

The fix seems to already be present in the `examples` version of the role; this
patch brings the contrib version in line with the example.