### PR TITLE
helm: add ability to exclude alertmanager from kube-prometheus

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.19
+version: 0.0.20

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -3,6 +3,7 @@ dependencies:
     version: 0.0.8
     #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+    condition: deployAlertManager
 
   - name: prometheus
     version: 0.0.14

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -9,6 +9,9 @@ deployGrafana: True
 global:
   rbacEnable: true
 
+# AlertManager
+deployAlertManager: True
+
 alertmanager:
   ## Alertmanager configuration directives
   ## Ref: https://prometheus.io/docs/alerting/configuration/


### PR DESCRIPTION
Some of us use an external alertmanager. Add an option to exclude alertmanager. It still includes it by default.