### PR TITLE
client-go/informers: Add namespace indexer to SharedIndexInformers (-> `master`)

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -197,7 +197,7 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 			ListFunc:  mclient.MonitoringV1().Prometheuses(c.config.Namespace).List,
 			WatchFunc: mclient.MonitoringV1().Prometheuses(c.config.Namespace).Watch,
 		},
-		&monitoringv1.Prometheus{}, resyncPeriod, cache.Indexers{},
+		&monitoringv1.Prometheus{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	c.promInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.handleAddPrometheus,
@@ -210,7 +210,7 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 			ListFunc:  mclient.MonitoringV1().ServiceMonitors(c.config.Namespace).List,
 			WatchFunc: mclient.MonitoringV1().ServiceMonitors(c.config.Namespace).Watch,
 		},
-		&monitoringv1.ServiceMonitor{}, resyncPeriod, cache.Indexers{},
+		&monitoringv1.ServiceMonitor{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	c.smonInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.handleSmonAdd,
@@ -223,7 +223,7 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 			ListFunc:  mclient.MonitoringV1().PrometheusRules(c.config.Namespace).List,
 			WatchFunc: mclient.MonitoringV1().PrometheusRules(c.config.Namespace).Watch,
 		},
-		&monitoringv1.PrometheusRule{}, resyncPeriod, cache.Indexers{},
+		&monitoringv1.PrometheusRule{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	c.ruleInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.handleRuleAdd,
@@ -233,7 +233,7 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 
 	c.cmapInf = cache.NewSharedIndexInformer(
 		cache.NewListWatchFromClient(c.kclient.Core().RESTClient(), "configmaps", c.config.Namespace, fields.Everything()),
-		&v1.ConfigMap{}, resyncPeriod, cache.Indexers{},
+		&v1.ConfigMap{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	c.cmapInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.handleConfigMapAdd,
@@ -242,7 +242,7 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 	})
 	c.secrInf = cache.NewSharedIndexInformer(
 		cache.NewListWatchFromClient(c.kclient.Core().RESTClient(), "secrets", c.config.Namespace, fields.Everything()),
-		&v1.Secret{}, resyncPeriod, cache.Indexers{},
+		&v1.Secret{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	c.secrInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.handleSecretAdd,
@@ -252,7 +252,7 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 
 	c.ssetInf = cache.NewSharedIndexInformer(
 		cache.NewListWatchFromClient(c.kclient.AppsV1beta2().RESTClient(), "statefulsets", c.config.Namespace, fields.Everything()),
-		&appsv1.StatefulSet{}, resyncPeriod, cache.Indexers{},
+		&appsv1.StatefulSet{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	c.ssetInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.handleAddStatefulSet,


### PR DESCRIPTION
`client-go/tools/cache.ListAllByNamespace` tries to search the given
cache by the namespace index. If that index is not present, it logs a
warning message and iterates over the objects itself [1].

Initially to remove the log line, but as a side effect also to improve query
speed, this patch adds the namespace index to all used SharedIndexInformers in
the Prometheus and Alertmanager operator.

[1]
```
items, err := indexer.Index(NamespaceIndex, &metav1.ObjectMeta{Namespace: namespace})
if err != nil {
	// Ignore error; do slow search without index.
	glog.Warningf("can not retrieve list of objects using index : %v", err)
	for _, m := range indexer.List() {
```