### PR TITLE
Improve "Control Plane Components Down" panel

### DIFF
--- a/helm/grafana/dashboards/kubernetes-cluster-health-dashboard.json
+++ b/helm/grafana/dashboards/kubernetes-cluster-health-dashboard.json
@@ -78,12 +78,13 @@
                         },
                         "targets": [
                             {
-                                "expr": "sum(up{job=~\"apiserver|kube-scheduler|kube-controller-manager\"} == 0)",
+                                "expr": "count(up{job=~\"apiserver|kube-scheduler|kube-controller-manager\"} == 0)",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A",
-                                "step": 600
+                                "step": 600,
+                                "instant": true
                             }
                         ],
                         "thresholds": "1, 3",


### PR DESCRIPTION
We want to count the number of jobs that are down. Also adding the "instant=true" checkbox yields better results.