### PR TITLE
Grouped queries to some alerts to get hold of pod/deployment labels

### DIFF
--- a/helm/exporter-kube-state/Chart.yaml
+++ b/helm/exporter-kube-state/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-state
-version: 0.1.15
+version: 0.1.16
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kube-state/templates/kube-state-metrics.rules.yaml
+++ b/helm/exporter-kube-state/templates/kube-state-metrics.rules.yaml
@@ -3,7 +3,8 @@ groups:
 - name: kube-state-metrics.rules
   rules:
   - alert: DeploymentGenerationMismatch
-    expr: kube_deployment_status_observed_generation != kube_deployment_metadata_generation
+    expr: (kube_deployment_status_observed_generation != kube_deployment_metadata_generation) /
+          on(deployment) group_right() kube_deployment_labels
     for: 15m
     labels:
       severity: warning
@@ -12,9 +13,11 @@ groups:
         deployment {{`{{$labels.namespaces}}`}}/{{`{{$labels.deployment}}`}}
       summary: Deployment is outdated
   - alert: DeploymentReplicasNotUpdated
-    expr: ((kube_deployment_status_replicas_updated != kube_deployment_spec_replicas)
-      or (kube_deployment_status_replicas_available != kube_deployment_spec_replicas))
-      unless (kube_deployment_spec_paused == 1)
+    expr: sum( ((kube_deployment_status_replicas_updated != kube_deployment_spec_replicas)
+             or (kube_deployment_status_replicas_available != kube_deployment_spec_replicas))
+             unless (kube_deployment_spec_paused == 1) )
+          by (deployment) /
+          on(deployment) group_right() kube_deployment_labels
     for: 15m
     labels:
       severity: warning
@@ -50,7 +53,8 @@ groups:
         to run.
       summary: Daemonsets are not scheduled correctly
   - alert: PodFrequentlyRestarting
-    expr: increase(kube_pod_container_status_restarts_total[1h]) > 5
+    expr: (sum(increase(kube_pod_container_status_restarts_total[1h]) > 5) by (pod))
+          / on(pod) group_right() kube_pod_labels
     for: 10m
     labels:
       severity: warning

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.35
+version: 0.0.36


### PR DESCRIPTION
As promised in https://github.com/coreos/prometheus-operator/issues/695#issuecomment-374511921 I have made an attempt to get some deployment and pod labels into the alerts.

Maybe there can be done some more, if so please suggest some changes, and I'll add them. #