### PR TITLE
Corrected API latency recording rule name

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,9 @@ kubectl delete --ignore-not-found customresourcedefinitions \
   1. build the container image with the docker host from within minikube by running `eval $(minikube docker-env)`.
   2. You can build the container using `make container`.
   3. Finally run the e2e tests using `make e2e-test`.
+
+### Updating contributed rules
+
+If you change any example rules in the `contrib` directory you'll need
+to regenerate them prior to submitting the updates. To do this, run
+`make generate` from the root of the repository and commit the result.

--- a/contrib/kube-prometheus/assets/prometheus/rules/kubernetes.rules.yaml
+++ b/contrib/kube-prometheus/assets/prometheus/rules/kubernetes.rules.yaml
@@ -32,7 +32,7 @@ groups:
       1e+06
     labels:
       quantile: "0.99"
-  - record: apiserver_latency:quantile_seconds
+  - record: apiserver_latency_seconds:quantile
     expr: histogram_quantile(0.9, rate(apiserver_request_latencies_bucket[5m])) /
       1e+06
     labels:

--- a/contrib/kube-prometheus/manifests/prometheus-k8s/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-k8s/prometheus-k8s-rules.yaml
@@ -415,7 +415,7 @@ data:
           1e+06
         labels:
           quantile: "0.99"
-      - record: apiserver_latency:quantile_seconds
+      - record: apiserver_latency_seconds:quantile
         expr: histogram_quantile(0.9, rate(apiserver_request_latencies_bucket[5m])) /
           1e+06
         labels:


### PR DESCRIPTION
This metric name should be consistent with the 50th and 99th percentile metrics.