### PR TITLE
Update Grafana service to use annotation values if provided.

### DIFF
--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.14
+version: 0.0.15

--- a/helm/grafana/templates/svc.yaml
+++ b/helm/grafana/templates/svc.yaml
@@ -7,6 +7,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
   name: {{ template "grafana.server.fullname" . }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
 spec:
   ports:
     - name: "http"

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.24
+version: 0.0.25

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -52,7 +52,7 @@ dependencies:
     condition: deployExporterNode
 
   - name: grafana
-    version: 0.0.14
+    version: 0.0.15
     #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana


### PR DESCRIPTION
I was trying to add annotations to the Grafana service earlier and noticed that they weren't being passed. This change successfully passes them.