### PR TITLE
[helm] PrometheusLabelValue Can Change Prometheus Name

### DIFF
--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.50
+version: 0.0.52
 

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-  name: {{ template "prometheus.fullname" . }}
+  name: {{ default (include "prometheus.fullname" .) .Values.prometheusLabelValue }}
 spec:
 {{- if .Values.labels }}
   podMetadata:


### PR DESCRIPTION
Older versions of the operator had a different way of naming resources created. Previously the prometheus pods were called `mcon-prometheus-0`, now they are called `prometheus-mcon-prometheus-0`... this change allows for the older behavior, if using `.Values.prometheusLabelValue`.