### PR TITLE
Support Alertmanager v0.15.0

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -89,7 +89,7 @@ Specification of the desired behavior of the Alertmanager cluster. More info: ht
 | ----- | ----------- | ------ | -------- |
 | podMetadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | *[metav1.ObjectMeta](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | false |
 | version | Version the cluster should be on. | string | false |
-| baseImage | Base image that is used to deploy pods. | string | false |
+| baseImage | Base image that is used to deploy pods, without tag. | string | false |
 | imagePullSecrets | An optional list of references to secrets in the same namespace to use for pulling prometheus and alertmanager images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod | [][v1.LocalObjectReference](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#localobjectreference-v1-core) | false |
 | replicas | Size is the expected size of the alertmanager cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | false |
 | storage | Storage is the definition of how storage will be used by the Alertmanager instances. | *[StorageSpec](#storagespec) | false |

--- a/example/prometheus-operator-crd/alertmanager.crd.yaml
+++ b/example/prometheus-operator-crd/alertmanager.crd.yaml
@@ -533,7 +533,7 @@ spec:
                             type: string
                       type: array
             baseImage:
-              description: Base image that is used to deploy pods.
+              description: Base image that is used to deploy pods, without tag.
               type: string
             containers:
               description: Containers allows injecting additional containers. This

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -15,6 +15,7 @@
 package alertmanager
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -209,4 +210,153 @@ func TestListenLocal(t *testing.T) {
 	if len(sset.Spec.Template.Spec.Containers[0].Ports) != 1 {
 		t.Fatal("Alertmanager container should only have one port defined")
 	}
+}
+
+// below Alertmanager v0.13.0 all flags are with single dash.
+func TestMakeStatefulSetSpecSingleDoubleDashedArgs(t *testing.T) {
+	tests := []struct {
+		version string
+		prefix  string
+		amount  int
+	}{
+		{"v0.12.0", "-", 1},
+		{"v0.13.0", "--", 2},
+	}
+
+	for _, test := range tests {
+		a := monitoringv1.Alertmanager{}
+		a.Spec.Version = test.version
+		replicas := int32(3)
+		a.Spec.Replicas = &replicas
+
+		statefulSet, err := makeStatefulSetSpec(&a, Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		amArgs := statefulSet.Template.Spec.Containers[0].Args
+
+		for _, arg := range amArgs {
+			if arg[:test.amount] != test.prefix {
+				t.Fatalf("expected all args to start with %v but got %v", test.prefix, arg)
+			}
+		}
+	}
+}
+
+// below Alertmanager v0.7.0 the flag 'web.route-prefix' does not exist
+func TestMakeStatefulSetSpecWebRoutePrefix(t *testing.T) {
+	tests := []struct {
+		version              string
+		expectWebRoutePrefix bool
+	}{
+		{"v0.6.0", false},
+		{"v0.7.0", true},
+	}
+
+	for _, test := range tests {
+		a := monitoringv1.Alertmanager{}
+		a.Spec.Version = test.version
+		replicas := int32(1)
+		a.Spec.Replicas = &replicas
+
+		statefulSet, err := makeStatefulSetSpec(&a, Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		amArgs := statefulSet.Template.Spec.Containers[0].Args
+
+		containsWebRoutePrefix := false
+
+		for _, arg := range amArgs {
+			if strings.Contains(arg, "-web.route-prefix") {
+				containsWebRoutePrefix = true
+			}
+		}
+
+		if containsWebRoutePrefix != test.expectWebRoutePrefix {
+			t.Fatalf("expected stateful set containing arg '-web.route-prefix' to be: %v", test.expectWebRoutePrefix)
+		}
+	}
+}
+
+// below Alertmanager v0.15.0 high availability flags are prefixed with 'mesh' instead of 'cluster'
+func TestMakeStatefulSetSpecMeshClusterFlags(t *testing.T) {
+	tests := []struct {
+		version       string
+		rightHAPrefix string
+		wrongHAPrefix string
+	}{
+		{"v0.14.0", "mesh", "cluster"},
+		{"v0.15.0", "cluster", "mesh"},
+	}
+
+	for _, test := range tests {
+		a := monitoringv1.Alertmanager{}
+		a.Spec.Version = test.version
+		replicas := int32(3)
+		a.Spec.Replicas = &replicas
+
+		statefulSet, err := makeStatefulSetSpec(&a, Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		haFlags := []string{"--%v.listen-address", "--%v.peer="}
+
+		amArgs := statefulSet.Template.Spec.Containers[0].Args
+
+		for _, flag := range haFlags {
+			if sliceContains(amArgs, fmt.Sprintf(flag, test.wrongHAPrefix)) {
+				t.Fatalf("expected Alertmanager args not to contain %v, but got %v", test.wrongHAPrefix, amArgs)
+			}
+			if !sliceContains(amArgs, fmt.Sprintf(flag, test.rightHAPrefix)) {
+				t.Fatalf("expected Alertmanager args to contain %v, but got %v", test.rightHAPrefix, amArgs)
+			}
+		}
+	}
+}
+
+// below Alertmanager v0.15.0 peer address port specification is not necessary
+func TestMakeStatefulSetSpecPeerFlagPort(t *testing.T) {
+	tests := []struct {
+		version    string
+		portNeeded bool
+	}{
+		{"v0.14.0", false},
+		{"v0.15.0", true},
+	}
+
+	for _, test := range tests {
+		a := monitoringv1.Alertmanager{}
+		a.Spec.Version = test.version
+		replicas := int32(3)
+		a.Spec.Replicas = &replicas
+
+		statefulSet, err := makeStatefulSetSpec(&a, Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		amArgs := statefulSet.Template.Spec.Containers[0].Args
+
+		for _, arg := range amArgs {
+			if strings.Contains(arg, ".peer") {
+				if strings.Contains(arg, ":6783") != test.portNeeded {
+					t.Fatalf("expected arg '%v' containing port specification to be: %v", arg, test.portNeeded)
+				}
+			}
+		}
+	}
+}
+
+func sliceContains(slice []string, match string) bool {
+	contains := false
+	for _, s := range slice {
+		if strings.Contains(s, match) {
+			contains = true
+		}
+	}
+	return contains
 }

--- a/pkg/client/monitoring/v1/openapi_generated.go
+++ b/pkg/client/monitoring/v1/openapi_generated.go
@@ -213,7 +213,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"baseImage": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Base image that is used to deploy pods.",
+								Description: "Base image that is used to deploy pods, without tag.",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -396,7 +396,7 @@ type AlertmanagerSpec struct {
 	PodMetadata *metav1.ObjectMeta `json:"podMetadata,omitempty"`
 	// Version the cluster should be on.
 	Version string `json:"version,omitempty"`
-	// Base image that is used to deploy pods.
+	// Base image that is used to deploy pods, without tag.
 	BaseImage string `json:"baseImage,omitempty"`
 	// An optional list of references to secrets in the same namespace
 	// to use for pulling prometheus and alertmanager images from registries

--- a/test/framework/context.go
+++ b/test/framework/context.go
@@ -31,7 +31,16 @@ type TestCtx struct {
 type finalizerFn func() error
 
 func (f *Framework) NewTestCtx(t *testing.T) TestCtx {
-	prefix := strings.TrimPrefix(strings.ToLower(t.Name()), "test")
+	// TestCtx is used among others for namespace names where '/' is forbidden
+	prefix := strings.TrimPrefix(
+		strings.Replace(
+			strings.ToLower(t.Name()),
+			"/",
+			"-",
+			-1,
+		),
+		"test",
+	)
 
 	id := prefix + "-" + strconv.FormatInt(time.Now().Unix(), 10)
 	return TestCtx{


### PR DESCRIPTION
With Alertmanager v0.15.0 the HA command line flag prefix changes from
"mesh" to "cluster" and peer ports need to be specified. This patch
enables running Alertmanager v0.15.0 with the Prometheus operator
without breaking backward compatibility.

In addition it does the following refactoring:

- Instead of generating the stateful set for an old AM version, and then
addressing all necessary changes up to the newest version, generate an
up to date stateful set version and address any changes necessary for
backward compatibility.

- Add unit tests for the various flag changes in between Alertmanager
version.

- Add v0.15.0 mesh initialization test