### PR TITLE
alertmanager: Allows specifying additional secrets

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -91,6 +91,7 @@ Specification of the desired behavior of the Alertmanager cluster. More info: ht
 | version | Version the cluster should be on. | string | false |
 | baseImage | Base image that is used to deploy pods, without tag. | string | false |
 | imagePullSecrets | An optional list of references to secrets in the same namespace to use for pulling prometheus and alertmanager images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod | [][v1.LocalObjectReference](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#localobjectreference-v1-core) | false |
+| secrets | Secrets is a list of Secrets in the same namespace as the Alertmanager object, which shall be mounted into the Alertmanager Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>. | []string | false |
 | replicas | Size is the expected size of the alertmanager cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | false |
 | storage | Storage is the definition of how storage will be used by the Alertmanager instances. | *[StorageSpec](#storagespec) | false |
 | externalUrl | The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name. | string | false |

--- a/example/prometheus-operator-crd/alertmanager.crd.yaml
+++ b/example/prometheus-operator-crd/alertmanager.crd.yaml
@@ -1590,6 +1590,13 @@ spec:
                 the server serves requests under a different route prefix. For example
                 for use with `kubectl proxy`.
               type: string
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                Alertmanager object, which shall be mounted into the Alertmanager
+                Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.
+              items:
+                type: string
+              type: array
             securityContext:
               description: PodSecurityContext holds pod-level security attributes
                 and common container settings. Some fields are also present in container.securityContext.  Field

--- a/pkg/client/monitoring/v1/openapi_generated.go
+++ b/pkg/client/monitoring/v1/openapi_generated.go
@@ -231,6 +231,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"secrets": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Secrets is a list of Secrets in the same namespace as the Alertmanager object, which shall be mounted into the Alertmanager Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.",
+								Type:        []string{"array"},
+								Items: &spec.SchemaOrArray{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Type:   []string{"string"},
+											Format: "",
+										},
+									},
+								},
+							},
+						},
 						"replicas": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Size is the expected size of the alertmanager cluster. The controller will eventually make the size of the running cluster equal to the expected size.",

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -402,6 +402,10 @@ type AlertmanagerSpec struct {
 	// to use for pulling prometheus and alertmanager images from registries
 	// see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
 	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	// Secrets is a list of Secrets in the same namespace as the Alertmanager
+	// object, which shall be mounted into the Alertmanager Pods.
+	// The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.
+	Secrets []string `json:"secrets,omitempty"`
 	// Size is the expected size of the alertmanager cluster. The controller will
 	// eventually make the size of the running cluster equal to the expected
 	// size.

--- a/pkg/client/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/client/monitoring/v1/zz_generated.deepcopy.go
@@ -142,6 +142,11 @@ func (in *AlertmanagerSpec) DeepCopyInto(out *AlertmanagerSpec) {
 		*out = make([]core_v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.Secrets != nil {
+		in, out := &in.Secrets, &out.Secrets
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
 		if *in == nil {


### PR DESCRIPTION
For sidecar proxies it may be desirable to add additional secrets to be mounted so they can be consumed by the sidecar.

@ant31 @fabxc @mxinden 