### PR TITLE
kube-prometheus: Remove default serviceMonitorsSelector

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.86
+version: 0.0.87

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -330,24 +330,7 @@ prometheus:
   ## Service monitors selector
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
   ##
-  serviceMonitorsSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - alertmanager
-      - exporter-coredns
-      - exporter-kube-controller-manager
-      - exporter-kube-dns
-      - exporter-kube-etcd
-      - exporter-kube-scheduler
-      - exporter-kube-state
-      - exporter-kubelets
-      - exporter-kubernetes
-      - exporter-node
-      - grafana
-      - prometheus
-      - prometheus-operator
+  serviceMonitorsSelector: {}
 
   ## ServiceMonitor CRDs to create & be scraped by the Prometheus instance.
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/service-monitor.md


### PR DESCRIPTION
The default serviceMonitorsSelector that the prometheus chart provides is sufficient and having one set in kube-prometheus makes it impossible to just get the default behaviour (without actually overriding it).