### PR TITLE
prometheus-config-reloader: Hardcode version

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -69,7 +69,7 @@ func init() {
 	flagset.StringVar(&cfg.TLSConfig.CAFile, "ca-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to TLS CA file.")
 	flagset.StringVar(&cfg.KubeletObject, "kubelet-service", "", "Service/Endpoints object to write kubelets into in format \"namespace/name\"")
 	flagset.BoolVar(&cfg.TLSInsecure, "tls-insecure", false, "- NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate.")
-	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", "quay.io/coreos/prometheus-config-reloader:v0.0.4", "Config and rule reload image")
+	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", "quay.io/coreos/prometheus-config-reloader:v0.20.0", "Config and rule reload image")
 	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "quay.io/coreos/configmap-reload:v0.0.1", "Reload Image")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", "quay.io/prometheus/alertmanager", "Alertmanager default base image")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", "quay.io/prometheus/prometheus", "Prometheus default base image")

--- a/contrib/prometheus-config-reloader/Makefile
+++ b/contrib/prometheus-config-reloader/Makefile
@@ -3,8 +3,8 @@ all: build
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 NAME = prometheus-config-reloader
-REPO = quay.io/coreos/$(NAME)
-TAG = v0.0.4
+REPO?=quay.io/coreos/$(NAME)
+TAG?=v0.20.0
 IMAGE = $(REPO):$(TAG)
 
 build:


### PR DESCRIPTION
The prometheus-config-reloader will be released alongside the
prometheus-operator. Thereby it holds the same version.

For now we will manually hardcode that version. In the future this could
be achieved dynamically via a compiler flags.