### PR TITLE
metrics-server: enable access to nodes/stats

### DIFF
--- a/contrib/kube-prometheus/experimental/metrics-server/metrics-server-cluster-role.yaml
+++ b/contrib/kube-prometheus/experimental/metrics-server/metrics-server-cluster-role.yaml
@@ -8,6 +8,7 @@ rules:
   resources:
   - pods
   - nodes
+  - nodes/stats
   - namespaces
   verbs:
   - get


### PR DESCRIPTION
Without this access the logs of metrics-server will show the following error line:
```
unable to fully scrape metrics from source kubelet_summary:k8s-1: unable to fetch metrics from Kubelet k8s-1 (10.8.10.14): request failed - "403 Forbidden", response: "Forbidden (user=system:serviceaccount:kube-system:metrics-server, verb=get, resource=nodes, subresource=stats)",
```
and `kubectl top nodes` will give no results