### PR TITLE
pkg: don't rely on ns informer if ns selected

### DIFF
--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -142,9 +142,10 @@ func (c *Operator) selectRuleNamespaces(p *monitoringv1.Prometheus) ([]string, e
 			return namespaces, errors.Wrap(err, "convert rule namespace label selector to selector")
 		}
 
-		cache.ListAll(c.nsInf.GetStore(), ruleNamespaceSelector, func(obj interface{}) {
-			namespaces = append(namespaces, obj.(*v1.Namespace).Name)
-		})
+		namespaces, err = c.listNamespaces(ruleNamespaceSelector)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	level.Debug(c.logger).Log(


### PR DESCRIPTION
If the operator is not watching all namespaces, then the namespace
informer is not started. This means that all operations that depend on
listing namespaces based on the informer will not work. This commit
modifies those operations so that they work in a single-namespace
configuration.

cc @mxinden @brancz 

~~Note: still needs a little more tweaking; there is some configuration that is causing the Prometheus-k8s instances to crashloop.~~ Disregard, crashlooping was due to a manually deployed alerting rule that was missing quotes around a string.