### PR TITLE
alertmanager: Test if Alertmanagers gossip silences

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -22,11 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1beta2"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	testFramework "github.com/coreos/prometheus-operator/test/framework"
 )
@@ -132,7 +134,7 @@ func TestMeshInitialization(t *testing.T) {
 
 	// Starting with Alertmanager v0.15.0 hashicorp/memberlist is used for HA.
 	// Make sure both memberlist as well as mesh (< 0.15.0) work
-	amVersions := []string{"v0.14.0", "v0.15.0-rc.0"}
+	amVersions := []string{"v0.14.0", "v0.15.0-rc.1"}
 
 	for _, v := range amVersions {
 		version := v
@@ -166,6 +168,55 @@ func TestMeshInitialization(t *testing.T) {
 				}
 			},
 		)
+	}
+}
+
+func TestAlertmanagerClusterGossipSilences(t *testing.T) {
+	t.Parallel()
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
+	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+
+	amClusterSize := 3
+	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
+	alertmanager.Spec.Version = "v0.15.0-rc.1"
+
+	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < amClusterSize; i++ {
+		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
+		if err := framework.WaitForAlertmanagerInitializedMesh(ns, name, amClusterSize); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	silId, err := framework.CreateSilence(ns, "alertmanager-test-0")
+	if err != nil {
+		t.Fatalf("failed to create silence: %v", err)
+	}
+
+	for i := 0; i < amClusterSize; i++ {
+		err = wait.Poll(time.Second, framework.DefaultTimeout, func() (bool, error) {
+			silences, err := framework.GetSilences(ns, "alertmanager-"+alertmanager.Name+"-"+strconv.Itoa(i))
+			if err != nil {
+				return false, err
+			}
+
+			if len(silences) != 1 {
+				return false, nil
+			}
+
+			if silences[0].ID != silId {
+				return false, errors.Errorf("expected silence id on alertmanager %v to match id of created silence '%v' but got %v", i, silId, silences[0].ID)
+			}
+			return true, nil
+		})
+		if err != nil {
+			t.Fatalf("could not retrieve created silence on alertmanager %v: %v", i, err)
+		}
 	}
 }
 

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -212,8 +212,8 @@ func (f *Framework) WaitForAlertmanagerInitializedMesh(ns, name string, amountPe
 	})
 }
 
-func (f *Framework) GetAlertmanagerConfig(ns, n string) (alertmanagerStatus, error) {
-	var amStatus alertmanagerStatus
+func (f *Framework) GetAlertmanagerConfig(ns, n string) (amAPIStatusResp, error) {
+	var amStatus amAPIStatusResp
 	request := ProxyGetPod(f.KubeClient, ns, n, "9093", "/api/v1/status")
 	resp, err := request.DoRaw()
 	if err != nil {
@@ -225,6 +225,56 @@ func (f *Framework) GetAlertmanagerConfig(ns, n string) (alertmanagerStatus, err
 	}
 
 	return amStatus, nil
+}
+
+func (f *Framework) CreateSilence(ns, n string) (string, error) {
+	var createSilenceResponse amAPICreateSilResp
+
+	request := ProxyPostPod(
+		f.KubeClient, ns, n,
+		"9093", "/api/v1/silences",
+		"{\"id\":\"\",\"createdBy\":\"Max Mustermann\",\"comment\":\"1234\",\"startsAt\":\"2030-04-09T09:16:15.114Z\",\"endsAt\":\"2031-04-09T11:16:15.114Z\",\"matchers\":[{\"name\":\"test\",\"value\":\"123\",\"isRegex\":false}]}",
+	)
+	resp, err := request.DoRaw()
+	if err != nil {
+		return "", err
+	}
+
+	if err := json.Unmarshal(resp, &createSilenceResponse); err != nil {
+		return "", err
+	}
+
+	if createSilenceResponse.Status != "success" {
+		return "", errors.Errorf(
+			"expected Alertmanager to return 'success', but got '%v' instead",
+			createSilenceResponse.Status,
+		)
+	}
+
+	return createSilenceResponse.Data.SilenceID, nil
+}
+
+func (f *Framework) GetSilences(ns, n string) ([]amAPISil, error) {
+	var getSilencesResponse amAPIGetSilResp
+
+	request := ProxyGetPod(f.KubeClient, ns, n, "9093", "/api/v1/silences")
+	resp, err := request.DoRaw()
+	if err != nil {
+		return getSilencesResponse.Data, err
+	}
+
+	if err := json.Unmarshal(resp, &getSilencesResponse); err != nil {
+		return getSilencesResponse.Data, err
+	}
+
+	if getSilencesResponse.Status != "success" {
+		return getSilencesResponse.Data, errors.Errorf(
+			"expected Alertmanager to return 'success', but got '%v' instead",
+			getSilencesResponse.Status,
+		)
+	}
+
+	return getSilencesResponse.Data, nil
 }
 
 func (f *Framework) WaitForSpecificAlertmanagerConfig(ns, amName string, expectedConfig string) error {
@@ -244,18 +294,37 @@ func (f *Framework) WaitForSpecificAlertmanagerConfig(ns, amName string, expecte
 	})
 }
 
-type alertmanagerStatus struct {
-	Data alertmanagerStatusData `json:"data"`
+type amAPICreateSilResp struct {
+	Status string             `json:"status"`
+	Data   amAPICreateSilData `json:"data"`
 }
 
-type alertmanagerStatusData struct {
+type amAPICreateSilData struct {
+	SilenceID string `json:"silenceId"`
+}
+
+type amAPIGetSilResp struct {
+	Status string     `json:"status"`
+	Data   []amAPISil `json:"data"`
+}
+
+type amAPISil struct {
+	ID        string `json:"id"`
+	CreatedBy string `json:"createdBy"`
+}
+
+type amAPIStatusResp struct {
+	Data amAPIStatusData `json:"data"`
+}
+
+type amAPIStatusData struct {
 	ClusterStatus *clusterStatus `json:"clusterStatus,omitempty"`
 	MeshStatus    *clusterStatus `json:"meshStatus,omitempty"`
 	ConfigYAML    string         `json:"configYAML"`
 }
 
 // Starting from AM v0.15.0 'MeshStatus' is called 'ClusterStatus'
-func (s *alertmanagerStatusData) getAmountPeers() int {
+func (s *amAPIStatusData) getAmountPeers() int {
 	if s.MeshStatus != nil {
 		return len(s.MeshStatus.Peers)
 	} else {

--- a/test/framework/helpers.go
+++ b/test/framework/helpers.go
@@ -157,6 +157,28 @@ func (f *Framework) Poll(timeout, pollInterval time.Duration, pollFunc func() (b
 	}
 }
 
-func ProxyGetPod(kubeClient kubernetes.Interface, namespace string, podName string, port string, path string) *rest.Request {
-	return kubeClient.CoreV1().RESTClient().Get().Prefix("proxy").Namespace(namespace).Resource("pods").Name(podName + ":" + port).Suffix(path)
+func ProxyGetPod(kubeClient kubernetes.Interface, namespace, podName, port, path string) *rest.Request {
+	return kubeClient.
+		CoreV1().
+		RESTClient().
+		Get().
+		Prefix("proxy").
+		Namespace(namespace).
+		Resource("pods").
+		Name(podName + ":" + port).
+		Suffix(path)
+}
+
+func ProxyPostPod(kubeClient kubernetes.Interface, namespace, podName, port, path, body string) *rest.Request {
+	return kubeClient.
+		CoreV1().
+		RESTClient().
+		Post().
+		Prefix("proxy").
+		Namespace(namespace).
+		Resource("pods").
+		Name(podName+":"+port).
+		Suffix(path).
+		Body([]byte(body)).
+		SetHeader("Content-Type", "application/json")
 }


### PR DESCRIPTION
This patch adds an e2e test. It creates a silence on alertmanager 0, and
checks if that silence is gossiped to alertmanager 1 and 2.

This should prevent regressions like https://github.com/prometheus/alertmanager/issues/1312