### PR TITLE
Update GKE kubelet scraping docs

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -362,6 +362,8 @@ Should the Prometheus `/targets` page show kubelet targets, but not able to succ
 
 As described in the [prerequisites](#prerequisites) section, in order to retrieve metrics from the kubelet token authentication and authorization must be enabled. Some Kubernetes setup tools do not enable this by default.
 
+If you are using Google's GKE product, see [docs/GKE-cadvisor-support.md].
+
 #### Authentication problem
 
 The Prometheus `/targets` page will show the kubelet job with the error `403 Unauthorized`, when token authentication is not enabled. Ensure, that the `--authentication-token-webhook=true` flag is enabled on all kubelet configurations.

--- a/contrib/kube-prometheus/docs/GKE-cadvisor-support.md
+++ b/contrib/kube-prometheus/docs/GKE-cadvisor-support.md
@@ -1,7 +1,22 @@
-# Kubelet / cAdvisor special configuration updates for GKE 
+# Kubelet / cAdvisor special configuration updates for GKE
 
-In order to allow Prometheus to access the endpoints provided by the kubelet/cAdvisor on GKE we have to downgrade the scheme to HTTP (from HTTPS).
+Prior to GKE 1.11, the kubelet does not support token
+authentication. Until it does, Prometheus must use HTTP (not HTTPS)
+for scraping.
 
+You can configure this behavior through kube-prometheus with:
+```
+local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
+    (import 'kube-prometheus/kube-prometheus-insecure-kubelet.libsonnet') +
+	{
+        _config+:: {
+		...
+		}
+    };
+{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) }
+```
+
+Or, you can patch and re-apply your existing manifests with:
 
 On linux:
 
@@ -10,9 +25,9 @@ sed -i -e 's/https/http/g' \
 contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-monitor-kubelet.yaml
 ```
 
-On MacOs: 
+On MacOs:
 
-``` 
+```
 sed -i '' -e 's/https/http/g' \
 contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-service-monitor-kubelet.yaml
 ```

--- a/contrib/kube-prometheus/docs/GKE-cadvisor-support.md
+++ b/contrib/kube-prometheus/docs/GKE-cadvisor-support.md
@@ -10,10 +10,9 @@ local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
     (import 'kube-prometheus/kube-prometheus-insecure-kubelet.libsonnet') +
 	{
         _config+:: {
-		...
+		# ... config here
 		}
     };
-{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) }
 ```
 
 Or, you can patch and re-apply your existing manifests with:


### PR DESCRIPTION
Chatting in https://github.com/coreos/prometheus-operator/issues/1623 it sounds like prior to 1.11, downgrading to https _is_ the correct approach.

This adds the jsonnet approach to to the docs, and adds a reference to it from the README