### PR TITLE
Makefile: Enable bash pipefail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash -o pipefail
 REPO?=quay.io/coreos/prometheus-operator
 TAG?=$(shell git rev-parse --short HEAD)
 NAMESPACE?=po-e2e-$(shell LC_ALL=C tr -dc a-z0-9 < /dev/urandom | head -c 13 ; echo '')


### PR DESCRIPTION
Enable bash pipefail flag for all Makefile operations. This arised when
running `make jsonnet`, where `jsonnet` failed, but the rest of the pipe
covered the error.