### PR TITLE
helm: Add grafana ldap configuration

### DIFF
--- a/helm/grafana/README.md
+++ b/helm/grafana/README.md
@@ -49,6 +49,7 @@ Parameter | Description | Default
 `ingress.labels` | Labels for Grafana Ingress | `{}`
 `ingress.hosts` | Grafana Ingress fully-qualified domain names | `[]`
 `ingress.tls` | TLS configuration for Grafana Ingress | `[]`
+`ldapSecret` | Secret name for LDAP config (key should be ldap.toml) | `""`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `resources` | Pod resource requests & limits | `{}`
 `service.annotations` | Annotations to be added to the Grafana Service | `{}`

--- a/helm/grafana/templates/grafana-deployment.yaml
+++ b/helm/grafana/templates/grafana-deployment.yaml
@@ -47,6 +47,11 @@ spec:
         - name: grafana-config
           mountPath: /etc/grafana
       {{- end }}
+      {{- if .Values.ldapSecret }}
+        - name: grafana-ldap
+          mountPath: /etc/grafana/ldap.toml
+          subPath: ldap.toml
+      {{- end }}
         ports:
         - name: web
           containerPort: 3000
@@ -124,4 +129,9 @@ spec:
         - name: {{ . }}
           configMap:
             name: {{ . }}
+      {{- end }}
+      {{- if .Values.ldapSecret }}
+        - name: grafana-ldap
+          secret:
+            secretName: {{ .Values.ldapSecret }}
       {{- end }}

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -44,6 +44,9 @@ mountGrafanaConfig: false
 adminUser: "admin"
 adminPassword: "admin"
 
+## Set secret name to use to get ldap config (key needs to be ldap.toml)
+ldapSecret:
+
 service:
 
   ## Annotations to be added to the Service


### PR DESCRIPTION
Allow LDAP secret for grafana LDAP authentication. This only allows a secret to be provided, not created, since it's not a great idea to have this in a configmap or checked in to your code at all, since it contains a bind user's password.