### PR TITLE
prometheus-config-reloader: propagate errors for refreshing config files

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -50,7 +50,7 @@ func init() {
 	flagset.StringVar(&cfg.TLSConfig.CAFile, "ca-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to TLS CA file.")
 	flagset.StringVar(&cfg.KubeletObject, "kubelet-service", "", "Service/Endpoints object to write kubelets into in format \"namespace/name\"")
 	flagset.BoolVar(&cfg.TLSInsecure, "tls-insecure", false, "- NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate.")
-	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", "quay.io/coreos/prometheus-config-reloader:v0.0.2", "Config and rule reload image")
+	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", "quay.io/coreos/prometheus-config-reloader:v0.0.3", "Config and rule reload image")
 	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "quay.io/coreos/configmap-reload:v0.0.1", "Reload Image")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", "quay.io/prometheus/alertmanager", "Alertmanager default base image")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", "quay.io/prometheus/prometheus", "Prometheus default base image")

--- a/contrib/prometheus-config-reloader/Makefile
+++ b/contrib/prometheus-config-reloader/Makefile
@@ -4,7 +4,7 @@ FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 NAME = prometheus-config-reloader
 REPO = quay.io/coreos/$(NAME)
-TAG = v0.0.2
+TAG = v0.0.3
 IMAGE = $(REPO):$(TAG)
 
 build:

--- a/contrib/prometheus-config-reloader/examples/prometheus-config-reloader.yaml
+++ b/contrib/prometheus-config-reloader/examples/prometheus-config-reloader.yaml
@@ -30,7 +30,7 @@ spec:
           mountPath: /etc/prometheus/rules
           readOnly: true
       - name: prometheus-config-reloader
-        image: quay.io/coreos/prometheus-config-reloader:v0.0.2
+        image: quay.io/coreos/prometheus-config-reloader:v0.0.3
         args:
         - '-config-volume-dir=/etc/prometheus/config'
         - '-rule-volume-dir=/etc/prometheus/rules'

--- a/contrib/prometheus-config-reloader/main.go
+++ b/contrib/prometheus-config-reloader/main.go
@@ -200,11 +200,14 @@ func (w *volumeWatcher) ReloadPrometheus() error {
 	return nil
 }
 
-func (w *volumeWatcher) Refresh() {
+func (w *volumeWatcher) Refresh() error {
 	w.logger.Log("msg", "Updating rule files...")
-	err := w.UpdateRuleFiles()
+	err := backoff.RetryNotify(w.UpdateRuleFiles, backoff.NewExponentialBackOff(), func(err error, next time.Duration) {
+		w.logger.Log("msg", "Updating rule files temporarily failed.", "err", err, "next-retry", next)
+	})
 	if err != nil {
 		w.logger.Log("msg", "Updating rule files failed.", "err", err)
+		return err
 	} else {
 		w.logger.Log("msg", "Rule files updated.")
 	}
@@ -215,9 +218,11 @@ func (w *volumeWatcher) Refresh() {
 	})
 	if err != nil {
 		w.logger.Log("msg", "Reloading Prometheus failed.", "err", err)
+		return err
 	} else {
 		w.logger.Log("msg", "Prometheus successfully reloaded.")
 	}
+	return nil
 }
 
 func (w *volumeWatcher) Run() {
@@ -229,7 +234,11 @@ func (w *volumeWatcher) Run() {
 	defer watcher.Close()
 
 	w.logger.Log("msg", "Starting...")
-	w.Refresh()
+	err = w.Refresh()
+	if err != nil {
+		w.logger.Log("msg", "Initial loading of config volume failed.", "err", err)
+		os.Exit(1)
+	}
 	err = watcher.Add(w.cfg.configVolumeDir)
 	if err != nil {
 		w.logger.Log("msg", "Adding config volume to be watched failed.", "err", err)
@@ -242,7 +251,10 @@ func (w *volumeWatcher) Run() {
 			if event.Op&fsnotify.Create == fsnotify.Create {
 				if filepath.Base(event.Name) == "..data" {
 					w.logger.Log("msg", "ConfigMap modified.")
-					w.Refresh()
+					if err := w.Refresh(); err != nil {
+						w.logger.Log("msg", "Rule files could not be refreshed.", "err", err)
+						os.Exit(1)
+					}
 				}
 			}
 		case err := <-watcher.Errors:

--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.13
+version: 0.0.14

--- a/helm/prometheus-operator/README.md
+++ b/helm/prometheus-operator/README.md
@@ -90,7 +90,7 @@ Parameter | Description | Default
 `kubeletService.name` | The name of the kubelet service to be created | `kubelet`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `prometheusConfigReloader.repository` | prometheus-config-reloader image | `quay.io/coreos/prometheus-config-reloader`
-`prometheusConfigReloader.tag` | prometheus-config-reloader tag | `v0.0.2`
+`prometheusConfigReloader.tag` | prometheus-config-reloader tag | `v0.0.3`
 `rbacEnable` | If true, create & use RBAC resources | `true`
 `resources` | Pod resource requests & limits | `{}`
 

--- a/helm/prometheus-operator/values.yaml
+++ b/helm/prometheus-operator/values.yaml
@@ -10,7 +10,7 @@ global:
 ##
 prometheusConfigReloader:
   repository: quay.io/coreos/prometheus-config-reloader
-  tag: v0.0.2
+  tag: v0.0.3
 
 ## Configmap-reload image to use for reloading configmaps
 ##


### PR DESCRIPTION
Resolves #1002 

Errors from `func (w *volumeWatcher) Refresh()` should be propagated. Right now, errors for refreshing the rules are ignored and may result in a Prometheus instance without rules, or without the latest rules loaded.