### PR TITLE
NodeDiskRunningFull ignore etc files mountpoints

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/node.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/node.libsonnet
@@ -11,7 +11,7 @@
               summary: 'Node disk is running full within 24 hours',
             },
             expr: |||
-              predict_linear(node_filesystem_free{%(nodeExporterSelector)s}[6h], 3600 * 24) < 0
+              predict_linear(node_filesystem_free{%(nodeExporterSelector)s,mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[6h], 3600 * 24) < 0
             ||| % $._config,
             'for': '30m',
             labels: {
@@ -25,7 +25,7 @@
               summary: 'Node disk is running full within 2 hours',
             },
             expr: |||
-              predict_linear(node_filesystem_free{%(nodeExporterSelector)s}[30m], 3600 * 2) < 0
+              predict_linear(node_filesystem_free{%(nodeExporterSelector)s,mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[30m], 3600 * 2) < 0
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -679,7 +679,7 @@ spec:
           full within the next 24 hours (mounted at {{$labels.mountpoint}})
         summary: Node disk is running full within 24 hours
       expr: |
-        predict_linear(node_filesystem_free{job="node-exporter"}[6h], 3600 * 24) < 0
+        predict_linear(node_filesystem_free{job="node-exporter",mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[6h], 3600 * 24) < 0
       for: 30m
       labels:
         severity: warning
@@ -689,7 +689,7 @@ spec:
           full within the next 2 hours (mounted at {{$labels.mountpoint}})
         summary: Node disk is running full within 2 hours
       expr: |
-        predict_linear(node_filesystem_free{job="node-exporter"}[30m], 3600 * 2) < 0
+        predict_linear(node_filesystem_free{job="node-exporter",mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[30m], 3600 * 2) < 0
       for: 10m
       labels:
         severity: critical


### PR DESCRIPTION
When NodeDiskRunningFull is alarmed 4 alerts are generated. 3 of those are for the following mountpoints: `/etc/resolv.conf`, `/etc/hosts`, `/etc/hostname` and the last one is for the `/` mountpoint.
A good example is https://github.com/coreos/prometheus-operator/issues/1180#issuecomment-382799514

N.B. Seems the automation to update the helm charts is broken /cc @gianrubio so I'm unsure if I should update them manually.