### PR TITLE
Adding Secrets for Prometheus Object, updating AlertManager wording

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.45
+version: 0.0.46

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -89,9 +89,9 @@ alertmanager:
     # requests:
     #   memory: 400Mi
 
-  ## List of Secrets in the same namespace as the Prometheus
-  ## object, which shall be mounted into the Prometheus Pods.
-  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  ## List of Secrets in the same namespace as the AlertManager
+  ## object, which shall be mounted into the AlertManager Pods.
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#alertmanagerspec
   ##
   secrets: []
 
@@ -214,6 +214,12 @@ prometheus:
   resources: {}
     # requests:
     #   memory: 400Mi
+
+  ## List of Secrets in the same namespace as the Prometheus
+  ## object, which shall be mounted into the Prometheus Pods.
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  ##
+  secrets: []
 
   ## How long to retain metrics
   ##


### PR DESCRIPTION
The kube-prometheus chart didn't have default configuration exposed for passing down the values to the Prometheus chart.