### PR TITLE
pkg/prometheus: Make Rule ConfigMap bin packing deterministic

### DIFF
--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -17,6 +17,7 @@ package prometheus
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -223,13 +224,21 @@ func makeRulesConfigMaps(p *monitoringv1.Prometheus, ruleFiles map[string]string
 	}
 	currBucketIndex := 0
 
-	for filename, filecontent := range ruleFiles {
-		// If rule file doesn't fit into current bucket, create new bucket
-		if bucketSize(buckets[currBucketIndex])+len(filecontent) > maxConfigMapDataSize {
+	// To make bin packing algorithm deterministic, sort ruleFiles filenames and
+	// iterate over filenames instead of ruleFiles map (not deterministic).
+	fileNames := []string{}
+	for n := range ruleFiles {
+		fileNames = append(fileNames, n)
+	}
+	sort.Strings(fileNames)
+
+	for _, filename := range fileNames {
+		// If rule file doesn't fit into current bucket, create new bucket.
+		if bucketSize(buckets[currBucketIndex])+len(ruleFiles[filename]) > maxConfigMapDataSize {
 			buckets = append(buckets, map[string]string{})
 			currBucketIndex++
 		}
-		buckets[currBucketIndex][filename] = filecontent
+		buckets[currBucketIndex][filename] = ruleFiles[filename]
 	}
 
 	ruleFileConfigMaps := []v1.ConfigMap{}

--- a/pkg/prometheus/rules_test.go
+++ b/pkg/prometheus/rules_test.go
@@ -64,8 +64,8 @@ func shouldSplitUpLargeSmallIntoTwo(t *testing.T) {
 	p := &monitoringv1.Prometheus{}
 	ruleFiles := map[string]string{}
 
-	ruleFiles["my-rule-file-1"] = strings.Repeat("a", maxConfigMapDataSize)
-	ruleFiles["my-rule-file-2"] = "a"
+	ruleFiles["first"] = strings.Repeat("a", maxConfigMapDataSize)
+	ruleFiles["second"] = "a"
 
 	configMaps, err := makeRulesConfigMaps(p, ruleFiles)
 	if err != nil {
@@ -76,8 +76,7 @@ func shouldSplitUpLargeSmallIntoTwo(t *testing.T) {
 		t.Fatalf("expected rule files to be split up into two ConfigMaps, but got '%v' instead", len(configMaps))
 	}
 
-	if configMaps[0].Data["my-rule-file-1"] != ruleFiles["my-rule-file-1"] &&
-		configMaps[1].Data["my-rule-file-2"] != ruleFiles["my-rule-file-2"] {
+	if configMaps[0].Data["first"] != ruleFiles["first"] || configMaps[1].Data["second"] != ruleFiles["second"] {
 		t.Fatal("expected ConfigMap data to match rule file content")
 	}
 }


### PR DESCRIPTION
Instead of iterating over a map, iterate over a sorted array of map
keys. This is relevant e.g. in a case with two small and one large
RuleFile. [small, large, small] results in three ConfigMaps, [small,
small, large] results in two.

Related to https://github.com/coreos/prometheus-operator/issues/1659.

//CC @Capitrium