### PR TITLE
quay: Push docker images to quay for all git branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 jobs:
   include:
   # Check generated contents are up to date and code is formatted.
-  - stage: Sanity check and unit tests 
+  - stage: Sanity check and unit tests
     script: ./scripts/check-make-generate.sh
   # Build Prometheus config reloader
   - script: cd contrib/prometheus-config-reloader && make build
@@ -28,3 +28,5 @@ jobs:
       script: make helm-sync-s3
       on:
         branch: master
+  - stage: push-docker-image
+    script: ./scripts/travis-push-docker-image.sh

--- a/scripts/travis-push-docker-image.sh
+++ b/scripts/travis-push-docker-image.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+function defer {
+	docker logout quay.io
+}
+trap defer EXIT
+
+if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
+	exit 0
+fi
+
+export REPO=quay.io/coreos/prometheus-operator
+# Push to Quay '-dev' repo if not a git tag or master branch build
+if [[ "${TRAVIS_TAG}" == "" ]] && [[ "${TRAVIS_BRANCH}" != master ]]; then
+	export REPO="${REPO}-dev"
+fi
+
+make crossbuild
+
+# For both git tags and git branches 'TRAVIS_BRANCH' contains the name.
+export TAG="${TRAVIS_BRANCH}"
+make container
+echo "${QUAY_PASSWORD}" | docker login -u "${QUAY_USERNAME}" --password-stdin quay.io
+docker push "${REPO}:${TRAVIS_BRANCH}"


### PR DESCRIPTION
Push all git tags and `master` branch builds to `quay.io/coreos/prometheus-operator`, and all other git branches to `quay.io/coreos/prometheus-operator-dev`.