### PR TITLE
[helm/alertmanager] Choose custom prometheus label value

### DIFF
--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.14
+version: 0.0.15

--- a/helm/alertmanager/templates/configmap.yaml
+++ b/helm/alertmanager/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app: "alertmanager"
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
-    prometheus: {{ .Release.Name }}
+    prometheus: {{ .Values.prometheusLabelValue | default .Release.Name | quote }}
     release: {{ .Release.Name }}
     role: alert-rules
     {{- if .Values.additionalRulesConfigMapLabels }}

--- a/helm/alertmanager/templates/servicemonitor.yaml
+++ b/helm/alertmanager/templates/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     component: alertmanager
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-    prometheus: {{ .Release.Name }}
+    prometheus: {{ .Values.prometheusLabelValue | default .Release.Name | quote }}
     {{- if .Values.additionalServiceMonitorLabels }}
 {{ toYaml .Values.additionalServiceMonitorLabels | indent 4 }}
     {{- end }}

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -63,6 +63,10 @@ image:
 ##
 labels: {}
 
+## "prometheus" label value for ServiceMonitor and rules ConfigMap
+## Release.Name by default
+prometheusLabelValue: ""
+
 ingress:
   ## If true, Alertmanager Ingress will be created
   ##

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.49
+version: 0.0.50

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: alertmanager
-    version: 0.0.14
+    version: 0.0.15
     #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployAlertManager


### PR DESCRIPTION
The value of the prometheus label is fixed to `Release.Name`, this means that alertmanager and prometheus should be deployed on the same release. In cases where this is not desirable or possible is useful to be able to specify a custom value for that label.

This can be more flexible allowing any generic set of labels but I didn't want to complicate the PR for now and preferred to maintain compatibility.