### PR TITLE
add additionalAlertManagerConfigs to helm chart

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.82
+version: 0.0.83

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.43
+    version: 0.0.44
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.43
+version: 0.0.44

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -124,4 +124,9 @@ spec:
     name: prometheus-{{ .Release.Name }}-additional-scrape-configs
     key: additional-scrape-configs.yaml
 {{- end }}
+{{- if .Values.additionalScrapeConfigs }}
+  additionalAlertManagerConfigs:
+    name: prometheus-{{ .Release.Name }}-additional-alertmanager-configs
+    key: additional-alertmanager-configs.yaml
+{{- end }}
 

--- a/helm/prometheus/templates/secret.yaml
+++ b/helm/prometheus/templates/secret.yaml
@@ -30,3 +30,20 @@ metadata:
 data:
   additional-scrape-configs.yaml: {{ toYaml .Values.additionalScrapeConfigs | b64enc | quote }}
 {{- end }}
+
+---
+
+{{- if .Values.additionalAlertManagerConfigs }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "prometheus.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    prometheus: {{ .Values.prometheusLabelValue | default .Release.Name | quote }}
+    release: {{ .Release.Name }}
+  name: prometheus-{{ .Release.Name }}-additional-alertmanager-configs
+data:
+  additional-alertmanager-configs.yaml: {{ toYaml .Values.additionalAlertManagerConfigs | b64enc | quote }}
+{{- end }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -339,4 +339,12 @@ additionalScrapeConfigs: []
 #   - targets:
 #     - "localhost:9090"
 
+## Prometheus AdditionalAlertManagerConfigs
+## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+##
+additionalAlertManagerConfigs: {}
+# static_configs:
+# - targets:
+#   - "localhost:9093"
+
 serviceMonitorNamespaceSelector: {}


### PR DESCRIPTION
This should help Helm users take advantage of the flexibility of the `additionalAlertManagerConfigs` field added to `PrometheusSpec`.

Fixes #1456