### PR TITLE
helm: kube-prometheus: add deployPrometheus toggle

### DIFF
--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.95
+version: 0.0.96

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -9,6 +9,7 @@ dependencies:
     version: 0.0.49
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+    condition: deployPrometheus
 
   - name: exporter-coredns
     version: 0.0.3

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -1,6 +1,9 @@
 # exporter-node configuration
 deployExporterNode: True
 
+# Prometheus
+deployPrometheus: True
+
 # Grafana
 deployGrafana: True
 


### PR DESCRIPTION
helm: kube-prometheus: Added deployPrometheus toggle value

This allows kube-prometheus to install all components except Prometheus so that Prometheus can be installed separately when greater customization on Prometheus are needed.

Fixes #1578 