### PR TITLE
grafana: count only running pods in utilization calculation

### DIFF
--- a/helm/grafana/dashboards/kubernetes-capacity-planning-dashboard.json
+++ b/helm/grafana/dashboards/kubernetes-capacity-planning-dashboard.json
@@ -808,7 +808,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(kube_pod_info)",
+                                "expr": "sum(kube_pod_status_phase{phase='Running'})",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "Current number of Pods",
@@ -904,7 +904,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "100 - (sum(kube_node_status_capacity_pods) - sum(kube_pod_info)) / sum(kube_node_status_capacity_pods) * 100",
+                                "expr": "100 - (sum(kube_node_status_capacity_pods) - sum(kube_pod_status_phase{phase='Running'})) / sum(kube_node_status_capacity_pods) * 100",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "",

--- a/helm/grafana/dashboards/kubernetes-cluster-status-dashboard.json
+++ b/helm/grafana/dashboards/kubernetes-cluster-status-dashboard.json
@@ -740,7 +740,7 @@
                         },
                         "targets": [
                             {
-                                "expr": "100 - (sum(kube_node_status_capacity_pods) - sum(kube_pod_info)) / sum(kube_node_status_capacity_pods) * 100",
+                                "expr": "100 - (sum(kube_node_status_capacity_pods) - sum(kube_pod_status_phase{phase='Running'})) / sum(kube_node_status_capacity_pods) * 100",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "refId": "A",


### PR DESCRIPTION
Kubernetes clusters with Jobs may have a significant number
of pods in 'Completed' states.  Only "Running" state should
count against capacity.