### PR TITLE
Documentation Update

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -202,6 +202,8 @@ spec:
 
 This Service object is discovered by a ServiceMonitor, which selects in the same way. The `app` label must have the value `example-app`.
 
+
+
 [embedmd]:# (../../example/user-guides/getting-started/example-app-service-monitor.yaml)
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -217,6 +219,8 @@ spec:
   endpoints:
   - port: web
 ```
+
+> Before the version `v0.19.0`, ServiceMonitors must be installed in the same namespace as the Prometheus Operator.
 
 ## Enable RBAC rules for Prometheus pods
 

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -157,7 +157,7 @@ The Prometheus resource declaratively describes the desired state of a Prometheu
 
 ![Prometheus Operator Architecture](images/architecture.png "Prometheus Operator Architecture")
 
-The Prometheus resource includes a field called `serviceMonitorSelector`, which defines a selection of ServiceMonitors to be used.
+The Prometheus resource includes a field called `serviceMonitorSelector`, which defines a selection of ServiceMonitors to be used. By default and before the version `v0.19.0`, ServiceMonitors must be installed in the same namespace as the Prometheus instance. With the Prometheus Operator `v0.19.0` and above, ServiceMonitors can be selected outside the Prometheus namespace via the `serviceMonitorNamespaceSelector` field of the Prometheus resource.
 
 First, deploy three instances of a simple example application, which listens and exposes metrics on port `8080`.
 
@@ -219,8 +219,6 @@ spec:
   endpoints:
   - port: web
 ```
-
-> Before the version `v0.19.0`, ServiceMonitors must be installed in the same namespace as the Prometheus Operator.
 
 ## Enable RBAC rules for Prometheus pods
 


### PR DESCRIPTION
This PR adds in the documentation the fact the ServiceMonitors must be installed in the same namespace as Prometheus Operator.

Related to this issue: https://github.com/coreos/prometheus-operator/issues/1435