### PR TITLE
docs: Removed reference to ROADMAP.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ post](https://coreos.com/blog/the-prometheus-operator.html).
 
 **Documentation is hosted on [coreos.com](https://coreos.com/operators/prometheus/docs/latest/)**
 
-The current project roadmap [can be found here](./ROADMAP.md).
-
 ## Prometheus Operator vs. kube-prometheus
 
 The Prometheus Operator makes the Prometheus configuration Kubernetes native


### PR DESCRIPTION
With PR #1481, I removed the ROADMAP.md file but did not delete the reference to that file inside the README.md. This commit fixes that.