### PR TITLE
Fixing default Prometheus endpoint for Grafana

### DIFF
--- a/helm/grafana/templates/dashboards-configmap.yaml
+++ b/helm/grafana/templates/dashboards-configmap.yaml
@@ -24,6 +24,6 @@ data:
       "basicAuth": false,
       "name": "prometheus",
       "type": "prometheus",
-      "url": "http://{{ printf "%s" .Release.Name }}:9090"
+      "url": "http://{{ printf "%s" .Release.Name }}-prometheus:9090"
     }
   {{- end }}


### PR DESCRIPTION
Fixes the URL for the Prometheus backend in Grafana

## Description
Out of the box, the Helm chart for Grafana uses the incorrect URL for the Prometheus backend. As a result, the following issue will pop up: https://github.com/coreos/kube-prometheus/issues/65. Basically, the naming scheme for the URL should be `http://{{ printf "%s" .Release.Name }}-prometheus:9090` to fix this.

## Motivation and Context
Ensuring that Grafana works out of the box with the `kube-prometheus` chart.

## How Has This Been Tested?
I had to fix this on my pre-production cluster. The Prometheus service is created as so:

```shell
$ kubectl get svc monpreprod-prometheus -o yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: prometheus
    chart: prometheus-0.0.50
    heritage: Tiller
    prometheus: monpreprod
    release: monpreprod
  name: monpreprod-prometheus
  namespace: monitoring
spec:
  clusterIP: <cluster-ip>
  ports:
  - name: http
    port: 9090
    protocol: TCP
    targetPort: 9090
  selector:
    app: prometheus
    prometheus: monpreprod-prometheus
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}
```

As you can see, this does not following the scheme in the original `dashboards-configmap.yaml` file.

## Screenshots (if appropriate):
![error](https://user-images.githubusercontent.com/33032791/42526484-db9df140-846d-11e8-864b-8bddad9099e2.png)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
