### PR TITLE
contrib/kube: Add rbac role to discover alertmanager

### DIFF
--- a/contrib/kube-prometheus/hack/example-service-monitoring/deploy
+++ b/contrib/kube-prometheus/hack/example-service-monitoring/deploy
@@ -1,18 +1,3 @@
 #!/usr/bin/env bash
 
-if [ -z "${KUBECONFIG}" ]; then
-    KUBECONFIG=~/.kube/config
-fi
-
-if [ -z "${NAMESPACE}" ]; then
-    NAMESPACE=default
-fi
-
-kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend-service-account.yaml
-kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend-role.yaml
-kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend-role-binding.yaml
-kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend-svc.yaml
-kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/example-app.yaml
-kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend.yaml
-kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/servicemonitor-frontend.yaml
-
+kubectl apply -f manifests/examples/example-app

--- a/contrib/kube-prometheus/hack/example-service-monitoring/teardown
+++ b/contrib/kube-prometheus/hack/example-service-monitoring/teardown
@@ -1,12 +1,3 @@
 #!/usr/bin/env bash
 
-if [ -z "${KUBECONFIG}" ]; then
-    KUBECONFIG=~/.kube/config
-fi
-
-if [ -z "${NAMESPACE}" ]; then
-    NAMESPACE=default
-fi
-
-kubectl --namespace "$NAMESPACE" --kubeconfig="$KUBECONFIG" delete -f manifests/examples/example-app
-
+kubectl delete -f manifests/examples/example-app

--- a/contrib/kube-prometheus/manifests/examples/example-app/example-app.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/example-app.yaml
@@ -4,6 +4,7 @@ metadata:
   name: example-app
   labels:
     tier: frontend
+  namespace: default
 spec: 
   selector: 
     app: example-app 
@@ -17,6 +18,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: example-app
+  namespace: default
 spec:
   replicas: 4
   template:

--- a/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-alertmanager-discovery-role-binding.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-alertmanager-discovery-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: prometheus-frontend
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: alertmanager-discovery
+subjects:
+- kind: ServiceAccount
+  name: prometheus-frontend
+  namespace: default

--- a/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-alertmanager-discovery-role.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-alertmanager-discovery-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: alertmanager-discovery
+  namespace: monitoring
+rules:
+- apiGroups: [""]
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs: ["list", "watch"]

--- a/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-service-account.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-service-account.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus-frontend
+  namespace: default

--- a/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-svc.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/prometheus-frontend-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-frontend
+  namespace: default
 spec:
   type: NodePort
   ports:

--- a/contrib/kube-prometheus/manifests/examples/example-app/servicemonitor-frontend.yaml
+++ b/contrib/kube-prometheus/manifests/examples/example-app/servicemonitor-frontend.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: frontend
+  namespace: default
   labels:
     tier: frontend
 spec:


### PR DESCRIPTION
The current example-app setup in the kube-prometheus project is able to
discover scraping targets in the default namespace. It is not able to
discover the configured Alertmanager in the monitoring namespace.

This patch adds an alertmanager-discovery rbac role, to permit the
above described action. In addition it does the following cleanups:

- Remove kubeconfig configuration in deploy and teardown script. kubectl
chooses .kube/config whenever KUBECONFIG is not set by default

- Remove namespace specification option via NAMESPACE env var. In most
of the manifests the metadata/namespace was hardcoded anyways, in
addition in the promtheus frontend role binding the service account
namespace is hardcoded to default as well.

- Instead of `kubectl {apply,delete}` individual manifests, the deploy
and teardown shell scripts {apply,delete} on the entire folder.