### PR TITLE
Prune/jsonnet roles

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -69,7 +69,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         roleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'prometheus-' + $._config.prometheus.name, namespace: $._config.namespace }]);
         
       local roleBindigList = k.rbac.v1.roleBindingList;
-      roleBindigList.new([newSpecificRoleBinding(x) for x in $._config.prometheus.namespaces]),
+      roleBindigList.new([newSpecificRoleBinding(x) for x in $._config.prometheus.namespaces+[$._config.namespace]]),
     clusterRole:
       local clusterRole = k.rbac.v1.clusterRole;
       local policyRule = clusterRole.rulesType;
@@ -142,7 +142,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         role.withRules(coreRule);
         
       local roleList = k.rbac.v1.roleList;
-      roleList.new([newSpecificRole(x) for x in $._config.prometheus.namespaces]),
+      roleList.new([newSpecificRole(x) for x in $._config.prometheus.namespaces+[$._config.namespace]]),
     prometheus:
       local container = k.core.v1.pod.mixin.spec.containersType;
       local resourceRequirements = container.mixin.resourcesType;

--- a/helm/alertmanager/templates/psp-clusterrole.yaml
+++ b/helm/alertmanager/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/alertmanager/templates/psp-clusterrolebinding.yaml
+++ b/helm/alertmanager/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/exporter-kube-state/templates/psp-clusterrole.yaml
+++ b/helm/exporter-kube-state/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/exporter-kube-state/templates/psp-clusterrolebinding.yaml
+++ b/helm/exporter-kube-state/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/exporter-node/templates/psp-clusterrole.yaml
+++ b/helm/exporter-node/templates/psp-clusterrole.yaml
@@ -6,6 +6,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/exporter-node/templates/psp-clusterrolebinding.yaml
+++ b/helm/exporter-node/templates/psp-clusterrolebinding.yaml
@@ -5,6 +5,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/grafana/templates/psp-clusterrole.yaml
+++ b/helm/grafana/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/grafana/templates/psp-clusterrolebinding.yaml
+++ b/helm/grafana/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/prometheus-operator/templates/clusterrole.yaml
+++ b/helm/prometheus-operator/templates/clusterrole.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRole
 metadata:

--- a/helm/prometheus-operator/templates/clusterrolebinding.yaml
+++ b/helm/prometheus-operator/templates/clusterrolebinding.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/prometheus-operator/templates/psp-clusterrole.yaml
+++ b/helm/prometheus-operator/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/prometheus-operator/templates/psp-clusterrolebinding.yaml
+++ b/helm/prometheus-operator/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/prometheus/templates/clusterrole.yaml
+++ b/helm/prometheus/templates/clusterrole.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRole
 metadata:

--- a/helm/prometheus/templates/clusterrolebinding.yaml
+++ b/helm/prometheus/templates/clusterrolebinding.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/prometheus/templates/psp-clusterrole.yaml
+++ b/helm/prometheus/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/prometheus/templates/psp-clusterrolebinding.yaml
+++ b/helm/prometheus/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
When overriding the `config.prometheus.namespaces` value, the namespace used to deploy the Operator is not added to the list. 
This PR solve this issue