### PR TITLE
Give operator permission to manager alertmanagers

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -38,6 +38,7 @@ rules:
   - alertmanagers
   - prometheuses
   - prometheuses/finalizers
+  - alertmanagers/finalizers
   - servicemonitors
   verbs:
   - "*"

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -52,6 +52,7 @@ rules:
   - alertmanagers
   - prometheuses
   - prometheuses/finalizers
+  - alertmanagers/finalizers
   - servicemonitors
   verbs:
   - "*"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -34,6 +34,7 @@ rules:
   - alertmanagers
   - prometheuses
   - prometheuses/finalizers
+  - alertmanagers/finalizers
   - servicemonitors
   verbs:
   - "*"

--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -21,6 +21,7 @@ rules:
   - alertmanagers
   - prometheuses
   - prometheuses/finalizers
+  - alertmanagers/finalizers
   - servicemonitors
   verbs:
   - "*"

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -21,6 +21,7 @@ rules:
   - alertmanagers
   - prometheuses
   - prometheuses/finalizers
+  - alertmanagers/finalizers
   - servicemonitors
   verbs:
   - "*"


### PR DESCRIPTION
Add a missing resource to the operator's cluster role allowing it to correctly
manager alertmanagers.