### PR TITLE
example service monitoring updated with missing config

### DIFF
--- a/contrib/kube-prometheus/hack/example-service-monitoring/deploy
+++ b/contrib/kube-prometheus/hack/example-service-monitoring/deploy
@@ -8,6 +8,9 @@ if [ -z "${NAMESPACE}" ]; then
     NAMESPACE=default
 fi
 
+kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend-service-account.yaml
+kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend-role.yaml
+kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend-role-binding.yaml
 kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend-svc.yaml
 kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/example-app.yaml
 kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend.yaml

--- a/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-role-binding.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: prometheus-frontend
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-frontend
+subjects:
+- kind: ServiceAccount
+  name: prometheus-frontend
+  namespace: default

--- a/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-role.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: prometheus-frontend
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]

--- a/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-service-account.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-frontend

--- a/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     prometheus: frontend
 spec:
+  serviceAccountName: prometheus-frontend
   version: v1.7.1
   serviceMonitorSelector:
     matchLabels:


### PR DESCRIPTION
added service account, role and role binding for the prometheus frontend
example, also updated prometheus to use the correct service account

fixes #1049