### PR TITLE
Ensure honorLabels is set to true for prometheus-operator ServiceMonitor

### DIFF
--- a/contrib/kube-prometheus/manifests/0prometheus-operator-serviceMonitor.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-serviceMonitor.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   endpoints:
   - port: http
+    honorLabels: true
   selector:
     matchLabels:
       k8s-app: prometheus-operator

--- a/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
+++ b/helm/prometheus-operator/templates/servicemonitor-configmap.yaml
@@ -25,3 +25,4 @@ data:
         endpoints:
         - port: http
           interval: 30s
+          honorLabels: true


### PR DESCRIPTION
This helps to resolve an issue identified in #1319 and relates to #1721 

I also couldn't spot where the `ServiceMonitor` for `prometheus-operator` was created in the `jsonnet` contrib - is it missing?