### PR TITLE
pkg/version: Pass Prometheus Operator version via ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,14 @@ all: format generate build test
 build: operator prometheus-config-reloader
 
 operator: $(GOLANG_FILES)
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o $@ cmd/operator/main.go
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+	-ldflags "-X github.com/coreos/prometheus-operator/pkg/version.Version=$(shell cat VERSION)" \
+	-o $@ cmd/operator/main.go
 
 prometheus-config-reloader:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o $@ cmd/$@/main.go
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+	-ldflags "-X github.com/coreos/prometheus-operator/pkg/version.Version=$(shell cat VERSION)" \
+	-o $@ cmd/$@/main.go
 
 pkg/client/monitoring/v1/zz_generated.deepcopy.go: $(DEEPCOPY_GEN_BINARY)
 	$(DEEPCOPY_GEN_BINARY) \

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/coreos/prometheus-operator/pkg/api"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	prometheuscontroller "github.com/coreos/prometheus-operator/pkg/prometheus"
+	"github.com/coreos/prometheus-operator/pkg/version"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 )
@@ -69,7 +70,11 @@ func init() {
 	flagset.StringVar(&cfg.TLSConfig.CAFile, "ca-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to TLS CA file.")
 	flagset.StringVar(&cfg.KubeletObject, "kubelet-service", "", "Service/Endpoints object to write kubelets into in format \"namespace/name\"")
 	flagset.BoolVar(&cfg.TLSInsecure, "tls-insecure", false, "- NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate.")
-	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", "quay.io/coreos/prometheus-config-reloader:v0.20.0", "Config and rule reload image")
+	// The Prometheus config reloader image is released along with the
+	// Prometheus Operator image, tagged with the same semver version. Default to
+	// the Prometheus Operator version if no Prometheus config reloader image is
+	// specified.
+	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", fmt.Sprintf("quay.io/coreos/prometheus-config-reloader:v%v", version.Version), "Prometheus config reloader image")
 	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "quay.io/coreos/configmap-reload:v0.0.1", "Reload Image")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", "quay.io/prometheus/alertmanager", "Alertmanager default base image")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", "quay.io/prometheus/prometheus", "Prometheus default base image")
@@ -105,6 +110,8 @@ func Main() int {
 	}
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
+
+	logger.Log("msg", fmt.Sprintf("Starting Prometheus Operator version '%v'.", version.Version))
 
 	r := prometheus.NewRegistry()
 	r.MustRegister(prometheus.NewGoCollector())

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/coreos/prometheus-operator/pkg/version"
+
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/reloader"
 	"github.com/oklog/run"
@@ -29,6 +31,8 @@ func main() {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
+
+	logger.Log("msg", fmt.Sprintf("Starting prometheus-config-reloader version '%v'.", version.Version))
 
 	app := kingpin.New("prometheus-config-reloader", "")
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,18 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// Version represents the software version of the Prometheus Operator
+var Version string


### PR DESCRIPTION
The Prometheus config reloader image is released along with the
Prometheus Operator image, tagged with the same semver version. In order
to default to the Prometheus Operator version if no Prometheus config
reloader image is specified, the content of `VERSION` needs to be passed
during compile time.