### PR TITLE
contrib/kube: Restrict example-app servicemonitor to default ns

### DIFF
--- a/contrib/kube-prometheus/manifests/examples/example-app/servicemonitor-frontend.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/servicemonitor-frontend.yaml
@@ -11,3 +11,6 @@ spec:
   endpoints:
   - port: web
     interval: 10s
+  namespaceSelector:
+    matchNames:
+      - default


### PR DESCRIPTION
The `prometheus-frontend` role of the example app kubeprometheus section
is scoped to the default namespace. Thereby the frontend Prometheus
instance is not able to discover anything outside of the default
namespace. We might as well restrict the front end service monitor to
the default namespace too.