### PR TITLE
alertmanager/statefulset: Move gossip port to 9094

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -81,7 +81,7 @@ AlertmanagerEndpoints defines a selection of a single Endpoints object containin
 
 ## AlertmanagerList
 
-A list of Alertmanagers.
+AlertmanagerList is a list of Alertmanagers.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -92,7 +92,7 @@ A list of Alertmanagers.
 
 ## AlertmanagerSpec
 
-Specification of the desired behavior of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+AlertmanagerSpec is a specification of the desired behavior of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -121,7 +121,7 @@ Specification of the desired behavior of the Alertmanager cluster. More info: ht
 
 ## AlertmanagerStatus
 
-Most recent observed status of the Alertmanager cluster. Read-only. Not included when requesting from the apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+AlertmanagerStatus is the most recent observed status of the Alertmanager cluster. Read-only. Not included when requesting from the apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -168,7 +168,7 @@ Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 
 ## NamespaceSelector
 
-A selector for selecting namespaces either selecting all namespaces or a list of namespaces.
+NamespaceSelector is a selector for selecting either all namespaces or a list of namespaces.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -213,7 +213,7 @@ PrometheusRule defines alerting rules for a Prometheus instance
 
 ## PrometheusRuleList
 
-A list of PrometheusRules.
+PrometheusRuleList is a list of PrometheusRules.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -234,7 +234,7 @@ PrometheusRuleSpec contains specification parameters for a Rule.
 
 ## PrometheusSpec
 
-Specification of the desired behavior of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+PrometheusSpec is a specification of the desired behavior of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -277,7 +277,7 @@ Specification of the desired behavior of the Prometheus cluster. More info: http
 
 ## PrometheusStatus
 
-Most recent observed status of the Prometheus cluster. Read-only. Not included when requesting from the apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+PrometheusStatus is the most recent observed status of the Prometheus cluster. Read-only. Not included when requesting from the apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -397,7 +397,7 @@ ServiceMonitor defines monitoring for a set of services.
 
 ## ServiceMonitorList
 
-A list of ServiceMonitors.
+ServiceMonitorList is a list of ServiceMonitors.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -460,7 +460,7 @@ ThanosGCSSpec defines parameters for use of Google Cloud Storage (GCS) with Than
 
 ## ThanosS3Spec
 
-ThanosSpec defines parameters for of AWS Simple Storage Service (S3) with Thanos. (S3 compatible services apply as well)
+ThanosS3Spec defines parameters for of AWS Simple Storage Service (S3) with Thanos. (S3 compatible services apply as well)
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |

--- a/Documentation/network-policies.md
+++ b/Documentation/network-policies.md
@@ -48,8 +48,8 @@ networkpolicy "prometheus" configured
 
 #### Alertmanager
 
-* Allow inbound tcp dst port 9093 from any source to alertmanager  
-* Allow inbound tcp dst port 6783 from only alertmanager to alertmanager 
+* Allow inbound tcp dst port 9093 from any source to alertmanager
+* Allow inbound tcp & udp dst port 9094 from only alertmanager to alertmanager
  
 [embedmd]:# (../example/networkpolicies/alertmanager.yaml)
 ```yaml
@@ -86,8 +86,10 @@ spec:
           values:
           - main
     ports:
-    - port: 6783
+    - port: 9094
       protocol: tcp
+    - port: 9094
+      protocol: udp
   podSelector:
     matchLabels:
       alertmanager: main

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ Documentation/api.md: $(PO_DOCGEN_BINARY) pkg/client/monitoring/v1/types.go
 Documentation/compatibility.md: $(PO_DOCGEN_BINARY) pkg/prometheus/statefulset.go
 	$(PO_DOCGEN_BINARY) compatibility > $@
 
-$(TO_BE_EXTENDED_DOCS): $(EMBEDMD_BINARY) $(shell find example) kube-prometheus
+$(TO_BE_EXTENDED_DOCS): $(EMBEDMD_BINARY) $(shell find example -type f) kube-prometheus
 	$(EMBEDMD_BINARY) -w `find Documentation -name "*.md" | grep -v vendor`
 
 

--- a/example/networkpolicies/alertmanager.yaml
+++ b/example/networkpolicies/alertmanager.yaml
@@ -31,8 +31,10 @@ spec:
           values:
           - main
     ports:
-    - port: 6783
+    - port: 9094
       protocol: tcp
+    - port: 9094
+      protocol: udp
   podSelector:
     matchLabels:
       alertmanager: main

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -344,7 +344,7 @@ func TestMakeStatefulSetSpecPeerFlagPort(t *testing.T) {
 
 		for _, arg := range amArgs {
 			if strings.Contains(arg, ".peer") {
-				if strings.Contains(arg, ":6783") != test.portNeeded {
+				if strings.Contains(arg, ":"+string(alertmanagerGossipPort)) != test.portNeeded {
 					t.Fatalf("expected arg '%v' containing port specification to be: %v", arg, test.portNeeded)
 				}
 			}


### PR DESCRIPTION
The Alertmanager upstream default port is 9094. This patch brings the
Proemtheus Operator project inline with the upstream default.

Fixes #1574 