### PR TITLE
charts: Pass TLS config to etcd service monitor

### DIFF
--- a/helm/exporter-kube-etcd/Chart.yaml
+++ b/helm/exporter-kube-etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-kube-etcd
-version: 0.1.8
+version: 0.1.9
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-kube-etcd/templates/servicemonitor.yaml
+++ b/helm/exporter-kube-etcd/templates/servicemonitor.yaml
@@ -24,7 +24,13 @@ spec:
     {{- if eq .Values.scheme "https" }}
     scheme: https
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      caFile: {{ .Values.caFile }}
+      {{- if  .Values.certFile }}
+      certFile: {{ .Values.certFile }}
+      {{- end }}
+      {{- if .Values.keyFile }}
+      keyFile: {{ .Values.keyFile }}
+      {{- end}}
       insecureSkipVerify: true
     {{- end }}
 

--- a/helm/exporter-kube-etcd/values.yaml
+++ b/helm/exporter-kube-etcd/values.yaml
@@ -6,3 +6,8 @@ endpoints: []
 scheme: http
 # default rules are in templates/etcd3.rules.yaml
 # prometheusRules: {}
+
+# TLS Cofiguration for the service monitor, default to none, but append cert and keyfile if passed
+caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+certFile: ""
+keyFile: ""

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.42
+version: 0.0.43

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-etcd
-    version: 0.1.8
+    version: 0.1.9
     #e2e-repository: file://../exporter-kube-etcd
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 


### PR DESCRIPTION
In order to use this chart in our environment we need to specify a TLS configuration
this will allow us to pass one.

Fixes #1162