### PR TITLE
Add documentation bit about ignoring controlplane targets on managed K8s

### DIFF
--- a/helm/kube-prometheus/README.md
+++ b/helm/kube-prometheus/README.md
@@ -5,3 +5,18 @@ This is the helm chart equivalent of `contrib/kube-prometheus`.
 # Prerequisites
 
 Requires helm >= 2.5.0
+
+# Installing on GKE/EKS/AKS
+
+Since the controlplane is managed in these solutions, make sure you tell prometheus to not monitor the scheduler or controller-manager:
+
+```
+deployKubeScheduler: False
+deployKubeControllerManager: False
+```
+
+Then install your custom values (for example):
+
+```
+helm upgrade --install kube-prometheus coreos/kube-prometheus --namespace monitoring -f /root/.helm/kube-prometheus-values.yml"
+```


### PR DESCRIPTION
I am fairly familiar with prometheus-operator and it took me a little digging to notice what these flags did so I think it would be useful to document it for new users. Maybe it belongs in Documentation?