### PR TITLE
Unify rule file label accross repository

### DIFF
--- a/Documentation/user-guides/alerting.md
+++ b/Documentation/user-guides/alerting.md
@@ -126,7 +126,7 @@ spec:
       memory: 400Mi
   ruleSelector:
     matchLabels:
-      role: prometheus-rulefiles
+      role: alert-rules
       prometheus: example
 ```
 
@@ -134,7 +134,7 @@ The above configuration specifies a `Prometheus` that finds all of the Alertmana
 
 Prometheus rule files are held in ConfigMaps. Use the label selector field `ruleSelector` in the Prometheus object to define the ConfigMaps from which rule files will be mounted. All top level files that end with the `.rules` extension will be loaded.
 
-The best practice is to label the `ConfigMap`s containing rule files with `role: prometheus-rulefiles` as well as the name of the Prometheus object, `prometheus: example` in this case.
+The best practice is to label the `ConfigMap`s containing rule files with `role: alert-rules` as well as the name of the Prometheus object, `prometheus: example` in this case.
 
 [embedmd]:# (../../example/user-guides/alerting/prometheus-example-rules.yaml)
 ```yaml
@@ -143,7 +143,7 @@ apiVersion: v1
 metadata:
   name: prometheus-example-rules
   labels:
-    role: prometheus-rulefiles
+    role: alert-rules
     prometheus: example
 data:
   example.rules.yaml: |+

--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -364,7 +364,7 @@ spec:
     - {key: k8s-app, operator: Exists}
   ruleSelector:
     matchLabels:
-      role: prometheus-rulefiles
+      role: alert-rules
       prometheus: k8s
   resources:
     requests:

--- a/contrib/kube-prometheus/hack/scripts/generate-rules-configmap.sh
+++ b/contrib/kube-prometheus/hack/scripts/generate-rules-configmap.sh
@@ -6,7 +6,7 @@ kind: ConfigMap
 metadata:
   name: prometheus-k8s-rules
   labels:
-    role: prometheus-rulefiles
+    role: alert-rules
     prometheus: k8s
 data:
 EOF

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: prometheus-k8s-rules
   labels:
-    role: prometheus-rulefiles
+    role: alert-rules
     prometheus: k8s
 data:
   alertmanager.rules.yaml: |+

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
@@ -13,7 +13,7 @@ spec:
     - {key: k8s-app, operator: Exists}
   ruleSelector:
     matchLabels:
-      role: prometheus-rulefiles
+      role: alert-rules
       prometheus: k8s
   resources:
     requests:

--- a/example/user-guides/alerting/prometheus-example-rules.yaml
+++ b/example/user-guides/alerting/prometheus-example-rules.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: prometheus-example-rules
   labels:
-    role: prometheus-rulefiles
+    role: alert-rules
     prometheus: example
 data:
   example.rules.yaml: |+

--- a/example/user-guides/alerting/prometheus-example.yaml
+++ b/example/user-guides/alerting/prometheus-example.yaml
@@ -17,5 +17,5 @@ spec:
       memory: 400Mi
   ruleSelector:
     matchLabels:
-      role: prometheus-rulefiles
+      role: alert-rules
       prometheus: example


### PR DESCRIPTION
In some cases we have been using `alert-rules` in some cases
`prometheus-rulefiles`. This led to confusion [1]. Instead, unify the
Prometheus rules configmap labels to:

```yaml
labels:
  role: alert-rules
```

[1] https://github.com/coreos/prometheus-operator/issues/1102

Fixes #1102 