### PR TITLE
docs: Run embedmd on both Docs and kube-prometheus README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ po-docgen:
 	@go install github.com/coreos/prometheus-operator/cmd/po-docgen
 
 docs: embedmd po-docgen
-	$(GOPATH)/bin/embedmd -w `find Documentation -name "*.md"`
+	$(GOPATH)/bin/embedmd -w `find Documentation contrib/kube-prometheus/README.md -name "*.md"`
 	$(GOPATH)/bin/po-docgen api pkg/client/monitoring/v1/types.go > Documentation/api.md
 	$(GOPATH)/bin/po-docgen compatibility > Documentation/compatibility.md
 

--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -83,9 +83,11 @@ To compile the above and get each manifest in a separate file on disk use the fo
 #!/usr/bin/env bash
 set -e
 set -x
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
 
                                                # optional, but we would like to generate yaml, not json
-jsonnet -J vendor -m manifests example.jsonnet | xargs -I{} sh -c 'cat $1 | gojsontoyaml > $1.yaml; rm $1' -- {}
+jsonnet -J vendor -m manifests example.jsonnet | xargs -I{} sh -c 'cat $1 | gojsontoyaml > $1.yaml; rm -f $1' -- {}
 
 ```
 

--- a/contrib/kube-prometheus/build.sh
+++ b/contrib/kube-prometheus/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 set -x
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
 
                                                # optional, but we would like to generate yaml, not json
 jsonnet -J vendor -m manifests example.jsonnet | xargs -I{} sh -c 'cat $1 | gojsontoyaml > $1.yaml; rm -f $1' -- {}


### PR DESCRIPTION
> actually just seconds after I merged I realized, but can you just re-embed this into the readme in kube-prometheus? looks like our generation make target is not picking that up

@brancz Follow up for https://github.com/coreos/prometheus-operator/pull/1334