### PR TITLE
*: Use all jsonnet from master branch

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "extract-po-jsonnet"
+            "version": "master"
         }
     ]
 }

--- a/hack/generate/jsonnetfile.json
+++ b/hack/generate/jsonnetfile.json
@@ -1,24 +1,14 @@
 {
     "dependencies": [
         {
-            "name": "ksonnet",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/ksonnet/ksonnet-lib",
-                    "subdir": ""
-                }
-            },
-            "version": "master"
-        },
-        {
             "name": "prometheus-operator",
             "source": {
                 "git": {
-                    "remote": "https://github.com/coreos/prometheus-operator",
+                    "remote": "../../",
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "extract-po-jsonnet"
+            "version": "."
         }
     ]
 }

--- a/jsonnet/prometheus-operator/.gitignore
+++ b/jsonnet/prometheus-operator/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+jsonnetfile.lock.json

--- a/jsonnet/prometheus-operator/jsonnetfile.json
+++ b/jsonnet/prometheus-operator/jsonnetfile.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        {
+            "name": "ksonnet",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/ksonnet/ksonnet-lib",
+                    "subdir": ""
+                }
+            },
+            "version": "master"
+        }
+    ]
+}


### PR DESCRIPTION
This is a follow up to #1443, changing the version of the prometheus-operator jsonnet package to the now existent `master` version.

@mxinden 