### PR TITLE
prometheus-operator RBAC permission

### DIFF
--- a/contrib/kube-prometheus/jsonnet/prometheus-operator/prometheus-operator-cluster-role.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/prometheus-operator/prometheus-operator-cluster-role.libsonnet
@@ -53,6 +53,7 @@ local routingRule = policyRule.new() +
   policyRule.withApiGroups([""]) +
   policyRule.withResources([
     "services",
+    "endpoints",
   ]) +
   policyRule.withVerbs(["get", "create", "update"]);
 

--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -66,3 +66,11 @@ rules:
   - namespaces
   verbs:
   - list
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - create
+  - update

--- a/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -49,6 +49,7 @@ rules:
   - ""
   resources:
   - services
+  - endpoints
   verbs:
   - get
   - create
@@ -66,11 +67,3 @@ rules:
   - namespaces
   verbs:
   - list
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - create
-  - update


### PR DESCRIPTION
Fixes the following errors i observed when setting up kube-operator

```
ts=2018-04-18T08:15:52.913335939Z caller=operator.go:353 component=prometheusoperator msg="syncing nodes into Endpoints object failed" err="synchronizing kubelet endpoints object failed: retrieving existing kubelet endpoints object failed: endpoints \"kubelet\" is forbidden: User \"system:serviceaccount:monitoring:prometheus-operator\" cannot get endpoints in the namespace \"kube-system\""
ts=2018-04-18T08:42:52.915294813Z caller=operator.go:353 component=prometheusoperator msg="syncing nodes into Endpoints object failed" err="synchronizing kubelet endpoints object failed: creating kubelet endpoints object failed: endpoints is forbidden: User \"system:serviceaccount:monitoring:prometheus-operator\" cannot create endpoints in the namespace \"kube-system\""
ts=2018-04-18T09:09:52.908066042Z caller=operator.go:353 component=prometheusoperator msg="syncing nodes into Endpoints object failed" err="synchronizing kubelet endpoints object failed: updating kubelet endpoints object failed: endpoints \"kubelet\" is forbidden: User \"system:serviceaccount:monitoring:prometheus-operator\" cannot update endpoints in the namespace \"kube-system\""
```

Kubelet metrics wasn't working until i fixed the rbac permissions