### PR TITLE
[helm/prometheus] CRB to wrong ServiceAccount when using custom name

### DIFF
--- a/helm/prometheus/templates/clusterrolebinding.yaml
+++ b/helm/prometheus/templates/clusterrolebinding.yaml
@@ -18,7 +18,7 @@ roleRef:
   name: {{ template "prometheus.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "prometheus.fullname" . }}
+    name: {{ template "prometheus.serviceAccountName" .}}
     namespace: {{ .Release.Namespace }}
 {{- end }}
 


### PR DESCRIPTION
As a side-effect of #1230, when creating a new ServiceAccount with a
custom name (`serviceAccount.create` is `true` and `serviceAccount.name`
is defined) the ClusterRoleBinding ends up referencing the incorrect
ServiceAccount name. Update the ClusterRoleBinding to use the
`prometheus.serviceAccountName` template, making it consistent with the
value used when creating the ServiceAccount:
https://github.com/coreos/prometheus-operator/blob/098fd87e2cf7e3cde6a111327e45af1d57e36bc9/helm/prometheus/templates/serviceaccount.yaml#L10