### PR TITLE
Add ability to specify pod metadata

### DIFF
--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.49
+version: 0.0.50
 

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -16,10 +16,21 @@ metadata:
 {{- end }}
   name: {{ template "prometheus.fullname" . }}
 spec:
-{{- if .Values.labels }}
+{{- if or .Values.podMetadata.annotations .Values.podMetadata.labels .Values.labels }}
   podMetadata:
+{{- if .Values.podMetadata.annotations }}
+    annotations:
+{{ toYaml .Values.podMetadata.annotations | indent 6 }}
+{{- end }}
+{{- if or .Values.podMetadata.labels .Values.labels }}
     labels:
+{{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 6 }}
+{{- end }}
+{{- if .Values.podMetadata.labels }}
+{{ toYaml .Values.podMetadata.labels | indent 6 }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.alertingEndpoints }}
   alerting:

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -127,6 +127,15 @@ logLevel: info
 ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
 podAntiAffinity: "soft"
 
+podMetadata:
+  ## Annotations to be added to Prometheus pods
+  ##
+  annotations: {}
+
+  ## Labels to be added to Prometheus pods
+  ##
+  labels: {}
+
 ## The remote_read spec configuration for Prometheus.
 ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
 remoteRead: {}


### PR DESCRIPTION
The `prometheus` Helm chart allows setting annotations on its Service and Ingress resources, but not on the Prometheus pods created by the operator. This PR makes the `podMetadata` property of the Prometheus resource configurable, which allows setting the annotations and labels of the Prometheus pods created by the operator. This can be useful for assigning IAM roles to Prometheus pods, etc.

The list of `podMetadata` labels is sourced from both `.Values.labels` and `.Values.podMetadata.labels` to preserve backwards compatibility.