### PR TITLE
pkg/client/monitoring: spelling mistake

### DIFF
--- a/pkg/client/monitoring/v1/alertmanager_test.go
+++ b/pkg/client/monitoring/v1/alertmanager_test.go
@@ -26,7 +26,7 @@ import (
 
 // TestAlertmanagerUnstructuredTimestamps ensures that an Alertmanager with many
 // default values can be converted into an Unstructured which would be valid to
-// POST (this is primarily to ensure that creationTimestamp is ommited).
+// POST (this is primarily to ensure that creationTimestamp is omitted).
 func TestAlertmanagerUnstructuredTimestamps(t *testing.T) {
 	p := &Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/client/monitoring/v1/prometheus_test.go
+++ b/pkg/client/monitoring/v1/prometheus_test.go
@@ -26,7 +26,7 @@ import (
 
 // TestPrometheusUnstructuredTimestamps ensures that a Prometheus with many
 // default values can be converted into an Unstructured which would be valid to
-// POST (this is primarily to ensure that creationTimestamp is ommited).
+// POST (this is primarily to ensure that creationTimestamp is omitted).
 func TestPrometheusUnstructuredTimestamps(t *testing.T) {
 	p := &Prometheus{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
small fix suggested from goreportcard.

cc @mxinden 