### PR TITLE
Package exporter-coredns during helm-sync-s3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ jsonnet-docker:
 	docker build -f scripts/jsonnet/Dockerfile -t po-jsonnet .
 
 helm-sync-s3:
-	helm/hack/helm-package.sh "alertmanager grafana prometheus prometheus-operator exporter-kube-dns exporter-kube-scheduler exporter-kubelets exporter-node exporter-kube-controller-manager exporter-kube-etcd exporter-kube-state exporter-kubernetes"
+	helm/hack/helm-package.sh "alertmanager grafana prometheus prometheus-operator exporter-kube-dns exporter-kube-scheduler exporter-kubelets exporter-node exporter-kube-controller-manager exporter-kube-etcd exporter-kube-state exporter-kubernetes exporter-coredns"
 	helm/hack/sync-repo.sh true
 	helm/hack/helm-package.sh kube-prometheus
 	helm/hack/sync-repo.sh true


### PR DESCRIPTION
CI on master branch is failing because helm sync is not exporting exporter-coredns to s3.

Looking forward to move all helm charts to kubernetes upstream and avoid this flaky CI caused by helm. 💀 