### PR TITLE
SpecificNamespaces includes config.namespace

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -69,7 +69,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         roleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'prometheus-' + $._config.prometheus.name, namespace: $._config.namespace }]);
         
       local roleBindigList = k.rbac.v1.roleBindingList;
-      roleBindigList.new([newSpecificRoleBinding(x) for x in $._config.prometheus.namespaces]),
+      roleBindigList.new([newSpecificRoleBinding(x) for x in $._config.prometheus.namespaces+[$._config.namespace]]),
     clusterRole:
       local clusterRole = k.rbac.v1.clusterRole;
       local policyRule = clusterRole.rulesType;
@@ -142,7 +142,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         role.withRules(coreRule);
         
       local roleList = k.rbac.v1.roleList;
-      roleList.new([newSpecificRole(x) for x in $._config.prometheus.namespaces]),
+      roleList.new([newSpecificRole(x) for x in $._config.prometheus.namespaces+[$._config.namespace]]),
     prometheus:
       local container = k.core.v1.pod.mixin.spec.containersType;
       local resourceRequirements = container.mixin.resourcesType;


### PR DESCRIPTION
When overriding the `config.prometheus.namespaces` value with your own, the namespace used to deploy the Operator is not added to the list of `roles`/`roleBindings`.
This PR solve this issue