### PR TITLE
Fix kube-prometheus chart not deploying when some features are disabled

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.67
+version: 0.0.68

--- a/helm/kube-prometheus/templates/NOTES.txt
+++ b/helm/kube-prometheus/templates/NOTES.txt
@@ -1,7 +1,5 @@
-{{- if or .Values.alertmanager.ingress.fqdn .Values.prometheus.ingress.fqdn .Values.grafana.ingress.fqdn -}}
 DEPRECATION NOTICE:
 
 - alertmanager.ingress.fqdn is not used anymore, use alertmanager.ingress.hosts []
 - prometheus.ingress.fqdn is not used anymore, use prometheus.ingress.hosts []
 - grafana.ingress.fqdn is not used anymore, use prometheus.grafana.hosts []
-{{- end -}}


### PR DESCRIPTION
We encountered the same issue as [#1342](https://github.com/coreos/prometheus-operator/issues/1342).
When installing `kube-prometheus:0.0.66` without Node Exporter or Grafana, it fails as values are not set.