### PR TITLE
Fixed CPU accounting in recording rules

### DIFF
--- a/contrib/kube-prometheus/assets/prometheus/rules/node.rules.yaml
+++ b/contrib/kube-prometheus/assets/prometheus/rules/node.rules.yaml
@@ -2,7 +2,7 @@ groups:
 - name: node.rules
   rules:
   - record: instance:node_cpu:rate:sum
-    expr: sum(rate(node_cpu{mode!="idle",mode!="iowait",mode!~"^(?:guest.*)$"}[3m]))
+    expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[3m]))
       BY (instance)
   - record: instance:node_filesystem_usage:sum
     expr: sum((node_filesystem_size{mountpoint="/"} - node_filesystem_free{mountpoint="/"}))
@@ -12,10 +12,10 @@ groups:
   - record: instance:node_network_transmit_bytes:rate:sum
     expr: sum(rate(node_network_transmit_bytes[3m])) BY (instance)
   - record: instance:node_cpu:ratio
-    expr: sum(rate(node_cpu{mode!="idle"}[5m])) WITHOUT (cpu, mode) / ON(instance)
+    expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[5m])) WITHOUT (cpu, mode) / ON(instance)
       GROUP_LEFT() count(sum(node_cpu) BY (instance, cpu)) BY (instance)
   - record: cluster:node_cpu:sum_rate5m
-    expr: sum(rate(node_cpu{mode!="idle"}[5m]))
+    expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[5m]))
   - record: cluster:node_cpu:ratio
     expr: cluster:node_cpu:rate5m / count(sum(node_cpu) BY (instance, cpu))
   - alert: NodeExporterDown

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -498,7 +498,7 @@ data:
     - name: node.rules
       rules:
       - record: instance:node_cpu:rate:sum
-        expr: sum(rate(node_cpu{mode!="idle",mode!="iowait",mode!~"^(?:guest.*)$"}[3m]))
+        expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[3m]))
           BY (instance)
       - record: instance:node_filesystem_usage:sum
         expr: sum((node_filesystem_size{mountpoint="/"} - node_filesystem_free{mountpoint="/"}))
@@ -508,10 +508,10 @@ data:
       - record: instance:node_network_transmit_bytes:rate:sum
         expr: sum(rate(node_network_transmit_bytes[3m])) BY (instance)
       - record: instance:node_cpu:ratio
-        expr: sum(rate(node_cpu{mode!="idle"}[5m])) WITHOUT (cpu, mode) / ON(instance)
+        expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[5m])) WITHOUT (cpu, mode) / ON(instance)
           GROUP_LEFT() count(sum(node_cpu) BY (instance, cpu)) BY (instance)
       - record: cluster:node_cpu:sum_rate5m
-        expr: sum(rate(node_cpu{mode!="idle"}[5m]))
+        expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[5m]))
       - record: cluster:node_cpu:ratio
         expr: cluster:node_cpu:rate5m / count(sum(node_cpu) BY (instance, cpu))
       - alert: NodeExporterDown

--- a/helm/exporter-node/Chart.yaml
+++ b/helm/exporter-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-node
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: Michael Goodness
     email: mgoodness@gmail.com

--- a/helm/exporter-node/templates/node.rules.yaml
+++ b/helm/exporter-node/templates/node.rules.yaml
@@ -3,7 +3,7 @@ groups:
 - name: node.rules
   rules:
   - record: instance:node_cpu:rate:sum
-    expr: sum(rate(node_cpu{mode!="idle",mode!="iowait",mode!~"^(?:guest.*)$"}[3m]))
+    expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[3m]))
       BY (instance)
   - record: instance:node_filesystem_usage:sum
     expr: sum((node_filesystem_size{mountpoint="/"} - node_filesystem_free{mountpoint="/"}))
@@ -13,10 +13,10 @@ groups:
   - record: instance:node_network_transmit_bytes:rate:sum
     expr: sum(rate(node_network_transmit_bytes[3m])) BY (instance)
   - record: instance:node_cpu:ratio
-    expr: sum(rate(node_cpu{mode!="idle"}[5m])) WITHOUT (cpu, mode) / ON(instance)
+    expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[5m])) WITHOUT (cpu, mode) / ON(instance)
       GROUP_LEFT() count(sum(node_cpu) BY (instance, cpu)) BY (instance)
   - record: cluster:node_cpu:sum_rate5m
-    expr: sum(rate(node_cpu{mode!="idle"}[5m]))
+    expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[5m]))
   - record: cluster:node_cpu:ratio
     expr: cluster:node_cpu:rate5m / count(sum(node_cpu) BY (instance, cpu))
   - alert: NodeExporterDown

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -53,7 +53,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-node
-    version: 0.2.0
+    version: 0.2.1
     #e2e-repository: file://../exporter-node
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployExporterNode


### PR DESCRIPTION
Currently, node recording rules features incorrect idle CPU accounting. This change aims to fix that.

Also removed negative regex match, since guest CPU time (albeit, rarely present on Kubernetes nodes) contributes to the overall non-idle CPU time.