### PR TITLE
helm: Allow setting pod selector on etcd

### DIFF
--- a/helm/exporter-kube-etcd/Chart.yaml
+++ b/helm/exporter-kube-etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: exporter-kube-etcd
-version: 0.1.13
+version: 0.1.14
 maintainers:
   - name: Giancarlo Rubio
     email: gianrubio@gmail.com

--- a/helm/exporter-kube-etcd/templates/service.yaml
+++ b/helm/exporter-kube-etcd/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
       targetPort: {{ .Values.etcdPort }}
 {{- if .Values.endpoints }}{{- else }}
   selector:
-    k8s-app: etcd-server
+    {{ .Values.serviceSelectorLabelKey }}: {{ .Values.serviceSelectorLabelValue }}
 {{- end }}
   type: ClusterIP

--- a/helm/exporter-kube-etcd/values.yaml
+++ b/helm/exporter-kube-etcd/values.yaml
@@ -4,6 +4,10 @@ etcdPort:  4001
 endpoints: []
 # Are we talking http or https?
 scheme: http
+# service selector label key to target kube etcd pods
+serviceSelectorLabelKey: k8s-app
+# service selector label value to target kube etcd pods
+serviceSelectorLabelValue: etcd-server
 # default rules are in templates/etcd3.rules.yaml
 # prometheusRules: {}
 

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.90
+version: 0.0.92

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -29,7 +29,7 @@ dependencies:
     condition: deployKubeDNS
 
   - name: exporter-kube-etcd
-    version: 0.1.13
+    version: 0.1.14
     #e2e-repository: file://../exporter-kube-etcd
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployKubeEtcd


### PR DESCRIPTION
Kubeadm uses different labels when it creates the pods. Other exporters allow selecting these, but etcd is set up by kubeadm has an additional discrepancy