### PR TITLE
*: Use data directory defined as volume in Dockerfile

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -36,7 +36,7 @@ const (
 	defaultVersion         = "v0.14.0"
 	alertmanagerConfDir    = "/etc/alertmanager/config"
 	alertmanagerConfFile   = alertmanagerConfDir + "/alertmanager.yaml"
-	alertmanagerStorageDir = "/var/alertmanager/data"
+	alertmanagerStorageDir = "/alertmanager"
 )
 
 var (

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -42,7 +42,7 @@ const (
 	configMapsFilename   = "configmaps.json"
 	prometheusConfDir    = "/etc/prometheus/config"
 	prometheusConfFile   = prometheusConfDir + "/prometheus.yaml"
-	prometheusStorageDir = "/var/prometheus/data"
+	prometheusStorageDir = "/prometheus"
 	prometheusRulesDir   = "/etc/prometheus/rules"
 	prometheusSecretsDir = "/etc/prometheus/secrets/"
 )

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -171,7 +171,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 								}, {
 									Name:      "prometheus--db",
 									ReadOnly:  false,
-									MountPath: "/var/prometheus/data",
+									MountPath: "/prometheus",
 									SubPath:   "",
 								}, {
 									Name:      "secret-test-secret1",


### PR DESCRIPTION
This changes Prometheus and Alertmanager Pods to mount the data volume under the same directory as specified as a volume in the respective `Dockerfile`.

@ant31 @fabxc @derekwaynecarr @ironcladlou 