### PR TITLE
'kubectl create' example needs -R flag

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -57,7 +57,7 @@ Although this project is intended to be used as a library, a compiled version of
 Simply create the stack:
 
 ```
-$ kubectl create -f manifests/
+$ kubectl create -R -f manifests/
 ```
 
 ## Usage


### PR DESCRIPTION
To apply all of the manifests in a directory recursively, the `-R` flag is needed, or else kubectl errors out like

```
$ kubectl create -f manifests/
error: error reading [manifests/]: recognized file extensions are [.json .yaml .yml]
```