### PR TITLE
operator: Support json as a log format

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -49,6 +49,11 @@ const (
 	logLevelNone  = "none"
 )
 
+const (
+	logFormatLogfmt = "logfmt"
+	logFormatJson   = "json"
+)
+
 var (
 	cfg                prometheuscontroller.Config
 	availableLogLevels = []string{
@@ -58,6 +63,10 @@ var (
 		logLevelWarn,
 		logLevelError,
 		logLevelNone,
+	}
+	availableLogFormats = []string{
+		logFormatLogfmt,
+		logFormatJson,
 	}
 )
 
@@ -86,12 +95,16 @@ func init() {
 	flagset.BoolVar(&cfg.EnableValidation, "with-validation", true, "Include the validation spec in the CRD")
 	flagset.BoolVar(&cfg.DisableAutoUserGroup, "disable-auto-user-group", false, "Disables the Prometheus Operator setting the `runAsUser` and `fsGroup` fields in Pods.")
 	flagset.StringVar(&cfg.LogLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(availableLogLevels, ", ")))
+	flagset.StringVar(&cfg.LogFormat, "log-format", logFormatLogfmt, fmt.Sprintf("Log format to use. Possible values: %s", strings.Join(availableLogFormats, ", ")))
 	flagset.Parse(os.Args[1:])
 
 }
 
 func Main() int {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+	if cfg.LogFormat == logFormatJson {
+		logger = log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+	}
 	switch cfg.LogLevel {
 	case logLevelAll:
 		logger = level.NewFilter(logger, level.AllowAll())

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -136,6 +136,7 @@ type Config struct {
 	EnableValidation             bool
 	DisableAutoUserGroup         bool
 	LogLevel                     string
+	LogFormat                    string
 }
 
 type BasicAuthCredentials struct {


### PR DESCRIPTION
It would be nice if all moving parts of the prometheus operator would support json-formatted structured logging.

Providing this as an early stage PR to gather feedback on it.

For upstream prometheus, there's a PR available here: https://github.com/prometheus/common/pull/136/files

* [x] prometheus-config-reloader needs an option as well