### PR TITLE
alertmanager: Pass pod ip to --cluster.listen-address

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -174,7 +174,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 
 	amArgs := []string{
 		fmt.Sprintf("--config.file=%s", alertmanagerConfFile),
-		fmt.Sprintf("--cluster.listen-address=:%d", 6783),
+		fmt.Sprintf("--cluster.listen-address=$(POD_IP):%d", 6783),
 		fmt.Sprintf("--storage.path=%s", alertmanagerStorageDir),
 	}
 
@@ -373,6 +373,17 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 						LivenessProbe:  livenessProbe,
 						ReadinessProbe: readinessProbe,
 						Resources:      a.Spec.Resources,
+						Env: []v1.EnvVar{
+							{
+								// Necessary for '--cluster.listen-address' flag
+								Name: "POD_IP",
+								ValueFrom: &v1.EnvVarSource{
+									FieldRef: &v1.ObjectFieldSelector{
+										FieldPath: "status.podIP",
+									},
+								},
+							},
+						},
 					}, {
 						Name:  "config-reloader",
 						Image: config.ConfigReloaderImage,


### PR DESCRIPTION
Alertmanager needs a routable IP address via the
`--cluster.listen-address` in order for other nodes in an Alertmanager
cluster to be able to reach it. This patch sets the
`--cluster.listen-address` to the k8s pod ip + `6783` port.

Fixes https://github.com/prometheus/alertmanager/issues/1312

//CC @gmauleon