### PR TITLE
Remove `description` from the root schema in CRDs

### DIFF
--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
@@ -11,7 +11,7 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: Alertmanager describes an Alertmanager cluster.
+      # description: Alertmanager describes an Alertmanager cluster.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
@@ -11,7 +11,7 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: Prometheus defines a Prometheus deployment.
+      # description: Prometheus defines a Prometheus deployment.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
@@ -11,7 +11,7 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: PrometheusRule defines alerting rules for a Prometheus instance
+      # description: PrometheusRule defines alerting rules for a Prometheus instance
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
@@ -11,7 +11,7 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: ServiceMonitor defines monitoring for a set of services.
+      # description: ServiceMonitor defines monitoring for a set of services.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/example/prometheus-operator-crd/alertmanager.crd.yaml
+++ b/example/prometheus-operator-crd/alertmanager.crd.yaml
@@ -12,7 +12,7 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: Alertmanager describes an Alertmanager cluster.
+      # description: Alertmanager describes an Alertmanager cluster.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/example/prometheus-operator-crd/prometheus.crd.yaml
+++ b/example/prometheus-operator-crd/prometheus.crd.yaml
@@ -12,7 +12,7 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: Prometheus defines a Prometheus deployment.
+      # description: Prometheus defines a Prometheus deployment.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/example/prometheus-operator-crd/prometheusrule.crd.yaml
+++ b/example/prometheus-operator-crd/prometheusrule.crd.yaml
@@ -12,7 +12,7 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: PrometheusRule defines alerting rules for a Prometheus instance
+      # description: PrometheusRule defines alerting rules for a Prometheus instance
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/example/prometheus-operator-crd/servicemonitor.crd.yaml
+++ b/example/prometheus-operator-crd/servicemonitor.crd.yaml
@@ -12,7 +12,7 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: ServiceMonitor defines monitoring for a set of services.
+      # description: ServiceMonitor defines monitoring for a set of services.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
Fixes  #1293

`description` is not allowed in the root schema in CRDs in Kubernetes v1.10 if subresources are enabled. They are allowed from Kubernetes v1.11.

/assign @brancz @sslavic
