### PR TITLE
cmd/po-rule-cm-to-rule-file-crds: Add migration CLI tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ jobs:
   - script: cd contrib/kube-prometheus && make test
   # Build Prometheus config reloader
   - script: cd contrib/prometheus-config-reloader && make build
+  # Build Prometheus Operator rule config map to rule file crds cli tool
+  - script: cd cmd/po-rule-cm-to-rule-file-crds && go install
   # Ensure vendor folder matches vendor.json
   - script: ./scripts/golang-dep-ensure.sh
   # Unit tests

--- a/cmd/po-rule-cm-to-rule-file-crds/main.go
+++ b/cmd/po-rule-cm-to-rule-file-crds/main.go
@@ -1,0 +1,84 @@
+// Copyright 2018 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/coreos/prometheus-operator/pkg/prometheus"
+
+	"k8s.io/api/core/v1"
+	k8sYAML "k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/ghodss/yaml"
+)
+
+func main() {
+	var ruleConfigMapName = flag.String("rule-config-map", "", "path to rule config map")
+	var ruleCRDSDestination = flag.String("rule-crds-destination", "", "destination new crds should be created in")
+	flag.Parse()
+
+	if *ruleConfigMapName == "" {
+		log.Print("please specify 'rule-config-map' flag")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	if *ruleCRDSDestination == "" {
+		log.Print("please specify 'rule-crds-destination' flag")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	destPath, err := filepath.Abs(*ruleCRDSDestination)
+	if err != nil {
+		log.Fatalf("failed to get absolut path of '%v': %v", ruleCRDSDestination, err.Error())
+	}
+	ruleCRDSDestination = &destPath
+
+	file, err := os.Open(*ruleConfigMapName)
+	if err != nil {
+		log.Fatalf("failed to read file '%v': %v", ruleConfigMapName, err.Error())
+	}
+
+	configMap := v1.ConfigMap{}
+
+	err = k8sYAML.NewYAMLOrJSONDecoder(file, 100).Decode(&configMap)
+	if err != nil {
+		log.Fatalf("failed to decode manifest: %v", err.Error())
+	}
+
+	ruleFiles, err := prometheus.CMToRuleFiles(&configMap)
+	if err != nil {
+		log.Fatalf("failed to transform config map to rule file crds: %v", err.Error())
+	}
+
+	for _, ruleFile := range ruleFiles {
+		encodedRuleFile, err := yaml.Marshal(ruleFile)
+		if err != nil {
+			log.Fatalf("failed to encode ruleFile '%v': %v", ruleFile.Name, err.Error())
+		}
+
+		err = ioutil.WriteFile(path.Join(*ruleCRDSDestination, ruleFile.Name), encodedRuleFile, 0644)
+		if err != nil {
+			log.Fatalf("failed to write yaml manifest for rule file '%v': %v", ruleFile.Name, err.Error())
+		}
+	}
+}

--- a/pkg/prometheus/rule_configmap_migration.go
+++ b/pkg/prometheus/rule_configmap_migration.go
@@ -49,7 +49,7 @@ func (c *Operator) migrateRuleConfigMapsToRuleFileCRDs(p *monitoringv1.Prometheu
 
 	ruleFiles := []monitoringv1.RuleFile{}
 	for _, cm := range configMaps {
-		files, err := cmToRuleFiles(cm)
+		files, err := CMToRuleFiles(cm)
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,10 @@ func (c *Operator) getRuleCMs(ns string, cmLabelSelector *metav1.LabelSelector) 
 	return configMaps, nil
 }
 
-func cmToRuleFiles(cm *v1.ConfigMap) ([]monitoringv1.RuleFile, error) {
+// CMToRuleFiles takes a rule config map and transforms it to possibly multiple
+// rule file crds. It is used in `cmd/po-rule-cm-to-rule-file-crds`. Thereby it
+// needs to be public.
+func CMToRuleFiles(cm *v1.ConfigMap) ([]monitoringv1.RuleFile, error) {
 	ruleFiles := []monitoringv1.RuleFile{}
 
 	for name, content := range cm.Data {
@@ -120,6 +123,11 @@ func cmToRuleFiles(cm *v1.ConfigMap) ([]monitoringv1.RuleFile, error) {
 		}
 
 		ruleFile := monitoringv1.RuleFile{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       monitoringv1.RuleFilesKind,
+				APIVersion: monitoringv1.Group + "/" + monitoringv1.Version,
+			},
+
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      cm.Name + "-" + name,
 				Namespace: cm.Namespace,

--- a/pkg/prometheus/rule_configmap_migration_test.go
+++ b/pkg/prometheus/rule_configmap_migration_test.go
@@ -32,7 +32,7 @@ func TestCMToRuleFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = cmToRuleFiles(cm)
+	_, err = CMToRuleFiles(cm)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This patch adds a cli tool to migrate existing Prometheus rule config
maps to Prometheus rule file CRDs.

Usage:
```bash
cd cmd/po-rule-cm-to-rule-file-crds
go install
po-rule-cm-to-rule-file-crds \
--rule-config-map=../../contrib/kube-prometheus/manifests/prometheus-rules.yaml \
--rule-crds-destination=.
```