### PR TITLE
documentation: clarify _RelabelConfig_ usage

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -234,7 +234,7 @@ Most recent observed status of the Prometheus cluster. Read-only. Not included w
 
 ## RelabelConfig
 
-RelabelConfig allows dynamic rewriting of the label set.
+RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |

--- a/example/prometheus-operator-crd/prometheus.crd.yaml
+++ b/example/prometheus-operator-crd/prometheus.crd.yaml
@@ -1036,8 +1036,10 @@ spec:
                   writeRelabelConfigs:
                     description: The list of remote write relabel configurations.
                     items:
-                      description: RelabelConfig allows dynamic rewriting of the label
-                        set.
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                       properties:
                         action:
                           description: Action to perform based on regex matching.

--- a/example/prometheus-operator-crd/servicemonitor.crd.yaml
+++ b/example/prometheus-operator-crd/servicemonitor.crd.yaml
@@ -83,8 +83,10 @@ spec:
                   metricRelabelings:
                     description: MetricRelabelConfigs to apply to samples before ingestion.
                     items:
-                      description: RelabelConfig allows dynamic rewriting of the label
-                        set.
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                       properties:
                         action:
                           description: Action to perform based on regex matching.

--- a/pkg/client/monitoring/v1/openapi_generated.go
+++ b/pkg/client/monitoring/v1/openapi_generated.go
@@ -884,7 +884,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1.RelabelConfig": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "RelabelConfig allows dynamic rewriting of the label set.",
+					Description: "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
 					Properties: map[string]spec.Schema{
 						"sourceLabels": {
 							SchemaProps: spec.SchemaProps{

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -218,7 +218,9 @@ type RemoteReadSpec struct {
 	ProxyURL string `json:"proxy_url,omitempty"`
 }
 
-// RelabelConfig allows dynamic rewriting of the label set.
+// RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion.
+// It defines `<metric_relabel_configs>`-section of Prometheus configuration.
+// More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
 // +k8s:openapi-gen=true
 type RelabelConfig struct {
 	//The source labels select values from existing labels. Their content is concatenated


### PR DESCRIPTION
The _RelabelConfig_ is confusing and connotes, that it is about `<relabel_config>`-section of the configuration, but in reality it is about `<metric_relabel_configs>`-section.

#1014