### PR TITLE
Update to Prometheus v2.2.0-rc.1

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -357,7 +357,7 @@ metadata:
     prometheus: k8s
 spec:
   replicas: 2
-  version: v2.2.0-rc.0
+  version: v2.2.0-rc.1
   serviceAccountName: prometheus-k8s
   serviceMonitorSelector:
     matchExpressions:

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
@@ -6,7 +6,7 @@ metadata:
     prometheus: k8s
 spec:
   replicas: 2
-  version: v2.2.0-rc.0
+  version: v2.2.0-rc.1
   serviceAccountName: prometheus-k8s
   serviceMonitorSelector:
     matchExpressions:

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	governingServiceName = "prometheus-operated"
-	DefaultVersion       = "v2.2.0-rc.0"
+	DefaultVersion       = "v2.2.0-rc.1"
 	defaultRetention     = "24h"
 	configMapsFilename   = "configmaps.json"
 	prometheusConfDir    = "/etc/prometheus/config"


### PR DESCRIPTION
Updates to latest Prometheus, notably this fixes an issue with alert manager where Prometheus was sending alert manager data in an unexpected format which was triggering one of the standard kube prometheus alerts.

https://github.com/prometheus/prometheus/issues/3543

Tested manually in my cluster, upgrade from v2.2.0-rc.0 to v2.2.0-rc.1 went smoothly and resolved the alerting issues with kube prometheus.

The part I haven't tested directly is the statefulset.go code change which sets a new default version, but since I haven't touched any of the other code I would assume it should work? Does CI cover that? 