### PR TITLE
Pass TLS config to etcd service monitor

### DIFF
--- a/helm/exporter-kube-etcd/templates/servicemonitor.yaml
+++ b/helm/exporter-kube-etcd/templates/servicemonitor.yaml
@@ -24,7 +24,13 @@ spec:
     {{- if eq .Values.scheme "https" }}
     scheme: https
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      caFile: {{ .Values.caFile }}
+      {{- if  .Values.certFile }}
+      certFile: {{ .Values.certFile }}
+      {{- end }}
+      {{- if .Values.keyFile }}
+      keyFile: {{ .Values.keyFile }}
+      {{- end}}
       insecureSkipVerify: true
     {{- end }}
 

--- a/helm/exporter-kube-etcd/values.yaml
+++ b/helm/exporter-kube-etcd/values.yaml
@@ -6,3 +6,8 @@ endpoints: []
 scheme: http
 # default rules are in templates/etcd3.rules.yaml
 # prometheusRules: {}
+
+# TLS Cofiguration for the service monitor, default to none, but append cert and keyfile if passed
+caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+certFile: ""
+keyFile: ""


### PR DESCRIPTION
In order to use this chart in our environment we need to specify a TLS configuration
this will allow a TLS configuration to be passed to the node-exporter-etcd chart.