### PR TITLE
Adding master toleration to node-exporter daemonset in kube-prometheus

### DIFF
--- a/contrib/kube-prometheus/manifests/node-exporter/node-exporter-daemonset.yaml
+++ b/contrib/kube-prometheus/manifests/node-exporter/node-exporter-daemonset.yaml
@@ -54,6 +54,9 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: node-exporter
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
       volumes:
       - hostPath:
           path: /proc

--- a/contrib/kube-prometheus/manifests/node-exporter/node-exporter-daemonset.yaml
+++ b/contrib/kube-prometheus/manifests/node-exporter/node-exporter-daemonset.yaml
@@ -54,9 +54,6 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: node-exporter
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
       volumes:
       - hostPath:
           path: /proc


### PR DESCRIPTION
Fixes #1241 .  Adding standard master toleration for node-exporter.