### PR TITLE
rbac: Remove Third Party Resources rules

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -21,12 +21,6 @@ metadata:
   name: prometheus-operator
 rules:
 - apiGroups:
-  - extensions
-  resources:
-  - thirdpartyresources
-  verbs:
-  - "*"
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
@@ -71,9 +65,9 @@ rules:
 
 > Note: A cluster admin is required to create this `ClusterRole` and create a `ClusterRoleBinding` or `RoleBinding` to the `ServiceAccount` used by the Prometheus Operator `Pod`. The `ServiceAccount` used by the Prometheus Operator `Pod` can be specified in the `Deployment` object used to deploy it.
 
-When the Prometheus Operator boots up for the first time it registers the `thirdpartyresources` it uses, therefore the `create` action on those is required.
+When the Prometheus Operator boots up for the first time it registers the `customresourcedefinitions` it uses, therefore the `create` action on those is required.
 
-As the Prometheus Operator works extensively with the `thirdpartyresources` it registers, it requires all actions on those objects. Those are:
+As the Prometheus Operator works extensively with the `customresourcedefinitions` it registers, it requires all actions on those objects. Those are:
 
 * `alertmanagers`
 * `prometheuses`

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -35,12 +35,6 @@ metadata:
   name: prometheus-operator
 rules:
 - apiGroups:
-  - extensions
-  resources:
-  - thirdpartyresources
-  verbs:
-  - "*"
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -17,12 +17,6 @@ metadata:
   name: prometheus-operator
 rules:
 - apiGroups:
-  - extensions
-  resources:
-  - thirdpartyresources
-  verbs:
-  - "*"
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-operator/prometheus-operator.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-operator/prometheus-operator.libsonnet
@@ -33,13 +33,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local clusterRole = k.rbac.v1.clusterRole;
       local policyRule = clusterRole.rulesType;
 
-      local extensionsRule = policyRule.new() +
-                             policyRule.withApiGroups(['extensions']) +
-                             policyRule.withResources([
-                               'thirdpartyresources',
-                             ]) +
-                             policyRule.withVerbs(['*']);
-
       local apiExtensionsRule = policyRule.new() +
                                 policyRule.withApiGroups(['apiextensions.k8s.io']) +
                                 policyRule.withResources([
@@ -102,7 +95,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                             ]) +
                             policyRule.withVerbs(['list', 'watch']);
 
-      local rules = [extensionsRule, apiExtensionsRule, monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule];
+      local rules = [apiExtensionsRule, monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule];
 
       clusterRole.new() +
       clusterRole.mixin.metadata.withName('prometheus-operator') +

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-clusterRole.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-clusterRole.yaml
@@ -4,12 +4,6 @@ metadata:
   name: prometheus-operator
 rules:
 - apiGroups:
-  - extensions
-  resources:
-  - thirdpartyresources
-  verbs:
-  - '*'
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -4,12 +4,6 @@ metadata:
   name: prometheus-operator
 rules:
 - apiGroups:
-  - extensions
-  resources:
-  - thirdpartyresources
-  verbs:
-  - "*"
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions


### PR DESCRIPTION
Since PR 460 [1] the Prometheus Operator is using Kubernetes Custom Resource
Definitions instead of Kubernetes Third Party Resources. Permissions to
handle Third Party Resources in the RBAC rules of the Prometheus
Operator is thereby obsolete.

[1] https://github.com/coreos/prometheus-operator/pull/460

//CC @brancz @ant31 