### PR TITLE
[helm/prometheus] Custom ServiceAccountName when rbac disabled

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.51
+version: 0.0.52

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.52
+version: 0.0.53

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.27
+    version: 0.0.28
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.27
+version: 0.0.28

--- a/helm/prometheus/templates/_helpers.tpl
+++ b/helm/prometheus/templates/_helpers.tpl
@@ -34,3 +34,14 @@ Return the appropriate apiVersion value to use for the prometheus-operator manag
 {{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "prometheus.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -53,9 +53,7 @@ spec:
 {{ toYaml .Values.secrets | indent 4 }}
 {{- end }}
 {{- if .Values.global.rbacEnable }}
-  serviceAccountName: {{ template "prometheus.fullname" . }}
-{{- else if .Values.serviceAccountName }}
-  serviceAccountName: {{ .Values.serviceAccountName }}
+  serviceAccountName: {{ template "prometheus.serviceAccountName" .}}
 {{- end }}
 {{ if and .Values.config.specifiedInValues .Values.config.value }}
 {{- else if .Values.serviceMonitorsSelector }}

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -54,6 +54,8 @@ spec:
 {{- end }}
 {{- if .Values.global.rbacEnable }}
   serviceAccountName: {{ template "prometheus.fullname" . }}
+{{- else if .Values.serviceAccountName }}
+  serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
 {{ if and .Values.config.specifiedInValues .Values.config.value }}
 {{- else if .Values.serviceMonitorsSelector }}

--- a/helm/prometheus/templates/serviceaccount.yaml
+++ b/helm/prometheus/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbacEnable }}
+{{- if and .Values.global.rbacEnable .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,5 +7,5 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "prometheus.fullname" . }}
+  name: {{ template "prometheus.serviceAccountName" .}}
 {{- end }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -97,10 +97,11 @@ paused: false
 global:
   rbacEnable: true
 
-## serviceAccountName will be used only when rbacEnable is false.
-## Use it if rbac objects are managed outside this Chart. 
+## serviceAccount to use by Prometheus
 ##
-serviceAccountName: ""
+serviceAccount:
+  create: true
+  name: ""
 
 ## Number of Prometheus replicas desired
 ##

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -97,6 +97,11 @@ paused: false
 global:
   rbacEnable: true
 
+## serviceAccountName will be used only when rbacEnable is false.
+## Use it if rbac objects are managed outside this Chart. 
+##
+serviceAccountName: ""
+
 ## Number of Prometheus replicas desired
 ##
 replicaCount: 1


### PR DESCRIPTION
On the cases where `global.rbacEnable: false` the `serviceAccountName` attribute of the Prometheus is not defined so is not possible to define a ServiceAccount outside the Chart and let the Prometheus object use it.

This change allows the case where custom rbac objects like ClusterRole, ServiceAccount and bindings are managed outside the Chart (so `global.rbacEnable: false`) and we want that the Prometheus objects uses that externally defined account.

## Specific use case
When installing prometheus on an specific namespace I want to define a custom role that gives access only to resources inside the namespace and with that a custom RoleBinding, so having full control of the ServiceAccount, makes sense to use that account on the Prometheus Chart instead of relying on the preconfigured account.