### PR TITLE
kube-prometheus: fix addon-resizer role binding

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-state-metrics/kube-state-metrics-role-binding.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-state-metrics/kube-state-metrics-role-binding.libsonnet
@@ -7,7 +7,7 @@ local roleBinding = k.rbac.v1.roleBinding;
           roleBinding.mixin.metadata.withName("kube-state-metrics") +
           roleBinding.mixin.metadata.withNamespace(namespace) +
           roleBinding.mixin.roleRef.withApiGroup("rbac.authorization.k8s.io") +
-          roleBinding.mixin.roleRef.withName("kube-state-metrics-addon-resizer") +
+          roleBinding.mixin.roleRef.withName("kube-state-metrics") +
           roleBinding.mixin.roleRef.mixinInstance({kind: "Role"}) +
           roleBinding.withSubjects([{kind: "ServiceAccount", name: "kube-state-metrics"}])
 }

--- a/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-role-binding.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics/kube-state-metrics-role-binding.yaml
@@ -6,7 +6,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kube-state-metrics-addon-resizer
+  name: kube-state-metrics
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics


### PR DESCRIPTION
The addon resizer was referring to an incorrect role binding and was unable to access the API.  This changes the rolebinding name to refer to the actually defined rolebinding.

Without this change, you get a lot of messages like this after deploying to a cluster with rbac enabled:

```
monitoring/kube-state-metrics-5d8784b89d-qw9r2[addon-resizer]: E0426 02:02:19.908809       1 nanny_lib.go:95] pods "kube-state-metrics-5d8784b89d-qw9r2" is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot get pods in the namespace "monitoring": Unknown user "system:serviceaccount:monitoring:kube-state-metrics"
```

Note that I couldn't easily get the ksonnet stuff building, so I just changed both the jsonnet file and the yaml manually.