### PR TITLE
[helm] Upgrade grafana image to 5.0.0

### DIFF
--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.17
+version: 0.0.18

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -60,7 +60,7 @@ service:
 ##
 image:
   repository: grafana/grafana
-  tag: 4.6.3
+  tag: 5.0.0
 
 grafanaWatcher:
   repository: quay.io/coreos/grafana-watcher

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.28
+version: 0.0.29

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -52,7 +52,7 @@ dependencies:
     condition: deployExporterNode
 
   - name: grafana
-    version: 0.0.17
+    version: 0.0.18
     #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana


### PR DESCRIPTION
This PR upgrades the image on grafana Chart to 5.0.0

There are other changes that can be applied given the changes on version 5, like removing the grafana-watcher image and adding dashboard and datasources configs given the new format but I think is better to dedicate efforts on https://github.com/brancz/kubernetes-grafana and use it in the future instead of trying to refactor the current grafana Chart.