### PR TITLE
Mount prometheus data volume into thanos sidecar (#1169)

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -611,6 +611,14 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config) (*appsv1.Stateful
 			}
 		}
 
+		thanosVolumeMounts := []v1.VolumeMount{
+			{
+				Name:      volName,
+				MountPath: storageDir,
+				SubPath:   subPathForStorage(p.Spec.Storage),
+			},
+		}
+
 		c := v1.Container{
 			Name:  "thanos-sidecar",
 			Image: thanosBaseImage + ":" + *p.Spec.Thanos.Version,
@@ -630,6 +638,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config) (*appsv1.Stateful
 				},
 			},
 			Env: envVars,
+			VolumeMounts:   thanosVolumeMounts,
 		}
 
 		additionalContainers = append(additionalContainers, c)

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -566,6 +566,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config) (*appsv1.Stateful
 
 		thanosArgs := []string{"sidecar"}
 
+		thanosArgs = append(thanosArgs, fmt.Sprintf("--tsdb.path=%s", storageDir))
 		if p.Spec.Thanos.Peers != nil {
 			thanosArgs = append(thanosArgs, fmt.Sprintf("--cluster.peers=%s", *p.Spec.Thanos.Peers))
 		}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -638,8 +638,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config) (*appsv1.Stateful
 					ContainerPort: 10900,
 				},
 			},
-			Env: envVars,
-			VolumeMounts:   thanosVolumeMounts,
+			Env:          envVars,
+			VolumeMounts: thanosVolumeMounts,
 		}
 
 		additionalContainers = append(additionalContainers, c)


### PR DESCRIPTION
As described in https://github.com/coreos/prometheus-operator/issues/1169#issuecomment-402659888, thanos sidecar container did not have prometheus data directory mounted inside it.

* Mounted prometheus data volume inside thanos on `/prometheus` path
* Override default `tsdb.path` directory to `storageDir` of prometheus operator (default `/prometheus`)