### PR TITLE
Scrape nginx ingress engine

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus-k8s/prometheus-k8s-cluster-role.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-k8s/prometheus-k8s-cluster-role.yaml
@@ -7,8 +7,14 @@ rules:
   - ""
   resources:
   - nodes/metrics
+  - nodes
+  - services
+  - endpoints
+  - pods
   verbs:
   - get
+  - list
+  - watch
 - nonResourceURLs:
   - /metrics
   verbs:


### PR DESCRIPTION
I was having the same problems reported in this issue https://github.com/coreos/prometheus-operator/issues/617 and I fixed it adding permissions to the cluster role used by prometheus-k8s.