### PR TITLE
prometheus: Improve metrics and stop reconciling on no update

### DIFF
--- a/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
@@ -4792,7 +4792,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "100 - (avg by (cpu) (irate(node_cpu{job=\"node-exporter\", mode=\"idle\", instance=\"$instance\"}[5m])) * 100)\n",
+                                  "expr": "1 - (avg by (cpu) (irate(node_cpu{job=\"node-exporter\", mode=\"idle\", instance=\"$instance\"}[5m])))\n",
                                   "format": "time_series",
                                   "intervalFactor": 10,
                                   "legendFormat": "{{cpu}}",
@@ -4822,18 +4822,18 @@ items:
                           },
                           "yaxes": [
                               {
-                                  "format": "percent",
+                                  "format": "percentunit",
                                   "label": null,
                                   "logBase": 1,
-                                  "max": 100,
+                                  "max": 1,
                                   "min": 0,
                                   "show": true
                               },
                               {
-                                  "format": "percent",
+                                  "format": "percentunit",
                                   "label": null,
                                   "logBase": 1,
-                                  "max": 100,
+                                  "max": 1,
                                   "min": 0,
                                   "show": true
                               }
@@ -4883,21 +4883,21 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "node_load1{job=\"node-exporter\", instance=\"$instance\"} * 100",
+                                  "expr": "max(node_load1{job=\"node-exporter\", instance=\"$instance\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "load 1m",
                                   "refId": "A"
                               },
                               {
-                                  "expr": "node_load5{job=\"node-exporter\", instance=\"$instance\"} * 100",
+                                  "expr": "max(node_load5{job=\"node-exporter\", instance=\"$instance\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "load 5m",
                                   "refId": "B"
                               },
                               {
-                                  "expr": "node_load15{job=\"node-exporter\", instance=\"$instance\"} * 100",
+                                  "expr": "max(node_load15{job=\"node-exporter\", instance=\"$instance\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "load 15m",
@@ -4927,7 +4927,7 @@ items:
                           },
                           "yaxes": [
                               {
-                                  "format": "percent",
+                                  "format": "percentunit",
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
@@ -4935,7 +4935,7 @@ items:
                                   "show": true
                               },
                               {
-                                  "format": "percent",
+                                  "format": "percentunit",
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
@@ -5002,28 +5002,28 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "node_memory_MemTotal{job=\"node-exporter\", instance=\"$instance\"}\n- node_memory_MemFree{job=\"node-exporter\", instance=\"$instance\"}\n- node_memory_Buffers{job=\"node-exporter\", instance=\"$instance\"}\n- node_memory_Cached{job=\"node-exporter\", instance=\"$instance\"}\n",
+                                  "expr": "max(\n  node_memory_MemTotal{job=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_MemFree{job=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Buffers{job=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Cached{job=\"node-exporter\", instance=\"$instance\"}\n)\n",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "memory used",
                                   "refId": "A"
                               },
                               {
-                                  "expr": "node_memory_Buffers{job=\"node-exporter\", instance=\"$instance\"}",
+                                  "expr": "max(node_memory_Buffers{job=\"node-exporter\", instance=\"$instance\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "memory buffers",
                                   "refId": "B"
                               },
                               {
-                                  "expr": "node_memory_Cached{job=\"node-exporter\", instance=\"$instance\"}",
+                                  "expr": "max(node_memory_Cached{job=\"node-exporter\", instance=\"$instance\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "memory cached",
                                   "refId": "C"
                               },
                               {
-                                  "expr": "node_memory_MemFree{job=\"node-exporter\", instance=\"$instance\"}",
+                                  "expr": "max(node_memory_MemFree{job=\"node-exporter\", instance=\"$instance\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "memory free",
@@ -5131,7 +5131,7 @@ items:
                           "tableColumn": "",
                           "targets": [
                               {
-                                  "expr": "(\n  node_memory_MemTotal{job=\"node-exporter\", instance=\"$instance\"}\n- node_memory_MemFree{job=\"node-exporter\", instance=\"$instance\"}\n- node_memory_Buffers{job=\"node-exporter\", instance=\"$instance\"}\n- node_memory_Cached{job=\"node-exporter\", instance=\"$instance\"}\n) * 100\n  /\nnode_memory_MemTotal{job=\"node-exporter\", instance=\"$instance\"}\n",
+                                  "expr": "max(\n  (\n    (\n      node_memory_MemTotal{job=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_MemFree{job=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Buffers{job=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Cached{job=\"node-exporter\", instance=\"$instance\"}\n    )\n    / node_memory_MemTotal{job=\"node-exporter\", instance=\"$instance\"}\n  ) * 100)\n",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": ""
@@ -5215,21 +5215,21 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum by (instance) (rate(node_disk_bytes_read{job=\"node-exporter\", instance=\"$instance\"}[2m]))",
+                                  "expr": "max(rate(node_disk_bytes_read{job=\"node-exporter\", instance=\"$instance\"}[2m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "read",
                                   "refId": "A"
                               },
                               {
-                                  "expr": "sum by (instance) (rate(node_disk_bytes_written{job=\"node-exporter\", instance=\"$instance\"}[2m]))",
+                                  "expr": "max(rate(node_disk_bytes_written{job=\"node-exporter\", instance=\"$instance\"}[2m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "written",
                                   "refId": "B"
                               },
                               {
-                                  "expr": "sum by (instance) (rate(node_disk_io_time_ms{job=\"node-exporter\",  instance=\"$instance\"}[2m]))",
+                                  "expr": "max(rate(node_disk_io_time_ms{job=\"node-exporter\",  instance=\"$instance\"}[2m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "io time",
@@ -5414,7 +5414,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "rate(node_network_receive_bytes{job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m])",
+                                  "expr": "max(rate(node_network_receive_bytes{job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{device}}",
@@ -5505,7 +5505,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "rate(node_network_transmit_bytes{job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m])",
+                                  "expr": "max(rate(node_network_transmit_bytes{job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{device}}",

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -98,7 +98,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                             policyRule.withResources([
                               'namespaces',
                             ]) +
-                            policyRule.withVerbs(['list', 'watch']);
+                            policyRule.withVerbs(['list', 'watch', 'get']);
 
       local rules = [apiExtensionsRule, monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule];
 

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -98,7 +98,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                             policyRule.withResources([
                               'namespaces',
                             ]) +
-                            policyRule.withVerbs(['list', 'watch', 'get']);
+                            policyRule.withVerbs(['list', 'watch']);
 
       local rules = [apiExtensionsRule, monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule];
 

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -72,6 +72,12 @@ type Operator struct {
 
 	statefulsetErrors prometheus.Counter
 
+	// triggerByCounterVec is a set of counters keeping track of the amount of
+	// times Prometheus Operator was triggered to reconcile its created objects. It
+	// is split in the dimensions of Kubernetes objects and corresponding actions
+	// (add, delete, update).
+	triggerByCounterVec *prometheus.CounterVec
+
 	host                   string
 	kubeletObjectName      string
 	kubeletObjectNamespace string
@@ -205,9 +211,9 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 		&monitoringv1.Prometheus{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	c.promInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.handleAddPrometheus,
-		DeleteFunc: c.handleDeletePrometheus,
-		UpdateFunc: c.handleUpdatePrometheus,
+		AddFunc:    c.handlePrometheusAdd,
+		DeleteFunc: c.handlePrometheusDelete,
+		UpdateFunc: c.handlePrometheusUpdate,
 	})
 
 	c.smonInf = cache.NewSharedIndexInformer(
@@ -260,9 +266,9 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 		&appsv1.StatefulSet{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	c.ssetInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.handleAddStatefulSet,
-		DeleteFunc: c.handleDeleteStatefulSet,
-		UpdateFunc: c.handleUpdateStatefulSet,
+		AddFunc:    c.handleStatefulSetAdd,
+		DeleteFunc: c.handleStatefulSetDelete,
+		UpdateFunc: c.handleStatefulSetUpdate,
 	})
 
 	c.nsInf = cache.NewSharedIndexInformer(
@@ -273,14 +279,24 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 	return c, nil
 }
 
+// RegisterMetrics registers Prometheus metrics on the given Prometheus registerer.
 func (c *Operator) RegisterMetrics(r prometheus.Registerer) {
 	c.statefulsetErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_prometheus_reconcile_errors_total",
 		Help: "Number of errors that occurred while reconciling the alertmanager statefulset",
 	})
 
+	c.triggerByCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_operator_triggered_total",
+		Help: "Number of times a Kubernetes object add, delete or update event" +
+			" triggered Prometheus Operator to reconcile an object",
+	},
+		[]string{"triggered_by", "action"},
+	)
+
 	r.MustRegister(
 		c.statefulsetErrors,
+		c.triggerByCounterVec,
 		NewPrometheusCollector(c.promInf.GetStore()),
 	)
 }
@@ -346,33 +362,40 @@ func (c *Operator) keyFunc(obj interface{}) (string, bool) {
 	return k, true
 }
 
-func (c *Operator) handleAddPrometheus(obj interface{}) {
+func (c *Operator) handlePrometheusAdd(obj interface{}) {
 	key, ok := c.keyFunc(obj)
 	if !ok {
 		return
 	}
 
 	level.Debug(c.logger).Log("msg", "Prometheus added", "key", key)
+	c.triggerByCounterVec.WithLabelValues(monitoringv1.PrometheusesKind, "add").Inc()
 	c.enqueue(key)
 }
 
-func (c *Operator) handleDeletePrometheus(obj interface{}) {
+func (c *Operator) handlePrometheusDelete(obj interface{}) {
 	key, ok := c.keyFunc(obj)
 	if !ok {
 		return
 	}
 
 	level.Debug(c.logger).Log("msg", "Prometheus deleted", "key", key)
+	c.triggerByCounterVec.WithLabelValues(monitoringv1.PrometheusesKind, "delete").Inc()
 	c.enqueue(key)
 }
 
-func (c *Operator) handleUpdatePrometheus(old, cur interface{}) {
+func (c *Operator) handlePrometheusUpdate(old, cur interface{}) {
+	if old.(*monitoringv1.Prometheus).ResourceVersion == cur.(*monitoringv1.Prometheus).ResourceVersion {
+		return
+	}
+
 	key, ok := c.keyFunc(cur)
 	if !ok {
 		return
 	}
 
 	level.Debug(c.logger).Log("msg", "Prometheus updated", "key", key)
+	c.triggerByCounterVec.WithLabelValues(monitoringv1.PrometheusesKind, "update").Inc()
 	c.enqueue(key)
 }
 
@@ -502,14 +525,24 @@ func (c *Operator) syncNodeEndpoints() error {
 func (c *Operator) handleSmonAdd(obj interface{}) {
 	o, ok := c.getObject(obj)
 	if ok {
+		level.Debug(c.logger).Log("msg", "ServiceMonitor added")
+		c.triggerByCounterVec.WithLabelValues(monitoringv1.ServiceMonitorsKind, "add").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
 
 // TODO: Don't enque just for the namespace
 func (c *Operator) handleSmonUpdate(old, cur interface{}) {
+	if old.(*monitoringv1.ServiceMonitor).ResourceVersion == cur.(*monitoringv1.ServiceMonitor).ResourceVersion {
+		return
+	}
+
 	o, ok := c.getObject(cur)
 	if ok {
+		level.Debug(c.logger).Log("msg", "ServiceMonitor updated")
+		c.triggerByCounterVec.WithLabelValues(monitoringv1.ServiceMonitorsKind, "update").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
@@ -518,6 +551,9 @@ func (c *Operator) handleSmonUpdate(old, cur interface{}) {
 func (c *Operator) handleSmonDelete(obj interface{}) {
 	o, ok := c.getObject(obj)
 	if ok {
+		level.Debug(c.logger).Log("msg", "ServiceMonitor delete")
+		c.triggerByCounterVec.WithLabelValues(monitoringv1.ServiceMonitorsKind, "delete").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
@@ -526,14 +562,24 @@ func (c *Operator) handleSmonDelete(obj interface{}) {
 func (c *Operator) handleRuleAdd(obj interface{}) {
 	o, ok := c.getObject(obj)
 	if ok {
+		level.Debug(c.logger).Log("msg", "PrometheusRule added")
+		c.triggerByCounterVec.WithLabelValues(monitoringv1.ServiceMonitorsKind, "add").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
 
 // TODO: Don't enque just for the namespace
 func (c *Operator) handleRuleUpdate(old, cur interface{}) {
+	if old.(*monitoringv1.PrometheusRule).ResourceVersion == cur.(*monitoringv1.PrometheusRule).ResourceVersion {
+		return
+	}
+
 	o, ok := c.getObject(cur)
 	if ok {
+		level.Debug(c.logger).Log("msg", "PrometheusRule updated")
+		c.triggerByCounterVec.WithLabelValues(monitoringv1.ServiceMonitorsKind, "update").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
@@ -542,6 +588,9 @@ func (c *Operator) handleRuleUpdate(old, cur interface{}) {
 func (c *Operator) handleRuleDelete(obj interface{}) {
 	o, ok := c.getObject(obj)
 	if ok {
+		level.Debug(c.logger).Log("msg", "PrometheusRule deleted")
+		c.triggerByCounterVec.WithLabelValues(monitoringv1.ServiceMonitorsKind, "delete").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
@@ -550,13 +599,23 @@ func (c *Operator) handleRuleDelete(obj interface{}) {
 func (c *Operator) handleSecretDelete(obj interface{}) {
 	o, ok := c.getObject(obj)
 	if ok {
+		level.Debug(c.logger).Log("msg", "Secret deleted")
+		c.triggerByCounterVec.WithLabelValues("Secret", "delete").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
 
 func (c *Operator) handleSecretUpdate(old, cur interface{}) {
+	if old.(*v1.Secret).ResourceVersion == cur.(*v1.Secret).ResourceVersion {
+		return
+	}
+
 	o, ok := c.getObject(cur)
 	if ok {
+		level.Debug(c.logger).Log("msg", "Secret updated")
+		c.triggerByCounterVec.WithLabelValues("Secret", "update").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
@@ -564,6 +623,9 @@ func (c *Operator) handleSecretUpdate(old, cur interface{}) {
 func (c *Operator) handleSecretAdd(obj interface{}) {
 	o, ok := c.getObject(obj)
 	if ok {
+		level.Debug(c.logger).Log("msg", "Secret added")
+		c.triggerByCounterVec.WithLabelValues("Secret", "add").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
@@ -572,6 +634,9 @@ func (c *Operator) handleSecretAdd(obj interface{}) {
 func (c *Operator) handleConfigMapAdd(obj interface{}) {
 	o, ok := c.getObject(obj)
 	if ok {
+		level.Debug(c.logger).Log("msg", "ConfigMap added")
+		c.triggerByCounterVec.WithLabelValues("ConfigMap", "add").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
@@ -579,13 +644,23 @@ func (c *Operator) handleConfigMapAdd(obj interface{}) {
 func (c *Operator) handleConfigMapDelete(obj interface{}) {
 	o, ok := c.getObject(obj)
 	if ok {
+		level.Debug(c.logger).Log("msg", "ConfigMap deleted")
+		c.triggerByCounterVec.WithLabelValues("ConfigMap", "delete").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
 
 func (c *Operator) handleConfigMapUpdate(old, cur interface{}) {
+	if old.(*v1.ConfigMap).ResourceVersion == cur.(*v1.ConfigMap).ResourceVersion {
+		return
+	}
+
 	o, ok := c.getObject(cur)
 	if ok {
+		level.Debug(c.logger).Log("msg", "ConfigMap updated")
+		c.triggerByCounterVec.WithLabelValues("ConfigMap", "update").Inc()
+
 		c.enqueueForNamespace(o.GetNamespace())
 	}
 }
@@ -695,31 +770,40 @@ func prometheusKeyToStatefulSetKey(key string) string {
 	return keyParts[0] + "/prometheus-" + keyParts[1]
 }
 
-func (c *Operator) handleDeleteStatefulSet(obj interface{}) {
+func (c *Operator) handleStatefulSetDelete(obj interface{}) {
 	if ps := c.prometheusForStatefulSet(obj); ps != nil {
+		level.Debug(c.logger).Log("msg", "StatefulSet delete")
+		c.triggerByCounterVec.WithLabelValues("StatefulSet", "delete").Inc()
+
 		c.enqueue(ps)
 	}
 }
 
-func (c *Operator) handleAddStatefulSet(obj interface{}) {
+func (c *Operator) handleStatefulSetAdd(obj interface{}) {
 	if ps := c.prometheusForStatefulSet(obj); ps != nil {
+		level.Debug(c.logger).Log("msg", "StatefulSet added")
+		c.triggerByCounterVec.WithLabelValues("StatefulSet", "add").Inc()
+
 		c.enqueue(ps)
 	}
 }
 
-func (c *Operator) handleUpdateStatefulSet(oldo, curo interface{}) {
+func (c *Operator) handleStatefulSetUpdate(oldo, curo interface{}) {
 	old := oldo.(*appsv1.StatefulSet)
 	cur := curo.(*appsv1.StatefulSet)
 
 	level.Debug(c.logger).Log("msg", "update handler", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
-	// Periodic resync may resend the deployment without changes in-between.
+	// Periodic resync may resend the StatefulSet without changes in-between.
 	// Also breaks loops created by updating the resource ourselves.
 	if old.ResourceVersion == cur.ResourceVersion {
 		return
 	}
 
 	if ps := c.prometheusForStatefulSet(cur); ps != nil {
+		level.Debug(c.logger).Log("msg", "StatefulSet updated")
+		c.triggerByCounterVec.WithLabelValues("StatefulSet", "update").Inc()
+
 		c.enqueue(ps)
 	}
 }

--- a/scripts/delete-minikube.sh
+++ b/scripts/delete-minikube.sh
@@ -11,5 +11,4 @@ set -x
 export KUBECONFIG=$HOME/.kube/config
 
 minikube version
-sudo minikube stop
 sudo minikube delete

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1295,7 +1295,10 @@ func TestPrometheusGetBasicAuthSecret(t *testing.T) {
 	}
 	testNamespace := ctx.CreateNamespace(t, framework.KubeClient)
 
-	testFramework.AddLabelsToNamespace(framework.KubeClient, testNamespace, maptest)
+	err := testFramework.AddLabelsToNamespace(framework.KubeClient, testNamespace, maptest)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	simple, err := testFramework.MakeDeployment("../../test/framework/ressources/basic-auth-app-deployment.yaml")
 	if err != nil {


### PR DESCRIPTION
- Introduce the 'prometheus_operator_triggered_total'
Prometheus metric counter, differentiated in label dimensions:
  - triggered_by
    - monitoringv1.PrometheusesKind
    - monitoringv1.ServiceMonitorsKind
    - monitoringv1.PrometheusRuleKind
    - "ConfigMap"
    - "Secret"
    - "StatefulSet"
    - "Namespace"
  - action
    - "add"
    - "delete"
    - "update"

- Add increase hooks of above mentioned metric to all Kubernetes
informer handlers and add simple log line on debug level.

- Add condition to Kubernetes informer update handlers to only preceed
when previous resource version is not equal to new resource version.
This will prevent triggering a reconciliation loop on informer resyncs.

Relates to https://github.com/coreos/prometheus-operator/issues/1659.