### PR TITLE
*: Adapt SecurityContext handling

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -59,7 +59,7 @@ func init() {
 	flagset.StringVar(&cfg.CrdGroup, "crd-apigroup", monitoringv1.Group, "prometheus CRD  API group name")
 	flagset.Var(&cfg.CrdKinds, "crd-kinds", " - EXPERIMENTAL (could be removed in future releases) - customize CRD kind names")
 	flagset.BoolVar(&cfg.EnableValidation, "with-validation", true, "Include the validation spec in the CRD")
-	flagset.BoolVar(&cfg.DisableRunAsUser, "disable-run-as-user", false, "Disables the Prometheus Operator setting the `runAsUser` field in Pod's SecurityContexts.")
+	flagset.BoolVar(&cfg.DisableAutoUserGroup, "disable-auto-user-group", false, "Disables the Prometheus Operator setting the `runAsUser` and `fsGroup` fields in Pods.")
 	flagset.Parse(os.Args[1:])
 
 }

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -72,7 +72,7 @@ type Config struct {
 	CrdKinds                     monitoringv1.CrdKinds
 	CrdGroup                     string
 	EnableValidation             bool
-	DisableRunAsUser             bool
+	DisableAutoUserGroup         bool
 }
 
 // New creates a new controller.
@@ -112,6 +112,7 @@ func New(c prometheusoperator.Config, logger log.Logger) (*Operator, error) {
 			CrdKinds:                     c.CrdKinds,
 			Labels:                       c.Labels,
 			EnableValidation:             c.EnableValidation,
+			DisableAutoUserGroup:         c.DisableAutoUserGroup,
 		},
 	}
 

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -225,10 +225,10 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*v1beta1.
 	uid := int64(1000)
 	nr := true
 	securityContext := &v1.PodSecurityContext{
-		FSGroup:      &gid,
 		RunAsNonRoot: &nr,
 	}
-	if !config.DisableRunAsUser {
+	if !config.DisableAutoUserGroup {
+		securityContext.FSGroup = &gid
 		securityContext.RunAsUser = &uid
 	}
 	if a.Spec.SecurityContext != nil {

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -127,7 +127,7 @@ type Config struct {
 	CrdGroup                     string
 	CrdKinds                     monitoringv1.CrdKinds
 	EnableValidation             bool
-	DisableRunAsUser             bool
+	DisableAutoUserGroup         bool
 }
 
 type BasicAuthCredentials struct {

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -366,10 +366,10 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMaps []
 		uid := int64(1000)
 		nr := true
 		securityContext = &v1.PodSecurityContext{
-			FSGroup:      &gid,
 			RunAsNonRoot: &nr,
 		}
-		if !c.DisableRunAsUser {
+		if !c.DisableAutoUserGroup {
+			securityContext.FSGroup = &gid
 			securityContext.RunAsUser = &uid
 		}
 	default:


### PR DESCRIPTION
This adds more SecurityContext handling to #1029

For context, OpenShift automatically sets group/user for security reasons.

@ant31 @fabxc 