### PR TITLE
crd: Enrich Prometheus operator CRD registration error handling

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -554,5 +554,8 @@ func (c *Operator) createCRDs() error {
 	}
 
 	// We have to wait for the CRDs to be ready. Otherwise the initial watch may fail.
-	return k8sutil.WaitForCRDReady(c.mclient.MonitoringV1().Alertmanagers(c.config.Namespace).List)
+	return errors.Wrap(
+		k8sutil.WaitForCRDReady(c.mclient.MonitoringV1().Alertmanagers(c.config.Namespace).List),
+		"waiting for Alertmanager crd failed",
+	)
 }

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -41,7 +41,7 @@ var CustomResourceDefinitionTypeMeta metav1.TypeMeta = metav1.TypeMeta{
 	APIVersion: "apiextensions.k8s.io/v1beta1",
 }
 
-// WaitForCRDReady waits for a third party resource to be available for use.
+// WaitForCRDReady waits for a custom resource definition to be available for use.
 func WaitForCRDReady(listFunc func(opts metav1.ListOptions) (runtime.Object, error)) error {
 	err := wait.Poll(3*time.Second, 10*time.Minute, func() (bool, error) {
 		_, err := listFunc(metav1.ListOptions{})
@@ -51,7 +51,7 @@ func WaitForCRDReady(listFunc func(opts metav1.ListOptions) (runtime.Object, err
 					return false, nil
 				}
 			}
-			return false, err
+			return false, errors.Wrap(err, "failed to list CRD")
 		}
 		return true, nil
 	})


### PR DESCRIPTION
If a user:
1. deploys the Prometheus operator without CRD validation
2. creates an invalid CRD instance (e.g. Servicemonitor)
3. restarts the Prometheus operator
it will crash-loop with a difficult to understand error message, failing
to parse the invalid CRD instance.

This patch improves the error feedback to the user, to identify the
invalid CRD more easily. The Prometheus operator will keep
crash-looping to enforce a valid CRD state on startup.

Fixes https://github.com/coreos/prometheus-operator/issues/1202