### PR TITLE
Jsonnet locking

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -59,7 +59,6 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.22.2
         image: quay.io/coreos/prometheus-operator:v0.22.2
@@ -70,13 +69,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 200Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 100Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+            memory: 50Mi
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:

--- a/contrib/kube-prometheus/.gitignore
+++ b/contrib/kube-prometheus/.gitignore
@@ -1,5 +1,4 @@
 tmp/
 minikube-manifests/
-jsonnetfile.lock.json
 vendor/
 ./auth

--- a/contrib/kube-prometheus/Makefile
+++ b/contrib/kube-prometheus/Makefile
@@ -30,7 +30,7 @@ manifests: vendor example.jsonnet build.sh
 	rm -rf manifests
 	./build.sh
 
-vendor: $(JB_BINARY) jsonnetfile.json
+vendor: $(JB_BINARY) jsonnetfile.json jsonnetfile.lock.json
 	rm -rf vendor
 	$(JB_BINARY) install
 

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "master"
+            "version": "v0.22.2"
         },
         {
             "name": "etcd-mixin",

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "."
+            "version": "ca9cf6257548c30a6d3d6e926f38498f96cc3525"
         }
     ]
 }

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "ca9cf6257548c30a6d3d6e926f38498f96cc3525"
+            "version": "2169c4435497eb9d1420e7be19b2a0aefaa0135e"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
@@ -23,8 +23,8 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
-          description: 'AlertmanagerSpec is a specification of the desired behavior
-            of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'Specification of the desired behavior of the Alertmanager
+            cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             affinity:
               description: Affinity is a group of affinity scheduling rules.
@@ -2372,9 +2372,9 @@ spec:
               description: Version the cluster should be on.
               type: string
         status:
-          description: 'AlertmanagerStatus is the most recent observed status of the
-            Alertmanager cluster. Read-only. Not included when requesting from the
-            apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'Most recent observed status of the Alertmanager cluster. Read-only.
+            Not included when requesting from the apiserver, only from the Prometheus
+            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             availableReplicas:
               description: Total number of available pods (ready for at least minReadySeconds)

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
@@ -23,8 +23,8 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
-          description: 'PrometheusSpec is a specification of the desired behavior
-            of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'Specification of the desired behavior of the Prometheus cluster.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             additionalAlertManagerConfigs:
               description: SecretKeySelector selects a key of a Secret.
@@ -671,76 +671,6 @@ spec:
                   type: array
               required:
               - alertmanagers
-            apiserverConfig:
-              description: 'APIServerConfig defines a host and auth methods to access
-                apiserver. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config'
-              properties:
-                basicAuth:
-                  description: 'BasicAuth allow an endpoint to authenticate over basic
-                    authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
-                  properties:
-                    password:
-                      description: SecretKeySelector selects a key of a Secret.
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or it's key must
-                            be defined
-                          type: boolean
-                      required:
-                      - key
-                    username:
-                      description: SecretKeySelector selects a key of a Secret.
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or it's key must
-                            be defined
-                          type: boolean
-                      required:
-                      - key
-                bearerToken:
-                  description: Bearer token for accessing apiserver.
-                  type: string
-                bearerTokenFile:
-                  description: File to read bearer token for accessing apiserver.
-                  type: string
-                host:
-                  description: Host of apiserver. A valid string consisting of a hostname
-                    or IP followed by an optional port number
-                  type: string
-                tlsConfig:
-                  description: TLSConfig specifies TLS configuration parameters.
-                  properties:
-                    caFile:
-                      description: The CA cert to use for the targets.
-                      type: string
-                    certFile:
-                      description: The client cert file for the targets.
-                      type: string
-                    insecureSkipVerify:
-                      description: Disable target certificate validation.
-                      type: boolean
-                    keyFile:
-                      description: The client key file for the targets.
-                      type: string
-                    serverName:
-                      description: Used to verify the hostname for the targets.
-                      type: string
-              required:
-              - host
             baseImage:
               description: Base image to use for a Prometheus deployment.
               type: string
@@ -2932,7 +2862,7 @@ spec:
                   description: Peers is a DNS name for Thanos to discover peers through.
                   type: string
                 s3:
-                  description: ThanosS3Spec defines parameters for of AWS Simple Storage
+                  description: ThanosSpec defines parameters for of AWS Simple Storage
                     Service (S3) with Thanos. (S3 compatible services apply as well)
                   properties:
                     accessKey:
@@ -3031,9 +2961,9 @@ spec:
               description: Version of Prometheus to be deployed.
               type: string
         status:
-          description: 'PrometheusStatus is the most recent observed status of the
-            Prometheus cluster. Read-only. Not included when requesting from the apiserver,
-            only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'Most recent observed status of the Prometheus cluster. Read-only.
+            Not included when requesting from the apiserver, only from the Prometheus
+            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             availableReplicas:
               description: Total number of available pods (ready for at least minReadySeconds)

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
@@ -169,7 +169,7 @@ spec:
               description: The label to use to retrieve the job name from.
               type: string
             namespaceSelector:
-              description: NamespaceSelector is a selector for selecting either all
+              description: A selector for selecting namespaces either selecting all
                 namespaces or a list of namespaces.
               properties:
                 any:

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -18,7 +18,6 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.22.2
         image: quay.io/coreos/prometheus-operator:v0.22.2
@@ -29,13 +28,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 200Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 100Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+            memory: 50Mi
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
@@ -34,9 +34,6 @@ rules:
   - apps
   resources:
   - statefulsets
-  - daemonsets
-  - deployments
-  - replicasets
   verbs:
   - list
   - watch

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
@@ -34,6 +34,9 @@ rules:
   - apps
   resources:
   - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-role.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-role.yaml
@@ -19,3 +19,12 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - apps
+  resourceNames:
+  - kube-state-metrics
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-role.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-role.yaml
@@ -19,12 +19,3 @@ rules:
   verbs:
   - get
   - update
-- apiGroups:
-  - apps
-  resourceNames:
-  - kube-state-metrics
-  resources:
-  - deployments
-  verbs:
-  - get
-  - update


### PR DESCRIPTION
This pull request introduces all the changes necessary to properly lock against jsonnet dependencies with jsonnet-bundler. It also locks the prometheus-operator dependency against `v0.22.2` in kube-prometheus.

The pull request to implement this in jsonnet-bundler is still pending, but will be merged should CI succeed here. Then I will revert the second commit of this pull request.

@mxinden @squat @metalmatze 