### PR TITLE
ISSUE-1306: Fix the Toleration field

### DIFF
--- a/helm/exporter-kube-state/Chart.yaml
+++ b/helm/exporter-kube-state/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-state
-version: 0.2.2
+version: 0.2.3
 maintainers:
   - name: Giancarlo Rubio
     email: gianrubio@gmail.com

--- a/helm/exporter-kube-state/templates/deployment.yaml
+++ b/helm/exporter-kube-state/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
     {{- if .Values.global.rbacEnable }}
       serviceAccountName: {{ template "exporter-kube-state.fullname" . }}
     {{- end }}
-    {{- if .Values.kube_state_metrics.tolerations }}
+{{- if .Values.tolerations }}
       tolerations:
-    {{ toYaml .Values.kube_state_metrics.tolerations | indent 4 }}
+{{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.66
+version: 0.0.67

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -38,7 +38,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-kube-state
-    version: 0.2.2
+    version: 0.2.3
     #e2e-repository: file://../exporter-kube-state
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 


### PR DESCRIPTION
This is to fix https://github.com/coreos/prometheus-operator/issues/1306#issuecomment-387434365. 

The "Toleration" field in `values.yaml` is out side of "kube_state_metric" field so we dont need it here.

The current `values.yaml` is:
```
kube_state_metrics:
  image:
    blah blah
  service:
    blah blah
addon_resizer:
   blah blah
   image:
    blah blah
  resources:
    blah blah

tolerations: {}     <--- And Toleration here is out side of those above
  #  - key: "key"
  #    operator: "Equal"
  #    value: "value"
  #    effect: "NoSchedule"
```