### PR TITLE
Added Pod Security Policies to the HELM Charts

### DIFF
--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -8,7 +8,7 @@ name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://github.com/prometheus/alertmanager
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.14.0"
 home: https://github.com/prometheus/alertmanager
 keywords:

--- a/helm/alertmanager/templates/psp-clusterrole.yaml
+++ b/helm/alertmanager/templates/psp-clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.pspEnable }}
+kind: ClusterRole
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+metadata:
+  labels:
+    app: {{ template "alertmanager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "alertmanager.fullname" . }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "alertmanager.fullname" . }}
+{{- end }}

--- a/helm/alertmanager/templates/psp-clusterrole.yaml
+++ b/helm/alertmanager/templates/psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnable }}
 {{- if .Values.global.pspEnable }}
 kind: ClusterRole
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
@@ -18,4 +19,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "alertmanager.fullname" . }}
+{{- end }}
 {{- end }}

--- a/helm/alertmanager/templates/psp-clusterrolebinding.yaml
+++ b/helm/alertmanager/templates/psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnable }}
 {{- if .Values.global.pspEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -20,4 +21,5 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/helm/alertmanager/templates/psp-clusterrolebinding.yaml
+++ b/helm/alertmanager/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.global.pspEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "alertmanager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "alertmanager.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-{{ template "alertmanager.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/alertmanager/templates/psp.yaml
+++ b/helm/alertmanager/templates/psp.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.global.pspEnable }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: {{ template "alertmanager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "alertmanager.fullname" . }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  # allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  #requiredDropCapabilities:
+  #  - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Permits the container to run with root privileges as well.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -175,14 +175,14 @@ global:
 ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
 ##
 storageSpec: {}
-  #  volumeClaimTemplate:
-  #    spec:
+#  volumeClaimTemplate:
+#    spec:
 #      storageClassName: gluster
-  #      accessModes: ["ReadWriteOnce"]
-  #      resources:
-  #        requests:
-  #          storage: 50Gi
-  #    selector: {}
+#      accessModes: ["ReadWriteOnce"]
+#      resources:
+#        requests:
+#          storage: 50Gi
+#    selector: {}
 
 # default rules are in templates/alertmanager.rules.yaml
 # prometheusRules: {}

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -165,22 +165,24 @@ service:
   ##
   type: ClusterIP
 
-## If true, create & use RBAC resources
+## If true, create & use RBAC resources resp. Pod Security Policies
 ##
-rbacEnable: true
+global:
+  rbacEnable: true
+  pspEnable: true
 
 ## Alertmanager StorageSpec for persistent data
 ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
 ##
 storageSpec: {}
-#  volumeClaimTemplate:
-#    spec:
+  #  volumeClaimTemplate:
+  #    spec:
 #      storageClassName: gluster
-#      accessModes: ["ReadWriteOnce"]
-#      resources:
-#        requests:
-#          storage: 50Gi
-#    selector: {}
+  #      accessModes: ["ReadWriteOnce"]
+  #      resources:
+  #        requests:
+  #          storage: 50Gi
+  #    selector: {}
 
 # default rules are in templates/alertmanager.rules.yaml
 # prometheusRules: {}

--- a/helm/exporter-kube-state/Chart.yaml
+++ b/helm/exporter-kube-state/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-state
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: Giancarlo Rubio
     email: gianrubio@gmail.com

--- a/helm/exporter-kube-state/templates/psp-clusterrole.yaml
+++ b/helm/exporter-kube-state/templates/psp-clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.global.rbacEnable }}
+{{- if .Values.global.pspEnable }}
+kind: ClusterRole
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+metadata:
+  labels:
+    app: {{ template "exporter-kube-state.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "exporter-kube-state.fullname" . }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "exporter-kube-state.fullname" . }}
+{{- end }}
+{{- end }}

--- a/helm/exporter-kube-state/templates/psp-clusterrolebinding.yaml
+++ b/helm/exporter-kube-state/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.global.rbacEnable }}
+{{- if .Values.global.pspEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "exporter-kube-state.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "exporter-kube-state.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-{{ template "exporter-kube-state.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "exporter-kube-state.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/helm/exporter-kube-state/templates/psp.yaml
+++ b/helm/exporter-kube-state/templates/psp.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.global.pspEnable }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: {{ template "exporter-kube-state.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "exporter-kube-state.fullname" . }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  # allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  #requiredDropCapabilities:
+  #  - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Permits the container to run with root privileges as well.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/exporter-kube-state/values.yaml
+++ b/helm/exporter-kube-state/values.yaml
@@ -3,10 +3,11 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 
-## If true, create & use RBAC resources
+## If true, create & use RBAC resources resp. Pod Security Policies
 ##
 global:
   rbacEnable: true
+  pspEnable: true
 
 kube_state_metrics:
   image:

--- a/helm/exporter-node/Chart.yaml
+++ b/helm/exporter-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes node exporter
 name: exporter-node
-version: 0.3.0
+version: 0.3.1
 maintainers:
   - name: Giancarlo Rubio
     email: gianrubio@gmail.com

--- a/helm/exporter-node/templates/daemonset.yaml
+++ b/helm/exporter-node/templates/daemonset.yaml
@@ -35,6 +35,9 @@ spec:
           volumeMounts:
 {{ toYaml .Values.container.volumeMounts | indent 10 }}
           {{- end }}
+    {{- if .Values.global.rbacEnable }}
+      serviceAccountName: {{ template "exporter-node.fullname" . }}
+    {{- end }}
     {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}

--- a/helm/exporter-node/templates/psp-clusterrole.yaml
+++ b/helm/exporter-node/templates/psp-clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.pspEnable }}
+kind: ClusterRole
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+metadata:
+  labels:
+    app: {{ template "exporter-node.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "exporter-node.fullname" . }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "exporter-node.fullname" . }}
+{{- end }}

--- a/helm/exporter-node/templates/psp-clusterrole.yaml
+++ b/helm/exporter-node/templates/psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnable }}
 {{- if .Values.global.pspEnable }}
 kind: ClusterRole
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
@@ -18,4 +19,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "exporter-node.fullname" . }}
+{{- end }}
 {{- end }}

--- a/helm/exporter-node/templates/psp-clusterrolebinding.yaml
+++ b/helm/exporter-node/templates/psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnable }}
 {{- if .Values.global.pspEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -21,4 +22,4 @@ subjects:
     name: {{ template "exporter-node.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
-
+{{- end }}

--- a/helm/exporter-node/templates/psp-clusterrolebinding.yaml
+++ b/helm/exporter-node/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.global.pspEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "exporter-node.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "exporter-node.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-{{ template "exporter-node.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "exporter-node.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/helm/exporter-node/templates/psp.yaml
+++ b/helm/exporter-node/templates/psp.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.global.pspEnable }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: {{ template "exporter-node.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "exporter-node.fullname" . }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  # allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  #requiredDropCapabilities:
+  #  - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+    - 'hostPath'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  runAsUser:
+    # Permits the container to run with root privileges as well.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/exporter-node/templates/serviceaccount.yaml
+++ b/helm/exporter-node/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.global.rbacEnable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "exporter-node.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "exporter-node.fullname" . }}
+{{- end }}

--- a/helm/exporter-node/values.yaml
+++ b/helm/exporter-node/values.yaml
@@ -46,6 +46,11 @@ tolerations:
 - effect: NoSchedule
   operator: Exists
 
+## If true, create & use RBAC resources resp. Pod Security Policies
+##
+global:
+  rbacEnable: true
+  pspEnable: true
 
 # default rules are in templates/node.rules.yaml
 # prometheusRules: {}

--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.27
+version: 0.0.28

--- a/helm/grafana/templates/grafana-deployment.yaml
+++ b/helm/grafana/templates/grafana-deployment.yaml
@@ -102,6 +102,9 @@ spec:
       nodeSelector:
     {{ toYaml .Values.nodeSelector | indent 4 }}
     {{- end }}
+    {{- if .Values.global.rbacEnable }}
+      serviceAccountName: {{ template "grafana.server.fullname" . }}
+    {{- end }}
     {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}

--- a/helm/grafana/templates/psp-clusterrole.yaml
+++ b/helm/grafana/templates/psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnable }}
 {{- if .Values.global.pspEnable }}
 kind: ClusterRole
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
@@ -18,4 +19,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "grafana.server.fullname" . }}
+{{- end }}
 {{- end }}

--- a/helm/grafana/templates/psp-clusterrole.yaml
+++ b/helm/grafana/templates/psp-clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.pspEnable }}
+kind: ClusterRole
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "grafana.server.fullname" . }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "grafana.server.fullname" . }}
+{{- end }}

--- a/helm/grafana/templates/psp-clusterrolebinding.yaml
+++ b/helm/grafana/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.global.pspEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "grafana.server.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-{{ template "grafana.server.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "grafana.server.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/helm/grafana/templates/psp-clusterrolebinding.yaml
+++ b/helm/grafana/templates/psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnable }}
 {{- if .Values.global.pspEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -21,4 +22,4 @@ subjects:
     name: {{ template "grafana.server.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
-
+{{- end }}

--- a/helm/grafana/templates/psp.yaml
+++ b/helm/grafana/templates/psp.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.global.pspEnable }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "grafana.server.fullname" . }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  # allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  #requiredDropCapabilities:
+  #  - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+    - 'hostPath'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  runAsUser:
+    # Permits the container to run with root privileges as well.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/grafana/templates/serviceaccount.yaml
+++ b/helm/grafana/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.global.rbacEnable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "grafana.server.fullname" . }}
+{{- end }}

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -18,6 +18,12 @@ selfServiceMonitor: true
 ##
 additionalServiceMonitorLabels: {}
 
+## If true, create & use RBAC resources resp. Pod Security Policies
+##
+global:
+  rbacEnable: true
+  pspEnable: true
+
 ## Pass extra environment variables to the Grafana container.
 ##
 # extraVars:

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.55
+version: 0.0.59

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -59,7 +59,7 @@ dependencies:
     condition: deployExporterNode
 
   - name: grafana
-    version: 0.0.27
+    version: 0.0.28
     #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -38,7 +38,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-state
-    version: 0.2.0
+    version: 0.2.1
     #e2e-repository: file://../exporter-kube-state
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
@@ -53,7 +53,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-node
-    version: 0.3.0
+    version: 0.3.1
     #e2e-repository: file://../exporter-node
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployExporterNode

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
   - name: alertmanager
-    version: 0.1.0
+    version: 0.1.1
     #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.31
+    version: 0.0.32
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -4,10 +4,11 @@ deployExporterNode: True
 # Grafana
 deployGrafana: True
 
-## If true, create & use RBAC resources
+## If true, create & use RBAC resources resp. Pod Security Policies
 ##
 global:
   rbacEnable: true
+  pspEnable: true
 
 # AlertManager
 deployAlertManager: True

--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.19
+version: 0.0.20

--- a/helm/prometheus-operator/templates/psp-clusterrole.yaml
+++ b/helm/prometheus-operator/templates/psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbacEnable }}
 {{- if .Values.pspEnable }}
 kind: ClusterRole
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
@@ -18,4 +19,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "prometheus-operator.fullname" . }}
+{{- end }}
 {{- end }}

--- a/helm/prometheus-operator/templates/psp-clusterrole.yaml
+++ b/helm/prometheus-operator/templates/psp-clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.pspEnable }}
+kind: ClusterRole
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+metadata:
+  labels:
+    app: {{ template "prometheus-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "prometheus-operator.fullname" . }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "prometheus-operator.fullname" . }}
+{{- end }}

--- a/helm/prometheus-operator/templates/psp-clusterrolebinding.yaml
+++ b/helm/prometheus-operator/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.pspEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "prometheus-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "prometheus-operator.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-{{ template "prometheus-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "prometheus-operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/helm/prometheus-operator/templates/psp-clusterrolebinding.yaml
+++ b/helm/prometheus-operator/templates/psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbacEnable }}
 {{- if .Values.pspEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -21,4 +22,4 @@ subjects:
     name: {{ template "prometheus-operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
-
+{{- end }}

--- a/helm/prometheus-operator/templates/psp.yaml
+++ b/helm/prometheus-operator/templates/psp.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.pspEnable }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: {{ template "prometheus-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "prometheus-operator.fullname" . }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  # allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  #requiredDropCapabilities:
+  #  - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Permits the container to run with root privileges as well.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/prometheus-operator/values.yaml
+++ b/helm/prometheus-operator/values.yaml
@@ -45,6 +45,9 @@ tolerations: {}
 ##
 rbacEnable: true
 
+## If true, create Pod Security Policy resources
+pspEnable: true
+
 ## Prometheus-operator resource limits & requests
 ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ##

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.31
+version: 0.0.32

--- a/helm/prometheus/templates/psp-clusterrole.yaml
+++ b/helm/prometheus/templates/psp-clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.pspEnable }}
+kind: ClusterRole
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+metadata:
+  labels:
+    app: {{ template "prometheus.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "prometheus.fullname" . }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "prometheus.fullname" . }}
+{{- end }}

--- a/helm/prometheus/templates/psp-clusterrole.yaml
+++ b/helm/prometheus/templates/psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnable }}
 {{- if .Values.global.pspEnable }}
 kind: ClusterRole
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
@@ -18,4 +19,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "prometheus.fullname" . }}
+{{- end }}
 {{- end }}

--- a/helm/prometheus/templates/psp-clusterrolebinding.yaml
+++ b/helm/prometheus/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.global.pspEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "prometheus.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: psp-{{ template "prometheus.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-{{ template "prometheus.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "prometheus.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/helm/prometheus/templates/psp-clusterrolebinding.yaml
+++ b/helm/prometheus/templates/psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnable }}
 {{- if .Values.global.pspEnable }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -21,4 +22,4 @@ subjects:
     name: {{ template "prometheus.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
-
+{{- end }}

--- a/helm/prometheus/templates/psp.yaml
+++ b/helm/prometheus/templates/psp.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.global.pspEnable }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: {{ template "prometheus.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "prometheus.fullname" . }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  # allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  #requiredDropCapabilities:
+  #  - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Permits the container to run with root privileges as well.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -92,10 +92,11 @@ tolerations: {}
 ##
 paused: false
 
-## If true, create & use RBAC resources
+## If true, create & use RBAC resources resp. Pod Security Policies
 ##
 global:
   rbacEnable: true
+  pspEnable: true
 
 ## serviceAccount to use by Prometheus
 ##


### PR DESCRIPTION
I added a default set of rather restrictive Pod Security Policies (PSP) to the charts.
The Alert Manager is created without a SA, so I had to add a PSP to the default SA.

This change is required once you enable the Admission Controller PodSecurityPolicy.
However, this is a draft to make it work. It should be definitely more configurable.