### PR TITLE
fixed prometheus datasource configuration in graphana configmap

### DIFF
--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.32
+version: 0.0.33

--- a/helm/grafana/templates/dashboards-configmap.yaml
+++ b/helm/grafana/templates/dashboards-configmap.yaml
@@ -24,6 +24,6 @@ data:
       "basicAuth": false,
       "name": "prometheus",
       "type": "prometheus",
-      "url": "http://{{ printf "%s-%s" .Release.Name "prometheus" }}:9090"
+      "url": "http://{{ printf "%s" .Release.Name }}:9090"
     }
   {{- end }}

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.77
+version: 0.0.79
 

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.75
+version: 0.0.77

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.76
+version: 0.0.77
 

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -59,7 +59,7 @@ dependencies:
     condition: deployExporterNode
 
   - name: grafana
-    version: 0.0.32
+    version: 0.0.33
     #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana


### PR DESCRIPTION
When installing the Helm charts the datasource for prometheus in graphana is not configured correctly, see issue #1412. Removed `-prometheus` from datasource URL in Helm chart