### PR TITLE
Typo fix in e2e test readme

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -7,7 +7,7 @@ End-to-end (e2e) testing is automated testing for real user scenarios.
 Prerequisites:
 - a running k8s cluster and kube config. We will need to pass kube config as arguments.
 - Have kubeconfig file ready.
-- Have etcd operator image ready.
+- Have prometheus operator image ready.
 
 e2e tests are written as Go test. All go test techniques apply, e.g. picking
 what to run, timeout length. Let's say I want to run all tests in "test/e2e/":


### PR DESCRIPTION
The current E2E testing readme indicates that you need to have an etcd operator image created prior to testing the prometheus operator, which was a little confusing. It looks like this was just a copy and paste issue from the etcd operator E2E test readme. This PR updates the readme to reflect that it's a prometheus operator image that is required.