### PR TITLE
bundle.yaml: Bump Prometheus Operator memory request and limit

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -70,10 +70,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -108,10 +108,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -29,10 +29,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/example/non-rbac/prometheus-operator.yaml
+++ b/example/non-rbac/prometheus-operator.yaml
@@ -29,10 +29,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -29,10 +29,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -127,8 +127,8 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         ]) +
         container.mixin.securityContext.withAllowPrivilegeEscalation(false) +
         container.mixin.securityContext.withReadOnlyRootFilesystem(true) +
-        container.mixin.resources.withRequests({ cpu: '100m', memory: '50Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '200m', memory: '100Mi' });
+        container.mixin.resources.withRequests({ cpu: '100m', memory: '100Mi' }) +
+        container.mixin.resources.withLimits({ cpu: '200m', memory: '200Mi' });
 
       deployment.new('prometheus-operator', 1, operatorContainer, podLabels) +
       deployment.mixin.metadata.withNamespace($._config.namespace) +

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -165,6 +165,26 @@ func (f *Framework) setupPrometheusOperator(opImage string) error {
 	}
 	f.OperatorPod = &pl.Items[0]
 
+	err = k8sutil.WaitForCRDReady(f.MonClientV1.Prometheuses(v1.NamespaceAll).List)
+	if err != nil {
+		return errors.Wrap(err, "Prometheus CRD not ready: %v\n")
+	}
+
+	err = k8sutil.WaitForCRDReady(f.MonClientV1.ServiceMonitors(v1.NamespaceAll).List)
+	if err != nil {
+		return errors.Wrap(err, "ServiceMonitor CRD not ready: %v\n")
+	}
+
+	err = k8sutil.WaitForCRDReady(f.MonClientV1.PrometheusRules(v1.NamespaceAll).List)
+	if err != nil {
+		return errors.Wrap(err, "PrometheusRule CRD not ready: %v\n")
+	}
+
+	err = k8sutil.WaitForCRDReady(f.MonClientV1.Alertmanagers(v1.NamespaceAll).List)
+	if err != nil {
+		return errors.Wrap(err, "Alertmanager CRD not ready: %v\n")
+	}
+
 	return nil
 }
 

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -42,3 +42,20 @@ func (f *Framework) PrintPodLogs(ns, p string) error {
 
 	return nil
 }
+
+// GetRestartCount returns a map of container names and their restart counts for
+// a given pod.
+func (f *Framework) GetRestartCount(ns, podName string) (map[string]int32, error) {
+	pod, err := f.KubeClient.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrieve pod to get restart count")
+	}
+
+	restarts := map[string]int32{}
+
+	for _, status := range pod.Status.ContainerStatuses {
+		restarts[status.Name] = status.RestartCount
+	}
+
+	return restarts, nil
+}


### PR DESCRIPTION
When handling big Kubernetes objects, marshalling objects is memory
intense. This can be reproduced with the end-to-end test
`TestPrometheusRulesExceedingConfigMapLimit`. This patch doubles the
memory request and limit of the Prometheus Operator deployment to 100mb
and 200mb.