### PR TITLE
prometheus chart: fix identation on serviceMonitorSelector

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.68
+version: 0.0.69

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.38
+    version: 0.0.39
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.38
+version: 0.0.39

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -64,8 +64,8 @@ spec:
   serviceMonitorSelector:
 {{ toYaml .Values.serviceMonitorsSelector | indent 4 }}
 {{- else if .Values.prometheusLabelValue }}
-   serviceMonitorSelector:
-     matchLabels:
+  serviceMonitorSelector:
+    matchLabels:
       prometheus: {{ .Values.prometheusLabelValue }}
 {{- end }}
 {{- if .Values.remoteRead }}


### PR DESCRIPTION
Hello,

This one should fix broken yaml in case of using `.Values.prometheusLabelValue` in the prometheus helm chart