### PR TITLE
adjust rbac apiGroups to support core workloads api apps/v1

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -74,6 +74,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                        policyRule.withApiGroups(['apps']) +
                        policyRule.withResources([
                          'statefulsets',
+                         'daemonsets',
+                         'deployments',
+                         'replicasets',
                        ]) +
                        policyRule.withVerbs(['list', 'watch']);
 
@@ -222,7 +225,15 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                              policyRule.withVerbs(['get', 'update']) +
                              policyRule.withResourceNames(['kube-state-metrics']);
 
-      local rules = [coreRule, extensionsRule];
+      local appsRule = policyRule.new() +
+                       policyRule.withApiGroups(['apps']) +
+                       policyRule.withResources([
+                         'deployments',
+                       ]) +
+                       policyRule.withVerbs(['get', 'update']) +
+                       policyRule.withResourceNames(['kube-state-metrics']);
+
+      local rules = [coreRule, extensionsRule, appsRule];
 
       role.new() +
       role.mixin.metadata.withName('kube-state-metrics') +

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
@@ -34,6 +34,9 @@ rules:
   - apps
   resources:
   - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-role.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-role.yaml
@@ -19,3 +19,12 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - apps
+  resourceNames:
+  - kube-state-metrics
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update


### PR DESCRIPTION
Add `apps` to apiGroups for daemonsets, deployments, and replicasets to support core workloads api `apps/v1`.
https://kubernetes.io/blog/2018/01/core-workloads-api-ga/

Tested on Kubernetes:
```
Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.3", GitCommit:"2bba0127d85d5a46ab4b778548be28623b32d0b0", GitTreeState:"clean", BuildDate:"2018-05-21T09:05:37Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
```