### PR TITLE
[helm/prometheus] Use contains on prometheus.fullname template

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.73
+version: 0.0.74

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.39
+    version: 0.0.40
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.39
+version: 0.0.40

--- a/helm/prometheus/templates/_helpers.tpl
+++ b/helm/prometheus/templates/_helpers.tpl
@@ -16,7 +16,7 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if eq $name .Release.Name -}}
+{{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/helm/prometheus/templates/configmap.yaml
+++ b/helm/prometheus/templates/configmap.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- if .Values.additionalRulesConfigMapLabels }}
 {{ toYaml .Values.additionalRulesConfigMapLabels | indent 4 }}
     {{- end }}    
-  name: {{ template "prometheus.fullname" . }}
+  name: {{ template "prometheus.fullname" . }}-rules
 data:
 {{- if .Values.prometheusRules }}
 {{- $root := . }}


### PR DESCRIPTION
Before this change a release name of "kube-prometheus" will have a prometheus pod called "prometheus-kube-prometheus-prometheus".

With this change the same release will have a pod name "prometheus-kube-prometheus"