### PR TITLE
Update kube-prometheus values for storageSpec

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -3,7 +3,7 @@
 ```
 helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 helm install coreos/prometheus-operator --name prometheus-operator --namespace monitoring
-helm install coreos/kube-prometheus --name kube-prometheus --set global.rbacEnable=true --namespace monitoring
+helm install coreos/kube-prometheus --name kube-prometheus --namespace monitoring
 ````
 
 # How to contribue?

--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.8
+version: 0.0.9

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -150,12 +150,14 @@ rbacEnable: true
 ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
 ##
 storageSpec: {}
-#   volumeClaimTemplate:
-#     spec:
-#       resources:
-#         requests:
-#           storage: 50Gi
-#   selector: {}
+#  volumeClaimTemplate:
+#    spec:
+#      storageClassName: gluster
+#      accessModes: ["ReadWriteOnce"]
+#      resources:
+#        requests:
+#          storage: 50Gi
+#    selector: {}
 
 # default rules are in templates/alertmanager.rules.yaml
 # prometheusRules: {}

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.20
+version: 0.0.21

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: alertmanager
-    version: 0.0.8
+    version: 0.0.9
     #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployAlertManager

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -127,10 +127,12 @@ alertmanager:
   storageSpec: {}
   #  volumeClaimTemplate:
   #    spec:
+  #      storageClassName: gluster
+  #      accessModes: ["ReadWriteOnce"]
   #      resources:
   #        requests:
   #          storage: 50Gi
-  #  selector: {}
+  #    selector: {}
 
 prometheus:
   ## Alertmanagers to which alerts will be sent
@@ -351,10 +353,12 @@ prometheus:
   storageSpec: {}
   #  volumeClaimTemplate:
   #    spec:
+  #      storageClassName: gluster
+  #      accessModes: ["ReadWriteOnce"]
   #      resources:
   #        requests:
   #          storage: 50Gi
-  #  selector: {}
+  #    selector: {}
 
 # default rules are in templates/general.rules.yaml
 # prometheusRules: {}


### PR DESCRIPTION
Update the values.yaml for kube-prometheus and alertmanager to be valid
templates and provide a better example. Also delete the --set reference
in the documentation since it is set by default in values.yaml.

Closes #979