### PR TITLE
e2e: Print Kubernetes events on test failures

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -16,11 +16,13 @@ package e2e
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"testing"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
 	operatorFramework "github.com/coreos/prometheus-operator/test/framework"
@@ -68,10 +70,32 @@ func TestMain(m *testing.M) {
 	defer func() {
 		if err := framework.Teardown(); err != nil {
 			log.Printf("failed to teardown framework: %v\n", err)
-			os.Exit(1)
+			code = 1
 		}
+
+		if code != 0 {
+			if err := printKubernetesEvents(); err != nil {
+				log.Printf("failed to print events: %v", err)
+			}
+		}
+
 		os.Exit(code)
 	}()
 
 	code = m.Run()
+}
+
+func printKubernetesEvents() error {
+	fmt.Println("Printing Kubernetes events for debugging:")
+	events, err := framework.KubeClient.CoreV1().Events("").List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	if events != nil {
+		for _, e := range events.Items {
+			fmt.Printf("FirstTimestamp: '%v', Reason: '%v', Message: '%v'\n", e.FirstTimestamp, e.Reason, e.Message)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
To improve the ability to debug the Prometheus Operator e2e tests, print
all Kubernetes events on test failure.