### PR TITLE
allow seting volume name via volumetemplateclaimtemplate in prom and alertmanager

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -324,9 +324,11 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 		},
 	}
 
-	volumeName := volumeName(a.Name)
-	if a.Spec.Storage.VolumeClaimTemplate.Name != "" {
-		volumeName = a.Spec.Storage.VolumeClaimTemplate.Name
+	volName := volumeName(a.Name)
+	if a.Spec.Storage != nil {
+		if a.Spec.Storage.VolumeClaimTemplate.Name != "" {
+			volName = a.Spec.Storage.VolumeClaimTemplate.Name
+		}
 	}
 
 	amVolumeMounts := []v1.VolumeMount{
@@ -335,7 +337,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 			MountPath: alertmanagerConfDir,
 		},
 		{
-			Name:      volumeName,
+			Name:      volName,
 			MountPath: alertmanagerStorageDir,
 			SubPath:   subPathForStorage(a.Spec.Storage),
 		},

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -117,7 +117,9 @@ func makeStatefulSet(am *monitoringv1.Alertmanager, old *appsv1.StatefulSet, con
 		})
 	} else {
 		pvcTemplate := storageSpec.VolumeClaimTemplate
-		pvcTemplate.Name = volumeName(am.Name)
+		if pvcTemplate.Name == "" {
+			pvcTemplate.Name = volumeName(am.Name)
+		}
 		pvcTemplate.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 		pvcTemplate.Spec.Resources = storageSpec.VolumeClaimTemplate.Spec.Resources
 		pvcTemplate.Spec.Selector = storageSpec.VolumeClaimTemplate.Spec.Selector

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -325,8 +325,8 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	}
 
 	volumeName := volumeName(a.Name)
-	if p.Spec.Storage.VolumeClaimTemplate.Name != "" {
-		volumeName := p.Spec.Storage.VolumeClaimTemplate.Name
+	if a.Spec.Storage.VolumeClaimTemplate.Name != "" {
+		volumeName = a.Spec.Storage.VolumeClaimTemplate.Name
 	}
 
 	amVolumeMounts := []v1.VolumeMount{

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -323,13 +323,19 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 			},
 		},
 	}
+
+	volumeName := volumeName(a.Name)
+	if p.Spec.Storage.VolumeClaimTemplate.Name != "" {
+		volumeName := p.Spec.Storage.VolumeClaimTemplate.Name
+	}
+
 	amVolumeMounts := []v1.VolumeMount{
 		{
 			Name:      "config-volume",
 			MountPath: alertmanagerConfDir,
 		},
 		{
-			Name:      volumeName(a.Name),
+			Name:      volumeName,
 			MountPath: alertmanagerStorageDir,
 			SubPath:   subPathForStorage(a.Spec.Storage),
 		},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -428,6 +428,11 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config) (*appsv1.Stateful
 		},
 	}
 
+	volumeName := volumeName(p.Name)
+	if p.Spec.Storage.VolumeClaimTemplate.Name != "" {
+		volumeName := p.Spec.Storage.VolumeClaimTemplate.Name
+	}
+
 	promVolumeMounts := []v1.VolumeMount{
 		{
 			Name:      "config-out",
@@ -439,7 +444,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config) (*appsv1.Stateful
 			MountPath: "/etc/prometheus/rules",
 		},
 		{
-			Name:      volumeName(p.Name),
+			Name:      volumeName,
 			MountPath: storageDir,
 			SubPath:   subPathForStorage(p.Spec.Storage),
 		},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -186,7 +186,9 @@ func makeStatefulSet(
 		})
 	} else {
 		pvcTemplate := storageSpec.VolumeClaimTemplate
-		pvcTemplate.Name = volumeName(p.Name)
+		if pvcTemplate.Name == "" {
+			pvcTemplate.Name = volumeName(p.Name)
+		}
 		pvcTemplate.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 		pvcTemplate.Spec.Resources = storageSpec.VolumeClaimTemplate.Spec.Resources
 		pvcTemplate.Spec.Selector = storageSpec.VolumeClaimTemplate.Spec.Selector

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -430,7 +430,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config) (*appsv1.Stateful
 
 	volumeName := volumeName(p.Name)
 	if p.Spec.Storage.VolumeClaimTemplate.Name != "" {
-		volumeName := p.Spec.Storage.VolumeClaimTemplate.Name
+		volumeName = p.Spec.Storage.VolumeClaimTemplate.Name
 	}
 
 	promVolumeMounts := []v1.VolumeMount{

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -428,9 +428,11 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config) (*appsv1.Stateful
 		},
 	}
 
-	volumeName := volumeName(p.Name)
-	if p.Spec.Storage.VolumeClaimTemplate.Name != "" {
-		volumeName = p.Spec.Storage.VolumeClaimTemplate.Name
+	volName := volumeName(p.Name)
+	if p.Spec.Storage != nil {
+		if p.Spec.Storage.VolumeClaimTemplate.Name != "" {
+			volName = p.Spec.Storage.VolumeClaimTemplate.Name
+		}
 	}
 
 	promVolumeMounts := []v1.VolumeMount{
@@ -444,7 +446,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config) (*appsv1.Stateful
 			MountPath: "/etc/prometheus/rules",
 		},
 		{
-			Name:      volumeName,
+			Name:      volName,
 			MountPath: storageDir,
 			SubPath:   subPathForStorage(p.Spec.Storage),
 		},


### PR DESCRIPTION
This pull request allows users that have more control over setting volumeclaim template. Specifically the volume claim name . If a person doesn't set the name then it is inserted for you by default as it has been doing for statefulset. This is needed more since using gluster as a storageclass , the name is too long . Giving user the ability to set their name for themselves, people that want to migrate to using gluster won't have this issue anymore since the user can set a short name and wont break anything for people already using volume claim template.

