### PR TITLE
helm: Update prometheus to v2.3.2

### DIFF
--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.50
+    version: 0.0.51
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -21,7 +21,7 @@ deployKubeState: True
 global:
   rbacEnable: true
   pspEnable: true
-  
+
   # Reference to one or more secrets to be used when pulling images
   imagePullSecrets: []
   #  - name: "image-pull-secret"
@@ -189,10 +189,10 @@ prometheus:
   externalUrl: ""
 
   ## Prometheus container image
-  ##
+  ## Keep in sync with version in helm/prometheus/values.yaml
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.2.1
+    tag: v2.3.2
 
   ingress:
     ## If true, Prometheus Ingress will be created

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.50
+version: 0.0.51
 

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -43,7 +43,7 @@ additionalRulesLabels: {}
 ##
 image:
   repository: quay.io/prometheus/prometheus
-  tag: v2.2.1
+  tag: v2.3.2
 
 ## Labels to be added to the Prometheus
 ##


### PR DESCRIPTION
This one might depend on https://github.com/coreos/prometheus-operator/pull/1670 I'll rebase it when https://github.com/coreos/prometheus-operator/pull/1670 got merged.