### PR TITLE
cmd/operator: add process collector

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -130,7 +130,10 @@ func Main() int {
 	logger.Log("msg", fmt.Sprintf("Starting Prometheus Operator version '%v'.", version.Version))
 
 	r := prometheus.NewRegistry()
-	r.MustRegister(prometheus.NewGoCollector())
+	r.MustRegister(
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(os.Getpid(), ""),
+	)
 
 	po, err := prometheuscontroller.New(cfg, log.With(logger, "component", "prometheusoperator"))
 	if err != nil {


### PR DESCRIPTION
As noted in
https://github.com/openshift/cluster-monitoring-operator/pull/52#discussion_r204747221,
the Prometheus Operator should also register process metrics.

cc @brancz 