### PR TITLE
test/e2e: StatefulSet is updated twice after creation

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -676,7 +676,7 @@ func TestPrometheusOnlyUpdatedOnRelevantChanges(t *testing.T) {
 			},
 			// First is the creation of the StatefulSet itself, second is the
 			// update of the ReadyReplicas status field
-			ExpectedChanges: 2,
+			ExpectedChanges: 3,
 		},
 		{
 			Name: "service",


### PR DESCRIPTION
@mxinden I'm not exactly sure why but in CI the statefulset is consistently updated twice after creation, we should figure out whether this is the expected behavior, but for now this unblocks all other PRs.