### PR TITLE
Added ruleNamespaceSelector to kube-prometheus and prometheus charts.

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.85
+version: 0.0.86

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.45
+    version: 0.0.46
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -261,6 +261,10 @@ prometheus:
   ##
   routePrefix: /
 
+  ## Namespaces to be selected for PrometheusRules discovery.
+  ## If unspecified, only the same namespace as the Prometheus object is in is used.
+  ruleNamespaceSelector: {}
+
   ## Rules configmap selector
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
   ##

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.45
+version: 0.0.46

--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -66,6 +66,7 @@ Parameter | Description | Default
 `retention` | How long to retain metrics | `24h`
 `routePrefix` | Prefix used to register routes, overriding externalUrl route | `/`
 `rules` | Prometheus alerting & recording rules | `{}`
+`ruleNamespaceSelector` | Namespaces to be selected for PrometheusRules discovery | `{}`
 `rulesSelector` | Rules ConfigMap selector | `{}`
 `secrets` | List of Secrets in the same namespace as the Prometheus object, which shall be mounted into the Prometheus Pods. | `{}`
 `service.annotations` | Annotations to be added to the Prometheus Service | `{}`

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -85,6 +85,9 @@ spec:
   remoteWrite:
 {{ toYaml .Values.remoteWrite | indent 4 }}
 {{- end }}
+{{- if .Values.ruleNamespaceSelector }}
+{{ toYaml .Values.ruleNamespaceSelector | indent 4 }}
+{{- end }}
 {{- if .Values.rulesSelector }}
   ruleSelector:
 {{ toYaml .Values.rulesSelector | indent 4 }}


### PR DESCRIPTION
Currently the `ruleNamespaceSelector` cannot be specified in the prometheus chart.