### PR TITLE
Added support for multiple hostnames to alertmanager/prometheus/grafana

### DIFF
--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -8,7 +8,7 @@ name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://github.com/prometheus/alertmanager
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.14.0"
 home: https://github.com/prometheus/alertmanager
 keywords:

--- a/helm/alertmanager/README.md
+++ b/helm/alertmanager/README.md
@@ -45,11 +45,13 @@ Parameter | Description | Default
 --- | --- | ---
 `config` | Alertmanager configuration directives | `{}`
 `externalUrl` | External URL at which Alertmanager will be reachable | `""`
+`routePrefix` | Prefix used to register routes | `"/"`
 `image.repository` | Image | `quay.io/prometheus/alertmanager`
 `image.tag` | Image tag | `v0.12.0`
 `ingress.enabled` | If true, Alertmanager Ingress will be created | `false`
 `ingress.annotations` | Annotations for Alertmanager Ingress` | `{}`
-`ingress.fqdn` | Alertmanager Ingress fully-qualified domain name | `""`
+`ingress.labels` | Labels for Alertmanager Ingress` | `{}`
+`ingress.hosts` | Alertmanager Ingress hosts | `[]`
 `ingress.tls` | TLS configuration for Alertmanager Ingress | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `paused` | If true, the Operator won't process any Alertmanager configuration changes | `false`

--- a/helm/alertmanager/templates/alertmanager.yaml
+++ b/helm/alertmanager/templates/alertmanager.yaml
@@ -15,8 +15,8 @@ spec:
   baseImage: "{{ .Values.image.repository }}"
 {{- if .Values.externalUrl }}
   externalUrl: "{{ .Values.externalUrl }}"
-{{- else if .Values.ingress.fqdn }}
-  externalUrl: http://{{ .Values.ingress.fqdn }}{{ .Values.routePrefix }}
+{{- else if .Values.ingress.enabled }}
+  externalUrl: "http://{{ index .Values.ingress.hosts 0 }}{{ .Values.routePrefix }}"
 {{- else }}
   externalUrl: http://{{ template "alertmanager.fullname" . }}.{{ .Release.Namespace }}:9093
 {{- end }}

--- a/helm/alertmanager/templates/ingress.yaml
+++ b/helm/alertmanager/templates/ingress.yaml
@@ -1,4 +1,6 @@
-{{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "alertmanager.fullname" . }}
+{{- $routePrefix := .Values.routePrefix }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,13 +20,15 @@ metadata:
   name: {{ template "alertmanager.fullname" . }}
 spec:
   rules:
-    - host: "{{ .Values.ingress.fqdn }}"
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
-          - path: "{{ .Values.routePrefix }}"
+          - path: "{{ $routePrefix }}"
             backend:
-              serviceName: {{ template "alertmanager.fullname" . }}
+              serviceName: "{{ $serviceName }}"
               servicePort: 9093
+    {{- end -}}              
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -82,7 +82,12 @@ ingress:
   ##
   labels: {}
 
-  fqdn: ""
+  ## Hostnames.
+  ## Must be provided if Ingress is enabled.
+  ##
+  # hosts:
+  #   - alertmanager.domain.com
+  hosts: []
 
   ## TLS configuration for Alertmanager Ingress
   ## Secret must be manually created in the namespace

--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.28
+version: 0.0.29

--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.29
+version: 0.0.30

--- a/helm/grafana/README.md
+++ b/helm/grafana/README.md
@@ -35,6 +35,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 Parameter | Description | Default
 --- | --- | ---
+`routePrefix` | Prefix used to register routes | `"/"`
 `auth.anonymous.enabled` | If true, enable anonymous authentication | `true`
 `adminUser` | Grafana admin user name | `admin`
 `adminPassword` | Grafana admin user password | `admin`
@@ -45,7 +46,8 @@ Parameter | Description | Default
 `grafanaWatcher.tag` | Image tag | `v0.0.8`
 `ingress.enabled` | If true, Grafana Ingress will be created | `false`
 `ingress.annotations` | Annotations for Grafana Ingress | `{}`
-`ingress.fqdn` | Grafana Ingress fully-qualified domain name | `""`
+`ingress.labels` | Labels for Grafana Ingress | `{}`
+`ingress.hosts` | Grafana Ingress fully-qualified domain names | `[]`
 `ingress.tls` | TLS configuration for Grafana Ingress | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `resources` | Pod resource requests & limits | `{}`

--- a/helm/grafana/templates/NOTES.txt
+++ b/helm/grafana/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{ $routePrefix := .Values.routePrefix }}
 1. Get your '{{ .Values.adminUser }}' user password by running:
 
    kubectl get secret --namespace {{ .Release.Namespace }} {{ template "grafana.fullname" . }} -o jsonpath="{.data.password}" | base64 --decode ; echo

--- a/helm/grafana/templates/NOTES.txt
+++ b/helm/grafana/templates/NOTES.txt
@@ -1,23 +1,25 @@
 1. Get your '{{ .Values.adminUser }}' user password by running:
 
-   kubectl get secret --namespace {{ .Release.Namespace }} {{ template "grafana.server.fullname" . }} -o jsonpath="{.data.password}" | base64 --decode ; echo
+   kubectl get secret --namespace {{ .Release.Namespace }} {{ template "grafana.fullname" . }} -o jsonpath="{.data.password}" | base64 --decode ; echo
 
 2. The Grafana server can be accessed via port 80 on the following DNS name from within your cluster:
 
-   {{ template "grafana.server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+   {{ template "grafana.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 {{ if .Values.ingress.enabled }}
    From outside the cluster, the server URL(s) are:
-     http://{{ .Values.ingress.fqdn }}
+   {{- range $host := .Values.ingress.hosts }}
+     http://{{ $host }}{{ $routePrefix }}
+   {{- end }} 
 {{ else }}
    Get the Grafana URL to visit by running these commands in the same shell:
 {{ if contains "NodePort" .Values.service.type -}}
-     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grafana.server.fullname" . }})
+     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grafana.fullname" . }})
      export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
      echo http://$NODE_IP:$NODE_PORT
 {{ else if contains "LoadBalancer" .Values.service.type -}}
    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "grafana.server.fullname" . }}'
-     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "grafana.server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "grafana.fullname" . }}'
+     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "grafana.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
      echo http://$SERVICE_IP:80
 {{ else if contains "ClusterIP"  .Values.service.type }}
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "grafana.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")

--- a/helm/grafana/templates/ingress.yaml
+++ b/helm/grafana/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $releaseName := .Release.Name -}}
+{{- $serviceName := include "grafana.fullname" . }}
+{{- $routePrefix := .Values.routePrefix }}
+{{- $releaseName := .Release.Name }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -8,24 +10,27 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "grafana.fullname" . }}
+    app: {{ template "grafana.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
-  name: {{ template "grafana.server.fullname" . }}
+  name: {{ template "grafana.fullname" . }}
 spec:
   rules:
-    - host: {{ .Values.ingress.fqdn }}
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
-          - backend:
+          - path: "{{ $routePrefix }}"
+            backend:
               serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
               servicePort: 80
-  {{- if .Values.ingress.tls }}
+    {{- end -}}              
+{{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -106,7 +106,16 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
 
-  fqdn: ""
+  ## Labels to be added to the Ingress
+  ##
+  labels: {}
+  
+  ## Hostnames.
+  ## Must be provided if Ingress is enabled.
+  ##
+  # hosts:
+  #   - grafana.domain.com
+  hosts: []
 
   ## TLS configuration for Alertmanager Ingress
   ## Secret must be manually created in the namespace

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.59
+version: 0.0.60

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
   - name: alertmanager
-    version: 0.1.1
+    version: 0.1.2
     #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.32
+    version: 0.0.33
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -59,7 +59,7 @@ dependencies:
     condition: deployExporterNode
 
   - name: grafana
-    version: 0.0.29
+    version: 0.0.30
     #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.33
+    version: 0.0.34
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -59,7 +59,7 @@ dependencies:
     condition: deployExporterNode
 
   - name: grafana
-    version: 0.0.28
+    version: 0.0.29
     #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana

--- a/helm/kube-prometheus/templates/NOTES.txt
+++ b/helm/kube-prometheus/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- if .Values.alertmanager.ingress.fqdn or .Values.prometheus.ingress.fqdn or .Values.grafana.ingress.fqdn -}}
+{{- if or .Values.alertmanager.ingress.fqdn .Values.prometheus.ingress.fqdn .Values.grafana.ingress.fqdn -}}
 DEPRECATION NOTICE:
 
 - alertmanager.ingress.fqdn is not used anymore, use alertmanager.ingress.hosts []

--- a/helm/kube-prometheus/templates/NOTES.txt
+++ b/helm/kube-prometheus/templates/NOTES.txt
@@ -1,0 +1,7 @@
+{{- if .Values.alertmanager.ingress.fqdn -}}
+Deprecation notice:
+
+- alertmanager.ingress.fqdn is not used anymore, use alertmanager.ingress.hosts []
+- prometheus.ingress.fqdn is not used anymore, use prometheus.ingress.hosts []
+- grafana.ingress.fqdn is not used anymore, use prometheus.grafana.hosts []
+{{- end -}}

--- a/helm/kube-prometheus/templates/NOTES.txt
+++ b/helm/kube-prometheus/templates/NOTES.txt
@@ -1,5 +1,5 @@
-{{- if .Values.alertmanager.ingress.fqdn -}}
-Deprecation notice:
+{{- if .Values.alertmanager.ingress.fqdn or .Values.prometheus.ingress.fqdn or .Values.grafana.ingress.fqdn -}}
+DEPRECATION NOTICE:
 
 - alertmanager.ingress.fqdn is not used anymore, use alertmanager.ingress.hosts []
 - prometheus.ingress.fqdn is not used anymore, use prometheus.ingress.hosts []

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -54,7 +54,16 @@ alertmanager:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
 
-    fqdn: ""
+    ## Labels to be added to the Ingress
+    ##
+    labels: {}
+
+    ## Hostnames.
+    ## Must be provided if Ingress is enabled.
+    ##
+    # hosts:
+    #   - alertmanager.domain.com
+    hosts: []
 
     ## TLS configuration for Alertmanager Ingress
     ## Secret must be manually created in the namespace
@@ -180,7 +189,16 @@ prometheus:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
 
-    fqdn: ""
+    ## Labels to be added to the Ingress
+    ##
+    labels: {}
+
+    ## Hostnames.
+    ## Must be provided if Ingress is enabled.
+    ##
+    # hosts:
+    #   - alertmanager.domain.com
+    hosts: []
 
     ## TLS configuration for Prometheus Ingress
     ## Secret must be manually created in the namespace

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.32
+version: 0.0.33

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.33
+version: 0.0.34

--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -47,11 +47,13 @@ Parameter | Description | Default
 `config` | Prometheus configuration directives | `{}`
 `externalLabels` | The labels to add to any time series or alerts when communicating with external systems  | `{}`
 `externalUrl` | External URL at which Prometheus will be reachable | `""`
+`routePrefix` | Prefix used to register routes | `"/"`
 `image.repository` | Image | `quay.io/prometheus/prometheus`
 `image.tag` | Image tag | `v2.2.1`
 `ingress.enabled` | If true, Prometheus Ingress will be created | `false`
 `ingress.annotations` | Annotations for Prometheus Ingress` | `{}`
-`ingress.fqdn` | Prometheus Ingress fully-qualified domain name | `""`
+`ingress.labels` | Labels for Prometheus Ingress | `{}`
+`ingress.hosts` | Prometheus Ingress fully-qualified domain names | `[]`
 `ingress.tls` | TLS configuration for Prometheus Ingress | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `paused` | If true, the Operator won't process any Prometheus configuration changes | `false`

--- a/helm/prometheus/templates/ingress.yaml
+++ b/helm/prometheus/templates/ingress.yaml
@@ -1,4 +1,6 @@
-{{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "prometheus.fullname" . }}
+{{- $routePrefix := .Values.routePrefix }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -7,10 +9,10 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
+    prometheus: {{ .Values.prometheusLabelValue | default .Release.Name | quote }}
     app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
-    prometheus: {{ .Values.prometheusLabelValue | default .Release.Name | quote }}
     release: {{ .Release.Name }}
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
@@ -18,13 +20,15 @@ metadata:
   name: {{ template "prometheus.fullname" . }}
 spec:
   rules:
-    - host: "{{ .Values.ingress.fqdn }}"
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
-          - path: "{{ .Values.routePrefix }}"
+          - path: "{{ $routePrefix }}"
             backend:
-              serviceName: {{ template "prometheus.fullname" . }}
+              serviceName: "{{ $serviceName }}"
               servicePort: 9090
+    {{- end -}}              
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -30,8 +30,8 @@ spec:
 {{- end }}
 {{- if .Values.externalUrl }}
   externalUrl: "{{ .Values.externalUrl }}"
-{{- else if .Values.ingress.fqdn }}
-  externalUrl: http://{{ .Values.ingress.fqdn }}{{ .Values.routePrefix }}
+{{- else if .Values.ingress.enabled }}
+  externalUrl: "http://{{ index .Values.ingress.hosts 0 }}{{ .Values.routePrefix }}"
 {{- else }}
   externalUrl: http://{{ template "prometheus.fullname" . }}.{{ .Release.Namespace }}:9090
 {{- end }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -63,7 +63,12 @@ ingress:
   ##
   labels: {}
 
-  fqdn: ""
+  ## Hostnames.
+  ## Must be provided if Ingress is enabled.
+  ##
+  # hosts:
+  #   - prometheus.domain.com
+  hosts: []
 
   ## TLS configuration for Prometheus Ingress
   ## Secret must be manually created in the namespace


### PR DESCRIPTION
Instead of using the String ``fqdn`` to configure the hostname in the Ingresses, the List ``hosts`` is now used to configure the hostnames for the Ingresses.

