### PR TITLE
Add the possiblity to set resource limits for kube-state-metrics cont…

### DIFF
--- a/helm/exporter-kube-state/templates/deployment.yaml
+++ b/helm/exporter-kube-state/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
             port: {{ .Values.kube_state_metrics.service.internalPort }}
           initialDelaySeconds: 30
           timeoutSeconds: 5
+        resources:
+{{ toYaml .Values.kube_state_metrics.resources | indent 12 }}
       - name: {{ .Chart.Name }}-addon-resizer
         image: "{{ .Values.addon_resizer.image.repository }}:{{ .Values.addon_resizer.image.tag }}"
         env:

--- a/helm/exporter-kube-state/values.yaml
+++ b/helm/exporter-kube-state/values.yaml
@@ -19,6 +19,7 @@ kube_state_metrics:
     type: ClusterIP
     externalPort: 80
     internalPort: 8080
+  resources: {}
 addon_resizer:
   memory: 130Mi
   extra_memory: 2Mi


### PR DESCRIPTION
The current chart only allows setting the resource limits for one of the two containers in the kube-state-metrics deployment. Since we're running bigger clusters and kube-state-metrics gets constantly OOM killed, this introduces a resource entries (without any defaults) in the values and deployment file.