### PR TITLE
kube-prometheus: Run node-exporter in host network

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -185,6 +185,7 @@ spec:
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100
+          hostPort: 9100
           name: https
         resources:
           limits:
@@ -193,6 +194,8 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+      hostNetwork: true
+      hostPID: true
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ generate-in-docker: hack/jsonnet-docker-image
 
 .PHONY: kube-prometheus
 kube-prometheus:
-	cd contrib/kube-prometheus; $(MAKE) generate
+	cd contrib/kube-prometheus && $(MAKE) generate
 
 example/prometheus-operator-crd/**.crd.yaml: pkg/client/monitoring/v1/openapi_generated.go $(PO_CRDGEN_BINARY)
 	po-crdgen prometheus > example/prometheus-operator-crd/prometheus.crd.yaml

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -90,7 +90,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           '--secure-listen-address=:9100',
           '--upstream=http://127.0.0.1:9101/',
         ]) +
-        container.withPorts(containerPort.newNamed('https', 9100)) +
+        container.withPorts(containerPort.new(9100) + containerPort.withHostPort(9100) + containerPort.withName('https')) +
         container.mixin.resources.withRequests({ cpu: '10m', memory: '20Mi' }) +
         container.mixin.resources.withLimits({ cpu: '20m', memory: '40Mi' });
 
@@ -108,7 +108,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       daemonset.mixin.spec.template.spec.withVolumes([procVolume, sysVolume]) +
       daemonset.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
       daemonset.mixin.spec.template.spec.securityContext.withRunAsUser(65534) +
-      daemonset.mixin.spec.template.spec.withServiceAccountName('node-exporter'),
+      daemonset.mixin.spec.template.spec.withServiceAccountName('node-exporter') +
+      daemonset.mixin.spec.template.spec.withHostPid(true) +
+      daemonset.mixin.spec.template.spec.withHostNetwork(true),
 
     serviceAccount:
       local serviceAccount = k.core.v1.serviceAccount;

--- a/contrib/kube-prometheus/manifests/grafana-dashboardDatasources.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-dashboardDatasources.yaml
@@ -2,12 +2,13 @@ apiVersion: v1
 data:
   prometheus.yaml: |-
     {
+        "apiVersion": 1,
         "datasources": [
             {
                 "access": "proxy",
                 "editable": false,
                 "name": "prometheus",
-                "org_id": 1,
+                "orgId": 1,
                 "type": "prometheus",
                 "url": "http://prometheus-k8s.monitoring.svc:9090",
                 "version": 1

--- a/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
+++ b/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
@@ -42,6 +42,7 @@ spec:
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100
+          hostPort: 9100
           name: https
         resources:
           limits:
@@ -50,6 +51,8 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+      hostNetwork: true
+      hostPID: true
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:


### PR DESCRIPTION
Node exporter needs to run in the host network, not in the pod network
in order to pick up network metrics of the node.

Fixes https://github.com/coreos/prometheus-operator/issues/1473