### PR TITLE
service-monitor: Revert static targets configuration in service monitors

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -152,7 +152,7 @@ Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 | honorLabels | HonorLabels chooses the metric's labels on collisions with target labels. | bool | false |
 | basicAuth | BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints | *[BasicAuth](#basicauth) | false |
 | metricRelabelings | MetricRelabelConfigs to apply to samples before ingestion. | []*[RelabelConfig](#relabelconfig) | false |
-| staticTargets | StaticTargets with targets to scrape. This is an experimental feature, it may change in any upcoming release in a breaking way. | []string | false |
+| staticTargets | StaticTargets with targets to scrape. | []string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -152,7 +152,6 @@ Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 | honorLabels | HonorLabels chooses the metric's labels on collisions with target labels. | bool | false |
 | basicAuth | BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints | *[BasicAuth](#basicauth) | false |
 | metricRelabelings | MetricRelabelConfigs to apply to samples before ingestion. | []*[RelabelConfig](#relabelconfig) | false |
-| staticTargets | StaticTargets with targets to scrape. | []string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/example/prometheus-operator-crd/servicemonitor.crd.yaml
+++ b/example/prometheus-operator-crd/servicemonitor.crd.yaml
@@ -141,9 +141,7 @@ spec:
                     description: Timeout after which the scrape is ended
                     type: string
                   staticTargets:
-                    description: StaticTargets with targets to scrape. This is an
-                      experimental feature, it may change in any upcoming release
-                      in a breaking way.
+                    description: StaticTargets with targets to scrape.
                     items:
                       type: string
                     type: array

--- a/example/prometheus-operator-crd/servicemonitor.crd.yaml
+++ b/example/prometheus-operator-crd/servicemonitor.crd.yaml
@@ -140,11 +140,6 @@ spec:
                   scrapeTimeout:
                     description: Timeout after which the scrape is ended
                     type: string
-                  staticTargets:
-                    description: StaticTargets with targets to scrape.
-                    items:
-                      type: string
-                    type: array
                   targetPort: {}
                   tlsConfig:
                     description: TLSConfig specifies TLS configuration parameters.

--- a/pkg/client/monitoring/v1/openapi_generated.go
+++ b/pkg/client/monitoring/v1/openapi_generated.go
@@ -541,7 +541,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"staticTargets": {
 							SchemaProps: spec.SchemaProps{
-								Description: "StaticTargets with targets to scrape. This is an experimental feature, it may change in any upcoming release in a breaking way.",
+								Description: "StaticTargets with targets to scrape.",
 								Type:        []string{"array"},
 								Items: &spec.SchemaOrArray{
 									Schema: &spec.Schema{

--- a/pkg/client/monitoring/v1/openapi_generated.go
+++ b/pkg/client/monitoring/v1/openapi_generated.go
@@ -539,20 +539,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
-						"staticTargets": {
-							SchemaProps: spec.SchemaProps{
-								Description: "StaticTargets with targets to scrape.",
-								Type:        []string{"array"},
-								Items: &spec.SchemaOrArray{
-									Schema: &spec.Schema{
-										SchemaProps: spec.SchemaProps{
-											Type:   []string{"string"},
-											Format: "",
-										},
-									},
-								},
-							},
-						},
 					},
 				},
 			},

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -347,7 +347,7 @@ type Endpoint struct {
 	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
 	// MetricRelabelConfigs to apply to samples before ingestion.
 	MetricRelabelConfigs []*RelabelConfig `json:"metricRelabelings,omitempty"`
-	// StaticTargets with targets to scrape. This is an experimental feature, it may change in any upcoming release in a breaking way.
+	// StaticTargets with targets to scrape.
 	StaticTargets []string `json:"staticTargets,omitempty"`
 }
 

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -347,8 +347,6 @@ type Endpoint struct {
 	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
 	// MetricRelabelConfigs to apply to samples before ingestion.
 	MetricRelabelConfigs []*RelabelConfig `json:"metricRelabelings,omitempty"`
-	// StaticTargets with targets to scrape.
-	StaticTargets []string `json:"staticTargets,omitempty"`
 }
 
 // BasicAuth allow an endpoint to authenticate over basic authentication

--- a/pkg/client/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/client/monitoring/v1/zz_generated.deepcopy.go
@@ -333,11 +333,6 @@ func (in *Endpoint) DeepCopyInto(out *Endpoint) {
 			}
 		}
 	}
-	if in.StaticTargets != nil {
-		in, out := &in.StaticTargets, &out.StaticTargets
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -244,16 +244,6 @@ func generateServiceMonitorConfig(version semver.Version, m *v1.ServiceMonitor, 
 
 	cfg = addTLStoYaml(cfg, ep.TLSConfig)
 
-	if ep.StaticTargets != nil {
-		cfg = append(cfg, yaml.MapItem{
-			Key: "static_configs",
-			Value: yaml.MapItem{
-				Key:   "targets",
-				Value: ep.StaticTargets,
-			},
-		})
-	}
-
 	if ep.BearerTokenFile != "" {
 		cfg = append(cfg, yaml.MapItem{Key: "bearer_token_file", Value: ep.BearerTokenFile})
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -247,8 +247,9 @@ func generateServiceMonitorConfig(version semver.Version, m *v1.ServiceMonitor, 
 	if ep.StaticTargets != nil {
 		cfg = append(cfg, yaml.MapItem{
 			Key: "static_configs",
-			Value: []yaml.MapSlice{
-				yaml.MapSlice{{Key: "targets", Value: ep.StaticTargets}},
+			Value: yaml.MapItem{
+				Key:   "targets",
+				Value: ep.StaticTargets,
 			},
 		})
 	}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -18,13 +18,13 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/blang/semver"
-	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 )
 
 func TestConfigGeneration(t *testing.T) {
@@ -147,80 +147,6 @@ alerting:
 `
 
 	result := string(cfg)
-
-	if expected != result {
-		t.Fatalf("Unexpected result.\n\nGot:\n\n%s\n\nExpected:\n\n%s\n\n", result, expected)
-	}
-}
-
-func TestStaticTargets(t *testing.T) {
-	ep := monitoringv1.Endpoint{
-		Port:        "web",
-		Interval:    "30s",
-		Path:        "/federate",
-		HonorLabels: true,
-		Params:      map[string][]string{"metrics[]": {"{__name__=~\"job:.*\"}"}},
-		StaticTargets: []string{
-			"source-prometheus-1:9090",
-			"source-prometheus-2:9090",
-			"source-prometheus-3:9090",
-		},
-	}
-
-	sm := &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "statictargetsmonitor",
-			Namespace: "default",
-			Labels: map[string]string{
-				"group": "group1",
-			},
-		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{ep},
-		},
-	}
-
-	smConfig := generateServiceMonitorConfig(semver.Version{}, sm, ep, 0, nil)
-	s, err := yaml.Marshal(smConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := `job_name: default/statictargetsmonitor/0
-honor_labels: true
-scrape_interval: 30s
-metrics_path: /federate
-params:
-  metrics[]:
-  - '{__name__=~"job:.*"}'
-static_configs:
-- targets:
-  - source-prometheus-1:9090
-  - source-prometheus-2:9090
-  - source-prometheus-3:9090
-relabel_configs:
-- action: keep
-  source_labels:
-  - __meta_kubernetes_endpoint_port_name
-  regex: web
-- source_labels:
-  - __meta_kubernetes_namespace
-  target_label: namespace
-- source_labels:
-  - __meta_kubernetes_pod_name
-  target_label: pod
-- source_labels:
-  - __meta_kubernetes_service_name
-  target_label: service
-- source_labels:
-  - __meta_kubernetes_service_name
-  target_label: job
-  replacement: ${1}
-- target_label: endpoint
-  replacement: web
-`
-
-	result := string(s)
 
 	if expected != result {
 		t.Fatalf("Unexpected result.\n\nGot:\n\n%s\n\nExpected:\n\n%s\n\n", result, expected)

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -319,30 +319,5 @@ func makeServiceMonitors() map[string]*monitoringv1.ServiceMonitor {
 		},
 	}
 
-	res["servicemonitor5"] = &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testservicemonitor5",
-			Namespace: "default",
-			Labels: map[string]string{
-				"group": "group4",
-			},
-		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{
-				{
-					Port:     "web",
-					Interval: "30s",
-					Path:     "/federate",
-					Params:   map[string][]string{"metrics[]": {"{__name__=~\"job:.*\"}"}},
-					StaticTargets: []string{
-						"source-prometheus-1:9090",
-						"source-prometheus-2:9090",
-						"source-prometheus-3:9090",
-					},
-				},
-			},
-		},
-	}
-
 	return res
 }


### PR DESCRIPTION
With the _additional-scrape-config_ feature (https://github.com/coreos/prometheus-operator/pull/1246) via Kubernetes secrets, the _static-configs_ feature in Service Monitors is redundant.

I suggest reverting the latter one, as _additional-scrape-config_ enables users to do a greater range of custom configurations.

@brancz @metalmatze What do you think?