### PR TITLE
helm: Update prometheus operator to 0.22.2

### DIFF
--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -7,8 +7,8 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.28
-appVersion: "0.20.0"
+version: 0.0.29
+appVersion: "0.22.2"
 home: https://github.com/coreos/prometheus-operator
 keywords:
 - operator

--- a/helm/prometheus-operator/values.yaml
+++ b/helm/prometheus-operator/values.yaml
@@ -10,7 +10,7 @@ global:
 ##
 prometheusConfigReloader:
   repository: quay.io/coreos/prometheus-config-reloader
-  tag: v0.20.0
+  tag: v0.22.2
 
 ## Configmap-reload image to use for reloading configmaps
 ##
@@ -22,7 +22,7 @@ configmapReload:
 ##
 image:
   repository: quay.io/coreos/prometheus-operator
-  tag: v0.20.0
+  tag: v0.22.2
   pullPolicy: IfNotPresent
 
 ## If enabled, prometheus-operator will create a service for scraping kubelets


### PR DESCRIPTION
Helm Chart deployment could not install on kubernetes version >= 1.10 because generated CRDs would not validate.  This is resolved in >=0.22.0

Fixes #1293