### PR TITLE
Add kube-state-metrics to Prometheus service monitor selector

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.64
+version: 0.0.65

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.63
+version: 0.0.64

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -314,10 +314,24 @@ prometheus:
   ## Service monitors selector
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
   ##
-  serviceMonitorsSelector: 
+  serviceMonitorsSelector:
     matchExpressions:
-    - {key: app, operator: In, values: [alertmanager, exporter-coredns, exporter-node, exporter-kubernetes, exporter-kube-controller-manager,  exporter-kubelets, exporter-kube-scheduler,
-        exporter-kube-etcd, exporter-kube-dns, grafana, prometheus, prometheus-operator ]}
+    - key: app
+      operator: In
+      values:
+      - alertmanager
+      - exporter-coredns
+      - exporter-kube-controller-manager
+      - exporter-kube-dns
+      - exporter-kube-etcd
+      - exporter-kube-scheduler
+      - exporter-kube-state
+      - exporter-kubelets
+      - exporter-kubernetes
+      - exporter-node
+      - grafana
+      - prometheus
+      - prometheus-operator
 
   ## ServiceMonitor CRDs to create & be scraped by the Prometheus instance.
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/service-monitor.md


### PR DESCRIPTION
Add back kube-state-metrics to the Prometheus service monitor selector.