### PR TITLE
Fix process memory graph in Etcd dashboard

### DIFF
--- a/contrib/kube-prometheus/assets/grafana/raw-json-dashboards/etcd-dashboard.json
+++ b/contrib/kube-prometheus/assets/grafana/raw-json-dashboards/etcd-dashboard.json
@@ -526,7 +526,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "process_resident_memory_bytes",
+              "expr": "process_resident_memory_bytes{job=\"etcd\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} Resident Memory",


### PR DESCRIPTION
Use `{job="etcd}"` label selector to filter out non-etcd processes.

Fixes #1295.