### PR TITLE
docs: Add node-exporter ServiceAccount to documentation

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -210,6 +210,18 @@ spec:
         name: sys
 ```
 
+The respective `ServiceAccount` manifest:
+
+[embedmd]:# (../../contrib/kube-prometheus/manifests/node-exporter-serviceAccount.yaml)
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-exporter
+  namespace: monitoring
+```
+
+
 And the respective `Service` manifest:
 
 [embedmd]:# (../../contrib/kube-prometheus/manifests/node-exporter-service.yaml)


### PR DESCRIPTION
This PR adds the node-exporter ServiceAccount to the Cluster monitoring guide. Without
the ServiceAccount the node-exporter pods are unable to start.

Fixes #1352