### PR TITLE
Fix prometheus service default pod selector in the prometheus chart

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.61
+version: 0.0.62

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.36
+    version: 0.0.37
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.36
+version: 0.0.37

--- a/helm/prometheus/templates/service.yaml
+++ b/helm/prometheus/templates/service.yaml
@@ -45,3 +45,4 @@ spec:
     prometheus: {{ .Values.prometheusLabelValue }}
     {{- end }}
   type: "{{ .Values.service.type }}"
+

--- a/helm/prometheus/templates/service.yaml
+++ b/helm/prometheus/templates/service.yaml
@@ -39,5 +39,9 @@ spec:
       protocol: TCP
   selector:
     app: {{ template "prometheus.name" . }}
-    prometheus: {{ .Values.prometheusLabelValue | default .Release.Name | quote }}
+    {{ if empty .Values.prometheusLabelValue -}}
+    prometheus: {{ template "prometheus.fullname" . }}
+    {{- else -}}
+    prometheus: {{ .Values.prometheusLabelValue }}
+    {{- end }}
   type: "{{ .Values.service.type }}"


### PR DESCRIPTION
In the case where `prometheusLabelValue` is not specified, the Prometheus CRD [is using a different default label than the service](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus/templates/prometheus.yaml#L9), resulting in the service not being able to select the right pods.

