### PR TITLE
e2e: ensure C locale when generating random string for namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO?=quay.io/coreos/prometheus-operator
 TAG?=$(shell git rev-parse --short HEAD)
-NAMESPACE?=po-e2e-$(shell LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 13 ; echo '')
+NAMESPACE?=po-e2e-$(shell LC_ALL=C tr -dc a-z0-9 < /dev/urandom | head -c 13 ; echo '')
 KUBECONFIG?=$(HOME)/.kube/config
 
 PROMU := $(GOPATH)/bin/promu


### PR DESCRIPTION
LC_ALL when set takes precedence over LC_CTYPE and might cause
the tr command to fail with 'illegal byte sequence' when
generating the random string.