### PR TITLE
Fix indentation of serverDashboardFiles

### DIFF
--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.11
+version: 0.0.12

--- a/helm/grafana/templates/dashboards-configmap.yaml
+++ b/helm/grafana/templates/dashboards-configmap.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ template "grafana.server.fullname" . }}
 data:
   {{- if .Values.serverDashboardFiles }}
-  {{ toYaml .Values.serverDashboardFiles | indent 2 }}
+{{ toYaml .Values.serverDashboardFiles | indent 2 }}
   {{ else }}
   {{- include "grafana-dashboards.yaml.tpl" . | indent 2}}
   {{- end }}

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -52,7 +52,7 @@ dependencies:
     condition: deployExporterNode
 
   - name: grafana
-    version: 0.0.11
+    version: 0.0.12
     #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana


### PR DESCRIPTION
This fixes a wrong indentation of serverDashboardFiles in the configmaps and fixes errors with conversion from YAML to JSON.

This brings it to the same line as the datasource and makes it valid.

Current behaviour on master
```
data:
    extra-dashboard.json: |
    {
      "test": "test2"
    }
  prometheus-datasource.json: |
    {
        "access": "proxy",
        "basicAuth": false,
        "name": "prometheus",
        "type": "prometheus",
        "url": "http://k8s-monitor-prometheus.infrastructure:9090"
    }
```

Behaviour with this fix:
```
data:
  extra-dashboard.json: |
    {
      "test": "test2"
    }
  prometheus-datasource.json: |
    {
        "access": "proxy",
        "basicAuth": false,
        "name": "prometheus",
        "type": "prometheus",
        "url": "http://k8s-monitor-prometheus.infrastructure:9090"
    }

```

You can reproduce this with the following values file
```
dataSource:  
    prometheus-datasource.json: |+
        {
            "access": "proxy",
            "basicAuth": false,
            "name": "prometheus",
            "type": "prometheus",
            "url": "http://k8s-monitor-prometheus.infrastructure:9090"
        }
serverDashboardFiles:
    extra-dashboard.json: |+
        {
          "test": "test2"
        }


```