### PR TITLE
prometheus-operator chart: remove redundant Label selector

### DIFF
--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.24
+version: 0.0.25
 appVersion: "0.19.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
+++ b/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
@@ -18,8 +18,6 @@ data:
         jobLabel: {{ template "prometheus-operator.name" . }}
         selector:
           matchLabels:
-        selector:
-          matchLabels:
             operated-prometheus: "true"
         namespaceSelector:
           matchNames:


### PR DESCRIPTION
Hello,
Looks like there are duplicating selectors in the service monitor of the prometheus-operator helm chart. This PR just removes the empty one. 