### PR TITLE
helm: support configurable podAntiAffinityTopologyKey

### DIFF
--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -8,7 +8,7 @@ name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://github.com/prometheus/alertmanager
-version: 0.1.6
+version: 0.1.7
 appVersion: "0.15.1"
 home: https://github.com/prometheus/alertmanager 
 keywords:

--- a/helm/alertmanager/README.md
+++ b/helm/alertmanager/README.md
@@ -57,6 +57,7 @@ Parameter | Description | Default
 `nodeSelector` | Node labels for pod assignment | `{}`
 `paused` | If true, the Operator won't process any Alertmanager configuration changes | `false`
 `podAntiAffinity` | If "soft", the scheduler attempts to place Alertmanager replicas on different nodes. If "hard" the scheduler is required to place them on different nodes. If "" (empty) then no anti-affinity rules will be configured. | `soft`
+`podAntiAffinityTopologyKey` | TopologyKey determines how Kubernetes will distribute the pods | `kubernetes.io/hostname`
 `prometheusRules` | Prometheus rules | `[templates/alertmanager.rules.yaml](templates/alertmanager.rules.yaml)`
 `replicaCount` | Number of Alertmanager replicas desired | `1`
 `resources` | Pod resource requests & limits | `{}`

--- a/helm/alertmanager/templates/alertmanager.yaml
+++ b/helm/alertmanager/templates/alertmanager.yaml
@@ -37,7 +37,7 @@ spec:
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - topologyKey: kubernetes.io/hostname
+      - topologyKey: {{ .Values.podAntiAffinityTopologyKey }}
         labelSelector:
           matchLabels:
             app: {{ template "alertmanager.name" . }}
@@ -48,7 +48,7 @@ spec:
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100
         podAffinityTerm:
-          topologyKey: kubernetes.io/hostname
+          topologyKey: {{ .Values.podAntiAffinityTopologyKey }}
           labelSelector:
             matchLabels:
               app: {{ template "alertmanager.name" . }}

--- a/helm/alertmanager/values.yaml
+++ b/helm/alertmanager/values.yaml
@@ -134,6 +134,10 @@ replicaCount: 1
 ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
 podAntiAffinity: "soft"
 
+## Pod anti-affinity topologyKey determines how pods are distributed in the cluster. 
+## The default value "kubernetes.io/hostname" means that pods will be distributed across nodes
+podAntiAffinityTopologyKey: kubernetes.io/hostname
+
 ## Resource limits & requests
 ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ##

--- a/helm/kube-prometheus/Chart.yaml
+++ b/helm/kube-prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.105
+version: 0.0.106

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -108,6 +108,10 @@ alertmanager:
   ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
   podAntiAffinity: "soft"
 
+  ## Pod anti-affinity topologyKey determines how pods are distributed in the cluster. 
+  ## The default value "kubernetes.io/hostname" means that pods will be distributed across nodes
+  podAntiAffinityTopologyKey: kubernetes.io/hostname
+
   ## Resource limits & requests
   ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.50
+version: 0.0.51
 

--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -58,6 +58,7 @@ Parameter | Description | Default
 `nodeSelector` | Node labels for pod assignment | `{}`
 `paused` | If true, the Operator won't process any Prometheus configuration changes | `false`
 `podAntiAffinity` | If "soft", the scheduler attempts to place Prometheus replicas on different nodes. If "hard" the scheduler is required to place them on different nodes. If "" (empty) then no anti-affinity rules will be configured. | `soft`
+`podAntiAffinityTopologyKey` | TopologyKey determines how Kubernetes will distribute the pods | `kubernetes.io/hostname`
 `prometheusRules` | Prometheus rules | `[templates/prometheus.rules.yaml](templates/prometheus.rules.yaml)`
 `replicaCount` | Number of Prometheus replicas desired | `1`
 `remoteRead` | The remote_read spec configuration for Prometheus | `{}`

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -117,7 +117,7 @@ spec:
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - topologyKey: kubernetes.io/hostname
+      - topologyKey: {{ .Values.podAntiAffinityTopologyKey }}
         labelSelector:
           matchLabels:
             app: {{ template "prometheus.name" . }}
@@ -128,7 +128,7 @@ spec:
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100
         podAffinityTerm:
-          topologyKey: kubernetes.io/hostname
+          topologyKey: {{ .Values.podAntiAffinityTopologyKey }}
           labelSelector:
             matchLabels:
               app: {{ template "prometheus.name" . }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -128,6 +128,10 @@ logLevel: info
 ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
 podAntiAffinity: "soft"
 
+## Pod anti-affinity topologyKey determines how pods are distributed in the cluster. 
+## The default value "kubernetes.io/hostname" means that pods will be distributed across nodes
+podAntiAffinityTopologyKey: kubernetes.io/hostname
+
 podMetadata:
   ## Annotations to be added to Prometheus pods
   ##


### PR DESCRIPTION
this gives user flexibility to determine how they want the pods to be distributed

Fixes #1715