### PR TITLE
e2e/alertmanager: Update version migration test to recent version

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -86,17 +86,17 @@ func TestAlertmanagerVersionMigration(t *testing.T) {
 	name := "test"
 
 	am := framework.MakeBasicAlertmanager(name, 1)
-	am.Spec.Version = "v0.7.0"
+	am.Spec.Version = "v0.14.0"
 	if err := framework.CreateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
 		t.Fatal(err)
 	}
 
-	am.Spec.Version = "v0.7.1"
+	am.Spec.Version = "v0.15.0-rc.1"
 	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
 		t.Fatal(err)
 	}
 
-	am.Spec.Version = "v0.7.0"
+	am.Spec.Version = "v0.14.0"
 	if err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Update TestAlertmanagerVersionMigration versions to `v0.14.0` and
`v0.15.0-rc.1`.