### PR TITLE
pkg/prometheus: fix web console libraries path

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -296,7 +296,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 
 	promArgs := []string{
 		"-web.console.templates=/etc/prometheus/consoles",
-		"-web.console.libraries=/etc/prometheus/console-libraries",
+		"-web.console.libraries=/etc/prometheus/console_libraries",
 	}
 
 	var securityContext *v1.PodSecurityContext


### PR DESCRIPTION
this corrects the location of the console libraries in the default prometheus image

Fixes #1460