### PR TITLE
travis: Move e2e tests to first stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
   - script: ./scripts/golang-dep-ensure.sh
   # Unit tests
   - script: make test
-  - stage: E2e
+  # E2e tests
     script: ./scripts/travis-e2e.sh
   - script: ./scripts/travis-e2e-helm.sh
   - stage: deploy


### PR DESCRIPTION
If both the *generate* as well as the *e2e* tests on a patch fail, a
user does not need to wait for the second (fixed) iteration of the
*generate* tests to pass until the user gets the *e2e* failure feedback.