### PR TITLE
Removed the architecture node selector

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
@@ -98,7 +98,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           replicas: $._config.alertmanager.replicas,
           version: $._config.versions.alertmanager,
           baseImage: $._config.imageRepos.alertmanager,
-          nodeSelector: { 'beta.kubernetes.io/os': 'linux' },
           serviceAccountName: 'alertmanager-' + $._config.alertmanager.name,
         },
       },

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -176,7 +176,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       deployment.mixin.metadata.withNamespace($._config.namespace) +
       deployment.mixin.metadata.withLabels(podLabels) +
       deployment.mixin.spec.selector.withMatchLabels(podLabels) +
-      deployment.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/os': 'linux' }) +
       deployment.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
       deployment.mixin.spec.template.spec.securityContext.withRunAsUser(65534) +
       deployment.mixin.spec.template.spec.withServiceAccountName('kube-state-metrics'),

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -103,7 +103,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       daemonset.mixin.spec.selector.withMatchLabels(podLabels) +
       daemonset.mixin.spec.template.metadata.withLabels(podLabels) +
       daemonset.mixin.spec.template.spec.withTolerations([masterToleration]) +
-      daemonset.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/os': 'linux' }) +
       daemonset.mixin.spec.template.spec.withContainers(c) +
       daemonset.mixin.spec.template.spec.withVolumes([procVolume, sysVolume]) +
       daemonset.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -215,7 +215,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           baseImage: $._config.imageRepos.prometheus,
           serviceAccountName: 'prometheus-' + $._config.prometheus.name,
           serviceMonitorSelector: selector.withMatchExpressions({ key: 'k8s-app', operator: 'Exists' }),
-          nodeSelector: { 'beta.kubernetes.io/os': 'linux' },
           ruleSelector: selector.withMatchLabels({
             role: 'alert-rules',
             prometheus: $._config.prometheus.name,


### PR DESCRIPTION
Can this be removed? It doesn't work well with podnodeselector admission controller