### PR TITLE
contrib/kube-prometheus: add `-f` to `rm` in `build.sh`

### DIFF
--- a/contrib/kube-prometheus/build.sh
+++ b/contrib/kube-prometheus/build.sh
@@ -3,5 +3,5 @@ set -e
 set -x
 
                                                # optional, but we would like to generate yaml, not json
-jsonnet -J vendor -m manifests example.jsonnet | xargs -I{} sh -c 'cat $1 | gojsontoyaml > $1.yaml; rm $1' -- {}
+jsonnet -J vendor -m manifests example.jsonnet | xargs -I{} sh -c 'cat $1 | gojsontoyaml > $1.yaml; rm -f $1' -- {}
 


### PR DESCRIPTION
According to the man pages of `rm` and the `-f` option:
> Attempt to remove the files without prompting for confirma- tion,
> regardless of the file's permissions.  If the file does not exist, do
> not display a diagnostic message or modify the exit status to reflect an
> error.  The -f option overrides any previous -i options.

This patch prevents the `build.sh` script from failing if files do not
exist when attempting to delete them.