### PR TITLE
Prometheus operator clusterrole needs namespace/watch permissions

### DIFF
--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.22
+version: 0.0.23
 appVersion: "0.19.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/helm/prometheus-operator/templates/clusterrole.yaml
+++ b/helm/prometheus-operator/templates/clusterrole.yaml
@@ -62,5 +62,5 @@ rules:
 - apiGroups: [""]
   resources:
   - namespaces
-  verbs: ["list"]
+  verbs: ["list", "watch"]
 {{- end }}


### PR DESCRIPTION
Seeing 403s in the kube-apiserver logs and error in prometheus-operator logs trying to watch namespaces. This seems to be a new thing.

Environment:

- Kubernetes v1.10.1
- Installed with helm 2.8.1
- prometheus-operator chart 0.0.22
- kube-prometheus chart 0.0.31 (probably not relevant)
 

```
{
   "log":{
      "kind":"Event",
      "apiVersion":"audit.k8s.iogv1beta1",
      "metadata":{
         "creationTimestamp":"2018-05-01T16:42:08Z"
      },
      "level":"Request",
      "timestamp":"2018-05-01T16:42:08Z",
      "auditID":"1a65c54b-7ea3-4ad7-a297-c401477eebd6",
      "stage":"ResponseStarted",
      "requestURI":"/api/v1/namespaces?resourceVersion=221057u0026timeoutSeconds=475u0026watch=true",
      "verb":"watch",
      "user":{
         "username":"system:serviceaccount:monitoring:prometheus-operator",
         "uid":"ee069c7e-4b52-11e8-bc29-0aa27986b75e",
         "groups":[
            "system:serviceaccounts",
            "system:serviceaccounts:monitoring",
            "system:authenticated"
         ]
      },
      "sourceIPs":[
         "10.1.30.90"
      ],
      "objectRef":{
         "resource":"namespaces",
         "apiVersion":"v1"
      },
      "responseStatus":{
         "kind":"Status",
         "apiVersion":"v1",
         "metadata":{

         },
         "status":"Failure",
         "message":"namespaces is forbidden: User system:serviceaccount:monitoring:prometheus-operator cannot watch namespaces at the cluster scope",
         "reason":"Forbidden",
         "details":{
            "kind":"namespaces"
         },
         "code":403
      },
      "requestReceivedTimestamp":"2018-05-01T16:42:08.686757Z",
      "stageTimestamp":"2018-05-01T16:42:08.686869Z"
   },
   "stream":"stdout",
   "time":"2018-05-01T16:42:08.687106343Z"
}
```

```
E0501 16:41:03.190718       1 reflector.go:322] github.com/coreos/prometheus-operator/pkg/prometheus/operator.go:300: Failed to watch *v1.Namespace: unknown (get namespaces)
```