### PR TITLE
[helm/prometheus] Rename extra rules

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.96
+version: 0.0.97

--- a/helm/prometheus/templates/rules.yaml
+++ b/helm/prometheus/templates/rules.yaml
@@ -8,10 +8,11 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Values.prometheusLabelValue | default .Release.Name | quote }}
     release: {{ .Release.Name }}
+    role: alert-rules
     {{- if .Values.rules.additionalLabels }}
 {{ toYaml .Values.rules.additionalLabels | indent 4 }}
     {{- end }}
-  name: prometheus-{{ .Release.Name }}-rules
+  name: {{ template "prometheus.fullname" . }}-extra-rules
 spec:
   groups:
 {{ toYaml .Values.rules.value | indent 4 }}


### PR DESCRIPTION
- If having a release that contains `prometheus` then those extra rules ConfigMap names will be something like `prometheus-prometheus-rules`
- Having the `rules` suffix clashes with the ConfigMap name for the default prometheus rules.