### PR TITLE
pkg: add flag to toggle CRD creation in operator

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -86,6 +86,7 @@ func init() {
 	flagset.BoolVar(&cfg.EnableValidation, "with-validation", true, "Include the validation spec in the CRD")
 	flagset.BoolVar(&cfg.DisableAutoUserGroup, "disable-auto-user-group", false, "Disables the Prometheus Operator setting the `runAsUser` and `fsGroup` fields in Pods.")
 	flagset.StringVar(&cfg.LogLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(availableLogLevels, ", ")))
+	flagset.BoolVar(&cfg.ManageCRDs, "manage-crds", true, "Manage all CRDs with the Prometheus Operator.")
 	flagset.Parse(os.Args[1:])
 
 }

--- a/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
@@ -2501,6 +2501,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "A",
                                   "step": 10
                               },
                               {
@@ -2509,6 +2510,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "B",
                                   "step": 10
                               },
                               {
@@ -2517,6 +2519,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "C",
                                   "step": 10
                               },
                               {
@@ -2525,6 +2528,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "D",
                                   "step": 10
                               },
                               {
@@ -2533,6 +2537,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "E",
                                   "step": 10
                               }
                           ],
@@ -2861,6 +2866,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "A",
                                   "step": 10
                               },
                               {
@@ -2869,6 +2875,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "B",
                                   "step": 10
                               },
                               {
@@ -2877,6 +2884,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "C",
                                   "step": 10
                               },
                               {
@@ -2885,6 +2893,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "D",
                                   "step": 10
                               },
                               {
@@ -2893,6 +2902,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "E",
                                   "step": 10
                               }
                           ],
@@ -3303,6 +3313,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "A",
                                   "step": 10
                               },
                               {
@@ -3311,6 +3322,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "B",
                                   "step": 10
                               },
                               {
@@ -3319,6 +3331,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "C",
                                   "step": 10
                               },
                               {
@@ -3327,6 +3340,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "D",
                                   "step": 10
                               },
                               {
@@ -3335,6 +3349,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "E",
                                   "step": 10
                               }
                           ],
@@ -3663,6 +3678,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "A",
                                   "step": 10
                               },
                               {
@@ -3671,6 +3687,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "B",
                                   "step": 10
                               },
                               {
@@ -3679,6 +3696,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "C",
                                   "step": 10
                               },
                               {
@@ -3687,6 +3705,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "D",
                                   "step": 10
                               },
                               {
@@ -3695,6 +3714,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "E",
                                   "step": 10
                               }
                           ],
@@ -4132,6 +4152,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "A",
                                   "step": 10
                               },
                               {
@@ -4140,6 +4161,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "B",
                                   "step": 10
                               },
                               {
@@ -4148,6 +4170,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "C",
                                   "step": 10
                               },
                               {
@@ -4156,6 +4179,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "D",
                                   "step": 10
                               },
                               {
@@ -4164,6 +4188,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "E",
                                   "step": 10
                               }
                           ],
@@ -4492,6 +4517,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "A",
                                   "step": 10
                               },
                               {
@@ -4500,6 +4526,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "B",
                                   "step": 10
                               },
                               {
@@ -4508,6 +4535,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "C",
                                   "step": 10
                               },
                               {
@@ -4516,6 +4544,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "D",
                                   "step": 10
                               },
                               {
@@ -4524,6 +4553,7 @@ items:
                                   "instant": true,
                                   "intervalFactor": 2,
                                   "legendFormat": "",
+                                  "refId": "E",
                                   "step": 10
                               }
                           ],
@@ -5696,14 +5726,14 @@ items:
                                   "refId": "A"
                               },
                               {
-                                  "expr": "sum by(container) (kube_pod_container_resource_requests_memory_bytes{job=\"kubelet\", namespace=\"$namespace\", pod=\"$pod\", container=\u007e\"$container\", container!=\"POD\"})",
+                                  "expr": "sum by(container) (kube_pod_container_resource_requests_memory_bytes{job=\"kube-state-metrics\", namespace=\"$namespace\", pod=\"$pod\", container=\u007e\"$container\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "Requested: {{ container }}",
                                   "refId": "B"
                               },
                               {
-                                  "expr": "sum by(container) (kube_pod_container_resource_limits_memory_bytes{job=\"kubelet\", namespace=\"$namespace\", pod=\"$pod\", container=\u007e\"$container\", container!=\"POD\"})",
+                                  "expr": "sum by(container) (kube_pod_container_resource_limits_memory_bytes{job=\"kube-state-metrics\", namespace=\"$namespace\", pod=\"$pod\", container=\u007e\"$container\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "Limit: {{ container }}",

--- a/contrib/kube-prometheus/manifests/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: grafana/grafana:5.1.0
+      - image: grafana/grafana:5.2.1
         name: grafana
         ports:
         - containerPort: 3000

--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -388,7 +388,7 @@ spec:
         kube_deployment_spec_replicas{job="kube-state-metrics"}
           !=
         kube_deployment_status_replicas_available{job="kube-state-metrics"}
-      for: 15m
+      for: 1h
       labels:
         severity: critical
     - alert: KubeStatefulSetReplicasMismatch

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -77,6 +77,7 @@ type Config struct {
 	CrdGroup                     string
 	EnableValidation             bool
 	DisableAutoUserGroup         bool
+	ManageCRDs                   bool
 }
 
 // New creates a new controller.
@@ -117,6 +118,7 @@ func New(c prometheusoperator.Config, logger log.Logger) (*Operator, error) {
 			Labels:                       c.Labels,
 			EnableValidation:             c.EnableValidation,
 			DisableAutoUserGroup:         c.DisableAutoUserGroup,
+			ManageCRDs:                   c.ManageCRDs,
 		},
 	}
 
@@ -171,9 +173,11 @@ func (c *Operator) Run(stopc <-chan struct{}) error {
 		}
 		level.Info(c.logger).Log("msg", "connection established", "cluster-version", v)
 
-		if err := c.createCRDs(); err != nil {
-			errChan <- err
-			return
+		if c.config.ManageCRDs {
+			if err := c.createCRDs(); err != nil {
+				errChan <- err
+				return
+			}
 		}
 		errChan <- nil
 	}()

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -320,7 +320,9 @@ func (c *Operator) Run(stopc <-chan struct{}) error {
 	go c.cmapInf.Run(stopc)
 	go c.secrInf.Run(stopc)
 	go c.ssetInf.Run(stopc)
-	go c.nsInf.Run(stopc)
+	if c.config.Namespace == v1.NamespaceAll {
+		go c.nsInf.Run(stopc)
+	}
 
 	if c.kubeletSyncEnabled {
 		go c.reconcileNodeEndpoints(stopc)

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -136,6 +136,7 @@ type Config struct {
 	EnableValidation             bool
 	DisableAutoUserGroup         bool
 	LogLevel                     string
+	ManageCRDs                   bool
 }
 
 type BasicAuthCredentials struct {
@@ -292,9 +293,11 @@ func (c *Operator) Run(stopc <-chan struct{}) error {
 		}
 		level.Info(c.logger).Log("msg", "connection established", "cluster-version", v)
 
-		if err := c.createCRDs(); err != nil {
-			errChan <- errors.Wrap(err, "creating CRDs failed")
-			return
+		if c.config.ManageCRDs {
+			if err := c.createCRDs(); err != nil {
+				errChan <- errors.Wrap(err, "creating CRDs failed")
+				return
+			}
 		}
 		errChan <- nil
 	}()


### PR DESCRIPTION
In certain Prometheus Operator deployment scenarios it is desirable to
manage CRD creation outside of the operator. Likewise, it can be
desirable to scope the permissions of the Prometheus Operator so that it
does not have cluster-level access. This commit enables operation in
these situations by adding a flag to configure whether or not the
Prometheus Operator should try to create CRDs itself.