### PR TITLE
Fixes a problem with variable scope

### DIFF
--- a/helm/prometheus/templates/servicemonitors.yaml
+++ b/helm/prometheus/templates/servicemonitors.yaml
@@ -3,6 +3,7 @@
 {{- $chartName := .Chart.Name -}}
 {{- $chartVersion := .Chart.Version -}}
 {{- $releaseService := .Release.Service -}}
+{{- $prometheusLabelValue := .Values.prometheusLabelValue -}}
 {{- if .Values.serviceMonitors }}
 apiVersion: v1
 kind: List
@@ -15,7 +16,7 @@ items:
         app: {{ $app }}
         chart: {{ $chartName }}-{{ $chartVersion }}
         heritage: {{ $releaseService }}
-        prometheus: {{ .Values.prometheusLabelValue | default $releaseName | quote }}
+        prometheus: {{ $prometheusLabelValue | default $releaseName | quote }}
         release: {{ $releaseName }}
         {{- if .serviceMonitorSelectorLabels }}
 {{ toYaml .serviceMonitorSelectorLabels | indent 8 }}


### PR DESCRIPTION
The error I was encountering was 

```
...
executing \"kube-prometheus/charts/prometheus/templates/servicemonitors.yaml\" at <.Values.prometheusLa...>: can't evaluate field prometheusLabelValue in type interface {}"
...
```

It was due to the scope change inside the `range` block