### PR TITLE
prometheus: Add ability to authenticate with bearer token from file

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -66,6 +66,7 @@ AlertmanagerEndpoints defines a selection of a single Endpoints object containin
 | scheme | Scheme to use when firing alerts. | string | false |
 | pathPrefix | Prefix for the HTTP path alerts are pushed to. | string | false |
 | tlsConfig | TLS Config to use for alertmanager connection. | *[TLSConfig](#tlsconfig) | false |
+| bearerTokenFile | BearerTokenFile to read from filesystem to use when authenticating to Alertmanager. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/example/prometheus-operator-crd/prometheus.crd.yaml
+++ b/example/prometheus-operator-crd/prometheus.crd.yaml
@@ -544,6 +544,10 @@ spec:
                       Endpoints object containing alertmanager IPs to fire alerts
                       against.
                     properties:
+                      bearerTokenFile:
+                        description: BearerTokenFile to read from filesystem to use
+                          when authenticating to Alertmanager.
+                        type: string
                       name:
                         description: Name of Endpoints object in Namespace.
                         type: string

--- a/pkg/client/monitoring/v1/openapi_generated.go
+++ b/pkg/client/monitoring/v1/openapi_generated.go
@@ -134,6 +134,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("github.com/coreos/prometheus-operator/pkg/client/monitoring/v1.TLSConfig"),
 							},
 						},
+						"bearerTokenFile": {
+							SchemaProps: spec.SchemaProps{
+								Description: "BearerTokenFile to read from filesystem to use when authenticating to Alertmanager.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
 					Required: []string{"namespace", "name", "port"},
 				},

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -271,6 +271,9 @@ type AlertmanagerEndpoints struct {
 	PathPrefix string `json:"pathPrefix,omitempty"`
 	// TLS Config to use for alertmanager connection.
 	TLSConfig *TLSConfig `json:"tlsConfig,omitempty"`
+	// BearerTokenFile to read from filesystem to use when authenticating to
+	// Alertmanager.
+	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 }
 
 // ServiceMonitor defines monitoring for a set of services.

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -497,6 +497,10 @@ func generateAlertmanagerConfig(version semver.Version, am v1.AlertmanagerEndpoi
 		cfg = append(cfg, k8sSDWithNamespaces([]string{am.Namespace}))
 	}
 
+	if am.BearerTokenFile != "" {
+		cfg = append(cfg, yaml.MapItem{Key: "bearer_token_file", Value: am.BearerTokenFile})
+	}
+
 	var relabelings []yaml.MapSlice
 
 	relabelings = append(relabelings, yaml.MapSlice{


### PR DESCRIPTION
This adds the ability to authenticate against Alertmanager with a bearer token read from file. It allows us to use a ServiceAccount token in a Prometheus Pod to authenticate against Alertmanager with it.

@ant31 @fabxc @derekwaynecarr @ironcladlou 