### PR TITLE
Add sidecar containers field to Prometheus Helm chart

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.83
+version: 0.0.84

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.44
+    version: 0.0.45
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -425,6 +425,10 @@ prometheus:
   #          storage: 50Gi
   #    selector: {}
 
+  sidecarsSpec: []
+  # - name: sidecar
+  #   image: registry/name:tag
+
 # default rules are in templates/general.rules.yaml
 # prometheusRules: {}
 

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.44
+version: 0.0.45

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -16,6 +16,11 @@ metadata:
 {{- end }}
   name: {{ template "prometheus.fullname" . }}
 spec:
+{{- if .Values.labels }}
+  podMetadata:
+    labels:
+{{ toYaml .Values.labels | indent 6 }}
+{{- end }}
 {{- if .Values.alertingEndpoints }}
   alerting:
     alertmanagers:

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -134,4 +134,8 @@ spec:
     name: prometheus-{{ .Release.Name }}-additional-alertmanager-configs
     key: additional-alertmanager-configs.yaml
 {{- end }}
+{{- if .Values.sidecarsSpec }}
+  containers:
+{{ toYaml .Values.sidecarsSpec | indent 4 }}
+{{- end }}
 

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -348,3 +348,7 @@ additionalAlertManagerConfigs: {}
 #   - "localhost:9093"
 
 serviceMonitorNamespaceSelector: {}
+
+sidecarsSpec: []
+# - name: sidecar
+#   image: registry/name:tag


### PR DESCRIPTION
Hi there,

I've been working on using Thanos with the kube-prometheus helm charts but I had to add some features to make it work. So now I'm contributing it back.

It adds:
- Prometheus sidecarsSpec field : necessary to add thanos's sidecar component to a Prometheus instance.
- Prometheus labels field as podMetadata.labels : necessary to make the thanos-peer service to work with thanos's sidecar component.