### PR TITLE
contrib/kube-prometheus: bump prometheus-operator

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -407,6 +407,9 @@ spec:
       prometheus: k8s
       role: alert-rules
   serviceAccountName: prometheus-k8s
+  serviceMonitorNamespaceSelector:
+    matchExpressions:
+    - {}
   serviceMonitorSelector:
     matchExpressions:
     - key: k8s-app

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "v0.22.2"
+            "version": "v0.23.0"
         },
         {
             "name": "etcd-mixin",

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "87358f68efee390c30c7d26ea98faeee331a177a"
+            "version": "f86bcb58b967bb41781976a2b25906fd536d3aa4"
         },
         {
             "name": "ksonnet",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "42f72ac60fad1022d26f1a88062689e94219d582"
+            "version": "a17504d81e2ab5b29d97c77faf72b8d7644bbabf"
         },
         {
             "name": "grafana",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "93be31d43a2728d1750120aeae7a483698ccead2"
+            "version": "9ad8f4c350368d42d988dd8c05801e40f597d369"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/prometheus-prometheus.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-prometheus.yaml
@@ -23,6 +23,9 @@ spec:
       prometheus: k8s
       role: alert-rules
   serviceAccountName: prometheus-k8s
+  serviceMonitorNamespaceSelector:
+    matchExpressions:
+    - {}
   serviceMonitorSelector:
     matchExpressions:
     - key: k8s-app


### PR DESCRIPTION
This commit bumps the version of the Prometheus Operator jsonnet
dependency in kube-prometheus. With this change, kube-prometheus now
supports Prometheus Operator v0.23.0.

cc @brancz @mxinden 