### PR TITLE
e2e/alertmanager: Check if config contains string in ReloadConfig

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -232,7 +232,7 @@ func TestAlertmanagerReloadConfig(t *testing.T) {
 
 	firstConfig := `
 global:
-  resolve_timeout: 6m
+  resolve_timeout: 5m
 route:
   group_by: ['job']
   group_wait: 30s
@@ -242,7 +242,7 @@ route:
 receivers:
 - name: 'webhook'
   webhook_configs:
-  - url: 'http://alertmanagerwh:30500/'
+  - url: 'http://firstConfigWebHook:30500/'
 `
 	secondConfig := `
 global:
@@ -256,7 +256,7 @@ route:
 receivers:
 - name: 'webhook'
   webhook_configs:
-  - url: 'http://alertmanagerwh:30500/'
+  - url: 'http://secondConfigWebHook:30500/'
 `
 
 	cfg := &v1.Secret{
@@ -276,9 +276,9 @@ receivers:
 		t.Fatal(err)
 	}
 
-	firstExpectedConfig := "global:\n  resolve_timeout: 6m\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/v2/enqueue\n  hipchat_api_url: https://api.hipchat.com/\n  opsgenie_api_url: https://api.opsgenie.com/\n  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: webhook\n  group_by:\n  - job\n  group_wait: 30s\n  group_interval: 5m\n  repeat_interval: 12h\nreceivers:\n- name: webhook\n  webhook_configs:\n  - send_resolved: true\n    url: http://alertmanagerwh:30500/\ntemplates: []\n"
+	firstExpectedString := "firstConfigWebHook"
 	log.Println("waiting for first expected config")
-	if err := framework.WaitForSpecificAlertmanagerConfig(ns, alertmanager.Name, firstExpectedConfig); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToContainString(ns, alertmanager.Name, firstExpectedString); err != nil {
 		t.Fatal(err)
 	}
 	log.Println("first expected config found")
@@ -289,9 +289,10 @@ receivers:
 		t.Fatal(err)
 	}
 
-	secondExpectedConfig := "global:\n  resolve_timeout: 5m\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/v2/enqueue\n  hipchat_api_url: https://api.hipchat.com/\n  opsgenie_api_url: https://api.opsgenie.com/\n  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: webhook\n  group_by:\n  - job\n  group_wait: 30s\n  group_interval: 5m\n  repeat_interval: 12h\nreceivers:\n- name: webhook\n  webhook_configs:\n  - send_resolved: true\n    url: http://alertmanagerwh:30500/\ntemplates: []\n"
+	secondExpectedString := "secondConfigWebHook"
+
 	log.Println("waiting for second expected config")
-	if err := framework.WaitForSpecificAlertmanagerConfig(ns, alertmanager.Name, secondExpectedConfig); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToContainString(ns, alertmanager.Name, secondExpectedString); err != nil {
 		t.Fatal(err)
 	}
 	log.Println("second expected config found")

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -278,18 +279,18 @@ func (f *Framework) GetSilences(ns, n string) ([]amAPISil, error) {
 	return getSilencesResponse.Data, nil
 }
 
-func (f *Framework) WaitForSpecificAlertmanagerConfig(ns, amName string, expectedConfig string) error {
+func (f *Framework) WaitForAlertmanagerConfigToContainString(ns, amName string, expectedString string) error {
 	return wait.Poll(10*time.Second, time.Minute*5, func() (bool, error) {
 		config, err := f.GetAlertmanagerConfig(ns, "alertmanager-"+amName+"-0")
 		if err != nil {
 			return false, err
 		}
 
-		if config.Data.ConfigYAML == expectedConfig {
+		if strings.Contains(config.Data.ConfigYAML, expectedString) {
 			return true, nil
 		}
 
-		log.Printf("\n\nFound:\n\n%#+v\n\nExpected:\n\n%#+v\n\n", config.Data.ConfigYAML, expectedConfig)
+		log.Printf("\n\nExpected:\n\n%#+v\n\nto contain:\n\n%#+v\n\n", config.Data.ConfigYAML, expectedString)
 
 		return false, nil
 	})


### PR DESCRIPTION
Instead of comparing full configs, just check for a unique keyword. This
makes the test more robust to upstream format changes.