### PR TITLE
charts: Add Core DNS Support

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-coredns-metrics.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-coredns-metrics.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-prometheus-discovery
+  namespace: kube-system
+  labels:
+    k8s-app: coredns
+    component: metrics
+spec:
+  ports:
+    - name: http-metrics
+      port: 9153
+      protocol: TCP
+      targetPort: 9153
+  selector:
+    k8s-app: coredns
+  type: ClusterIP
+  clusterIP: None

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-monitor-coredns.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-monitor-coredns.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: coredns
+  name: coredns
+spec:
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      k8s-app: coredns
+      component: metrics
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  endpoints:
+  - port: http-metrics
+    interval: 15s
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/helm/exporter-coredns/.helmignore
+++ b/helm/exporter-coredns/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/exporter-coredns/Chart.yaml
+++ b/helm/exporter-coredns/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for coredns metrics
+name: exporter-coredns
+version: 0.0.1

--- a/helm/exporter-coredns/templates/_helpers.tpl
+++ b/helm/exporter-coredns/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "exporter-coredns.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "exporter-coredns.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
+*/}}
+{{- define "prometheus-operator.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- printf "%s" "monitoring.coreos.com/v1" -}}
+{{- else -}}
+{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/exporter-coredns/templates/service.yaml
+++ b/helm/exporter-coredns/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "exporter-coredns.name" . }}
+    component: {{ .Values.selectorLabel }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "exporter-coredns.fullname" . }}
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics-coredns
+      port: {{ .Values.port }}
+      protocol: TCP
+      targetPort: {{ .Values.port }}
+  selector:
+    k8s-app: {{ .Values.selectorLabel }}
+  type: ClusterIP

--- a/helm/exporter-coredns/templates/servicemonitor.yaml
+++ b/helm/exporter-coredns/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: {{ template "prometheus-operator.apiVersion" . }}
+kind: ServiceMonitor
+metadata:
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ .Values.selectorLabel }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+    prometheus: {{ .Release.Name }}
+  name: {{ template "exporter-coredns.fullname" . }}
+spec:
+  jobLabel: component
+  selector:
+    matchLabels:
+      app: {{ template "exporter-coredns.name" . }}
+      component: {{ .Values.selectorLabel }}
+  namespaceSelector:
+    matchNames:
+      - "kube-system"
+  endpoints:
+  - port: http-metrics-coredns
+    interval: 15s
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/helm/exporter-coredns/values.yaml
+++ b/helm/exporter-coredns/values.yaml
@@ -1,7 +1,7 @@
 # Default values for exporter-coredns.
 
 # Port that core DNS Metrics are exposed on
-port: 9001
+port: 9153
 
 # The k8s-app label coredns is deployed with
 selectorLabel: coredns

--- a/helm/exporter-coredns/values.yaml
+++ b/helm/exporter-coredns/values.yaml
@@ -1,0 +1,7 @@
+# Default values for exporter-coredns.
+
+# Port that core DNS Metrics are exposed on
+port: 9001
+
+# The k8s-app label coredns is deployed with
+selectorLabel: coredns

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.43
+version: 0.0.44

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -10,6 +10,12 @@ dependencies:
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
+  - name: exporter-coredns
+    version: 0.0.1
+    #e2e-repository: file://../exporter-coredns
+    repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+    condition: deployCoreDNS
+
   - name: exporter-kube-controller-manager
     version: 0.1.7
     #e2e-repository: file://../exporter-kube-controller-manager
@@ -19,6 +25,7 @@ dependencies:
     version: 0.1.5
     #e2e-repository: file://../exporter-kube-dns
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+    condition: deployKubeDNS
 
   - name: exporter-kube-etcd
     version: 0.1.9

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -385,3 +385,7 @@ prometheus:
 
 # default rules are in templates/general.rules.yaml
 # prometheusRules: {}
+
+# Select Deployed DNS Solution
+deployCoreDNS: false
+deployKubeDNS: true


### PR DESCRIPTION
With CoreDNS becoming a first class citizen it should be an optional part
of the kube-prometheus deployment.

Fixes: #1174

Note: I don't know how this fits into the existing testing pipeline since it includes CoreDNS which may not be part of the e2e testing environment