### PR TITLE
Merge master into release-0.23

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -407,6 +407,9 @@ spec:
       prometheus: k8s
       role: alert-rules
   serviceAccountName: prometheus-k8s
+  serviceMonitorNamespaceSelector:
+    matchExpressions:
+    - {}
   serviceMonitorSelector:
     matchExpressions:
     - key: k8s-app

--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -59,9 +59,10 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
+        - -logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.22.2
-        image: quay.io/coreos/prometheus-operator:v0.22.2
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
+        image: quay.io/coreos/prometheus-operator:v0.23.0
         name: prometheus-operator
         ports:
         - containerPort: 8080
@@ -69,10 +70,13 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:
@@ -407,13 +411,8 @@ spec:
       prometheus: k8s
       role: alert-rules
   serviceAccountName: prometheus-k8s
-  serviceMonitorNamespaceSelector:
-    matchExpressions:
-    - {}
-  serviceMonitorSelector:
-    matchExpressions:
-    - key: k8s-app
-      operator: Exists
+  serviceMonitorNamespaceSelector: {}
+  serviceMonitorSelector: {}
   version: v2.3.1
 ```
 

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -115,7 +115,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
+        - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
         image: quay.io/coreos/prometheus-operator:v0.23.0

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -97,7 +97,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
+        - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
         image: quay.io/coreos/prometheus-operator:v0.23.0

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/prometheus.libsonnet
@@ -131,7 +131,7 @@
             },
           },
           {
-            alert: 'PrometheusTargetScapesDuplicate',
+            alert: 'PrometheusTargetScrapesDuplicate',
             annotations: {
               description: '{{$labels.namespace}}/{{$labels.pod}} has many samples rejected due to duplicate timestamps but different values',
               summary: 'Prometheus has many samples rejected',

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "v0.22.2"
+            "version": "v0.23.0"
         },
         {
             "name": "etcd-mixin",

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -167,6 +167,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           baseImage: $._config.imageRepos.prometheus,
           serviceAccountName: 'prometheus-' + $._config.prometheus.name,
           serviceMonitorSelector: selector.withMatchExpressions({ key: 'k8s-app', operator: 'Exists' }),
+          serviceMonitorNamespaceSelector: selector.withMatchExpressions({}),
           nodeSelector: { 'beta.kubernetes.io/os': 'linux' },
           ruleSelector: selector.withMatchLabels({
             role: 'alert-rules',

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -21,7 +21,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       replicas: 2,
       rules: {},
       renderedRules: {},
-      namespaces: ["default", "kube-system",$._config.namespace],
+      namespaces: ['default', 'kube-system', $._config.namespace],
     },
   },
 
@@ -59,7 +59,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
     roleBindingSpecificNamespaces:
       local roleBinding = k.rbac.v1.roleBinding;
 
-      local newSpecificRoleBinding(namespace) =   
+      local newSpecificRoleBinding(namespace) =
         roleBinding.new() +
         roleBinding.mixin.metadata.withName('prometheus-' + $._config.prometheus.name) +
         roleBinding.mixin.metadata.withNamespace(namespace) +
@@ -67,7 +67,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         roleBinding.mixin.roleRef.withName('prometheus-' + $._config.prometheus.name) +
         roleBinding.mixin.roleRef.mixinInstance({ kind: 'Role' }) +
         roleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'prometheus-' + $._config.prometheus.name, namespace: $._config.namespace }]);
-        
+
       local roleBindigList = k.rbac.v1.roleBindingList;
       roleBindigList.new([newSpecificRoleBinding(x) for x in $._config.prometheus.namespaces]),
     clusterRole:
@@ -134,13 +134,13 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                          'pods',
                        ]) +
                        policyRule.withVerbs(['get', 'list', 'watch']);
-                      
-      local newSpecificRole(namespace) =                 
+
+      local newSpecificRole(namespace) =
         role.new() +
         role.mixin.metadata.withName('prometheus-' + $._config.prometheus.name) +
         role.mixin.metadata.withNamespace(namespace) +
         role.withRules(coreRule);
-        
+
       local roleList = k.rbac.v1.roleList;
       roleList.new([newSpecificRole(x) for x in $._config.prometheus.namespaces]),
     prometheus:
@@ -166,8 +166,8 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           version: $._config.versions.prometheus,
           baseImage: $._config.imageRepos.prometheus,
           serviceAccountName: 'prometheus-' + $._config.prometheus.name,
-          serviceMonitorSelector: selector.withMatchExpressions({ key: 'k8s-app', operator: 'Exists' }),
-          serviceMonitorNamespaceSelector: selector.withMatchExpressions({}),
+          serviceMonitorSelector: {},
+          serviceMonitorNamespaceSelector: {},
           nodeSelector: { 'beta.kubernetes.io/os': 'linux' },
           ruleSelector: selector.withMatchLabels({
             role: 'alert-rules',

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "87358f68efee390c30c7d26ea98faeee331a177a"
+            "version": "f86bcb58b967bb41781976a2b25906fd536d3aa4"
         },
         {
             "name": "ksonnet",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "42f72ac60fad1022d26f1a88062689e94219d582"
+            "version": "a17504d81e2ab5b29d97c77faf72b8d7644bbabf"
         },
         {
             "name": "grafana",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "93be31d43a2728d1750120aeae7a483698ccead2"
+            "version": "9ad8f4c350368d42d988dd8c05801e40f597d369"
         }
     ]
 }

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "f86bcb58b967bb41781976a2b25906fd536d3aa4"
+            "version": "01491ecb1b47620e19bf59fdc104add04a4b4ac8"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "01491ecb1b47620e19bf59fdc104add04a4b4ac8"
+            "version": "793d90134afffc41c07d0482794379962f3e14ec"
         },
         {
             "name": "ksonnet",
@@ -58,7 +58,7 @@
                     "subdir": "grafana"
                 }
             },
-            "version": "8f131a315dfe877819c3a490eedfbcfe183b95cf"
+            "version": "942cd2349e27c2510c71158ee9ca953df33724f2"
         },
         {
             "name": "prometheus-operator",
@@ -68,7 +68,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "87000af76132515a1a2721e836c282d97f82593b"
+            "version": "82ac49106139eee53f1d76e062782f2e8449dd45"
         },
         {
             "name": "etcd-mixin",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "9ad8f4c350368d42d988dd8c05801e40f597d369"
+            "version": "6c9a853f04f8e0cde6139f3a9d04d00517407b91"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
@@ -23,8 +23,8 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
-          description: 'Specification of the desired behavior of the Alertmanager
-            cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'AlertmanagerSpec is a specification of the desired behavior
+            of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             affinity:
               description: Affinity is a group of affinity scheduling rules.
@@ -1687,6 +1687,10 @@ spec:
                     to Limits if that is explicitly specified, otherwise to an implementation-defined
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
+            retention:
+              description: Time duration Alertmanager shall retain data for. Default
+                is '120h'.
+              type: string
             routePrefix:
               description: The route prefix Alertmanager registers HTTP handlers for.
                 This is useful, if using ExternalURL and a proxy is rewriting HTTP
@@ -2372,9 +2376,9 @@ spec:
               description: Version the cluster should be on.
               type: string
         status:
-          description: 'Most recent observed status of the Alertmanager cluster. Read-only.
-            Not included when requesting from the apiserver, only from the Prometheus
-            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'AlertmanagerStatus is the most recent observed status of the
+            Alertmanager cluster. Read-only. Not included when requesting from the
+            apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             availableReplicas:
               description: Total number of available pods (ready for at least minReadySeconds)

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
@@ -23,8 +23,8 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
-          description: 'Specification of the desired behavior of the Prometheus cluster.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'PrometheusSpec is a specification of the desired behavior
+            of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             additionalAlertManagerConfigs:
               description: SecretKeySelector selects a key of a Secret.
@@ -671,6 +671,76 @@ spec:
                   type: array
               required:
               - alertmanagers
+            apiserverConfig:
+              description: 'APIServerConfig defines a host and auth methods to access
+                apiserver. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config'
+              properties:
+                basicAuth:
+                  description: 'BasicAuth allow an endpoint to authenticate over basic
+                    authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                  properties:
+                    password:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                    username:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                bearerToken:
+                  description: Bearer token for accessing apiserver.
+                  type: string
+                bearerTokenFile:
+                  description: File to read bearer token for accessing apiserver.
+                  type: string
+                host:
+                  description: Host of apiserver. A valid string consisting of a hostname
+                    or IP followed by an optional port number
+                  type: string
+                tlsConfig:
+                  description: TLSConfig specifies TLS configuration parameters.
+                  properties:
+                    caFile:
+                      description: The CA cert to use for the targets.
+                      type: string
+                    certFile:
+                      description: The client cert file for the targets.
+                      type: string
+                    insecureSkipVerify:
+                      description: Disable target certificate validation.
+                      type: boolean
+                    keyFile:
+                      description: The client key file for the targets.
+                      type: string
+                    serverName:
+                      description: Used to verify the hostname for the targets.
+                      type: string
+              required:
+              - host
             baseImage:
               description: Base image to use for a Prometheus deployment.
               type: string
@@ -2024,7 +2094,8 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
             retention:
-              description: Time duration Prometheus shall retain data for.
+              description: Time duration Prometheus shall retain data for. Default
+                is '24h'.
               type: string
             routePrefix:
               description: The route prefix Prometheus registers HTTP handlers for.
@@ -2858,11 +2929,41 @@ spec:
                       description: Google Cloud Storage bucket name for stored blocks.
                         If empty it won't store any block inside Google Cloud Storage.
                       type: string
+                    credentials:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
                 peers:
                   description: Peers is a DNS name for Thanos to discover peers through.
                   type: string
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
                 s3:
-                  description: ThanosSpec defines parameters for of AWS Simple Storage
+                  description: ThanosS3Spec defines parameters for of AWS Simple Storage
                     Service (S3) with Thanos. (S3 compatible services apply as well)
                   properties:
                     accessKey:
@@ -2884,6 +2985,9 @@ spec:
                     bucket:
                       description: S3-Compatible API bucket name for stored blocks.
                       type: string
+                    encryptsse:
+                      description: Whether to use Server Side Encryption
+                      type: boolean
                     endpoint:
                       description: S3-Compatible API endpoint for stored blocks.
                       type: string
@@ -2961,9 +3065,9 @@ spec:
               description: Version of Prometheus to be deployed.
               type: string
         status:
-          description: 'Most recent observed status of the Prometheus cluster. Read-only.
-            Not included when requesting from the apiserver, only from the Prometheus
-            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'PrometheusStatus is the most recent observed status of the
+            Prometheus cluster. Read-only. Not included when requesting from the apiserver,
+            only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             availableReplicas:
               description: Total number of available pods (ready for at least minReadySeconds)

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
@@ -169,7 +169,7 @@ spec:
               description: The label to use to retrieve the job name from.
               type: string
             namespaceSelector:
-              description: A selector for selecting namespaces either selecting all
+              description: NamespaceSelector is a selector for selecting either all
                 namespaces or a list of namespaces.
               properties:
                 any:

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -18,9 +18,10 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
+        - -logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.22.2
-        image: quay.io/coreos/prometheus-operator:v0.22.2
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
+        image: quay.io/coreos/prometheus-operator:v0.23.0
         name: prometheus-operator
         ports:
         - containerPort: 8080
@@ -28,10 +29,13 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-serviceMonitor.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-serviceMonitor.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: monitoring
 spec:
   endpoints:
-  - port: http
+  - honorLabels: true
+    port: http
   selector:
     matchLabels:
       k8s-app: prometheus-operator

--- a/contrib/kube-prometheus/manifests/grafana-dashboardSources.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-dashboardSources.yaml
@@ -1,17 +1,20 @@
 apiVersion: v1
 data:
   dashboards.yaml: |-
-    [
-        {
-            "folder": "",
-            "name": "0",
-            "options": {
-                "path": "/grafana-dashboard-definitions/0"
-            },
-            "org_id": 1,
-            "type": "file"
-        }
-    ]
+    {
+        "apiVersion": 1,
+        "providers": [
+            {
+                "folder": "",
+                "name": "0",
+                "options": {
+                    "path": "/grafana-dashboard-definitions/0"
+                },
+                "orgId": 1,
+                "type": "file"
+            }
+        ]
+    }
 kind: ConfigMap
 metadata:
   name: grafana-dashboards

--- a/contrib/kube-prometheus/manifests/prometheus-prometheus.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-prometheus.yaml
@@ -23,6 +23,9 @@ spec:
       prometheus: k8s
       role: alert-rules
   serviceAccountName: prometheus-k8s
+  serviceMonitorNamespaceSelector:
+    matchExpressions:
+    - {}
   serviceMonitorSelector:
     matchExpressions:
     - key: k8s-app

--- a/contrib/kube-prometheus/manifests/prometheus-prometheus.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-prometheus.yaml
@@ -23,11 +23,6 @@ spec:
       prometheus: k8s
       role: alert-rules
   serviceAccountName: prometheus-k8s
-  serviceMonitorNamespaceSelector:
-    matchExpressions:
-    - {}
-  serviceMonitorSelector:
-    matchExpressions:
-    - key: k8s-app
-      operator: Exists
+  serviceMonitorNamespaceSelector: {}
+  serviceMonitorSelector: {}
   version: v2.3.1

--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -849,7 +849,7 @@ spec:
       for: 10m
       labels:
         severity: warning
-    - alert: PrometheusTargetScapesDuplicate
+    - alert: PrometheusTargetScrapesDuplicate
       annotations:
         description: '{{$labels.namespace}}/{{$labels.pod}} has many samples rejected
           due to duplicate timestamps but different values'

--- a/example/non-rbac/prometheus-operator.yaml
+++ b/example/non-rbac/prometheus-operator.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
+        - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
         image: quay.io/coreos/prometheus-operator:v0.23.0

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
+        - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
         image: quay.io/coreos/prometheus-operator:v0.23.0

--- a/helm/alertmanager/Chart.yaml
+++ b/helm/alertmanager/Chart.yaml
@@ -8,7 +8,7 @@ name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://github.com/prometheus/alertmanager
-version: 0.1.6
+version: 0.1.7
 appVersion: "0.15.1"
 home: https://github.com/prometheus/alertmanager 
 keywords:

--- a/helm/alertmanager/templates/psp-clusterrole.yaml
+++ b/helm/alertmanager/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/alertmanager/templates/psp-clusterrolebinding.yaml
+++ b/helm/alertmanager/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/exporter-kube-state/Chart.yaml
+++ b/helm/exporter-kube-state/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart singleton for kube-state-metrics
 name: exporter-kube-state
-version: 0.2.5
+version: 0.2.6
 maintainers:
   - name: Giancarlo Rubio
     email: gianrubio@gmail.com

--- a/helm/exporter-kube-state/templates/clusterrole.yaml
+++ b/helm/exporter-kube-state/templates/clusterrole.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRole
 metadata:

--- a/helm/exporter-kube-state/templates/clusterrolebinding.yaml
+++ b/helm/exporter-kube-state/templates/clusterrolebinding.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/exporter-kube-state/templates/psp-clusterrole.yaml
+++ b/helm/exporter-kube-state/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/exporter-kube-state/templates/psp-clusterrolebinding.yaml
+++ b/helm/exporter-kube-state/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/exporter-kube-state/templates/role.yaml
+++ b/helm/exporter-kube-state/templates/role.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: Role
 metadata:

--- a/helm/exporter-kube-state/templates/rolebinding.yaml
+++ b/helm/exporter-kube-state/templates/rolebinding.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: RoleBinding
 metadata:

--- a/helm/exporter-node/templates/psp-clusterrole.yaml
+++ b/helm/exporter-node/templates/psp-clusterrole.yaml
@@ -6,6 +6,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/exporter-node/templates/psp-clusterrolebinding.yaml
+++ b/helm/exporter-node/templates/psp-clusterrolebinding.yaml
@@ -5,6 +5,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/grafana/Chart.yaml
+++ b/helm/grafana/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/coreos/prometheus-operator
-version: 0.0.36
+version: 0.0.37

--- a/helm/grafana/templates/psp-clusterrole.yaml
+++ b/helm/grafana/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/grafana/templates/psp-clusterrolebinding.yaml
+++ b/helm/grafana/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
   - name: alertmanager
-    version: 0.1.6
+    version: 0.1.7
     #e2e-repository: file://../alertmanager
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployAlertManager
 
   - name: prometheus
-    version: 0.0.50
+    version: 0.0.51
     #e2e-repository: file://../prometheus
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
@@ -41,7 +41,7 @@ dependencies:
     condition: deployKubeScheduler
 
   - name: exporter-kube-state
-    version: 0.2.5
+    version: 0.2.6
     #e2e-repository: file://../exporter-kube-state
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployKubeState
@@ -64,7 +64,7 @@ dependencies:
     condition: deployExporterNode
 
   - name: grafana
-    version: 0.0.36
+    version: 0.0.37
     #e2e-repository: file://../grafana
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployGrafana

--- a/helm/prometheus-operator/Chart.yaml
+++ b/helm/prometheus-operator/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.28
+version: 0.0.29
 appVersion: "0.20.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/helm/prometheus-operator/templates/clusterrole.yaml
+++ b/helm/prometheus-operator/templates/clusterrole.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRole
 metadata:

--- a/helm/prometheus-operator/templates/clusterrolebinding.yaml
+++ b/helm/prometheus-operator/templates/clusterrolebinding.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/prometheus-operator/templates/psp-clusterrole.yaml
+++ b/helm/prometheus-operator/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/prometheus-operator/templates/psp-clusterrolebinding.yaml
+++ b/helm/prometheus-operator/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/prometheus/Chart.yaml
+++ b/helm/prometheus/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.0.50
+version: 0.0.51
 

--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -101,7 +101,7 @@ Custom service monitors can be added in values.yaml in the `serviceMonitors` sec
 #### Example service monitor
 
 
-This example Service Monitor will monitor applications matching `app: nginx-ingress`. The port `metrics` will be scraped with the path `/merics`. The endpoint will be scraped every 30 seconds.
+This example Service Monitor will monitor applications matching `app: nginx-ingress`. The port `metrics` will be scraped with the path `/metrics`. The endpoint will be scraped every 30 seconds.
 
 ```
 serviceMonitors:

--- a/helm/prometheus/templates/clusterrole.yaml
+++ b/helm/prometheus/templates/clusterrole.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRole
 metadata:

--- a/helm/prometheus/templates/clusterrolebinding.yaml
+++ b/helm/prometheus/templates/clusterrolebinding.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/helm/prometheus/templates/prometheus.rules.yaml
+++ b/helm/prometheus/templates/prometheus.rules.yaml
@@ -92,7 +92,7 @@ groups:
       description: "Prometheus {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod}}`}} isn't ingesting samples."
       summary: "Prometheus isn't ingesting samples"
 
-  - alert: PrometheusTargetScapesDuplicate
+  - alert: PrometheusTargetScrapesDuplicate
     expr: increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[5m]) > 0
     for: 10m
     labels:

--- a/helm/prometheus/templates/psp-clusterrole.yaml
+++ b/helm/prometheus/templates/psp-clusterrole.yaml
@@ -5,6 +5,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/helm/prometheus/templates/psp-clusterrolebinding.yaml
+++ b/helm/prometheus/templates/psp-clusterrolebinding.yaml
@@ -4,6 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -121,7 +121,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           '--kubelet-service=kube-system/kubelet',
           // Prometheus Operator is run with a read-only root file system. By
           // default glog saves logfiles to /tmp. Make it log to stderr instead.
-          '-logtostderr=true',
+          '--logtostderr=true',
           '--config-reloader-image=' + $._config.imageRepos.configmapReloader + ':' + $._config.versions.configmapReloader,
           '--prometheus-config-reloader=' + $._config.imageRepos.prometheusConfigReloader + ':' + $._config.versions.prometheusOperator,
         ]) +

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -170,6 +170,10 @@ func makeStatefulSetService(p *monitoringv1.Alertmanager, config Config) *v1.Ser
 }
 
 func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.StatefulSetSpec, error) {
+	// Before editing 'a' create deep copy, to prevent side effects. For more
+	// details see https://github.com/coreos/prometheus-operator/issues/1659
+	a = a.DeepCopy()
+
 	tag := a.Spec.Version
 	if a.Spec.Tag != "" {
 		tag = a.Spec.Tag

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -917,6 +917,8 @@ func (c *Operator) sync(key string) error {
 		if _, err := c.kclient.Core().Secrets(p.Namespace).Create(s); err != nil && !apierrors.IsAlreadyExists(err) {
 			return errors.Wrap(err, "creating empty config file failed")
 		}
+	}
+	if !apierrors.IsNotFound(err) && err != nil {
 		return err
 	}
 

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -84,6 +84,12 @@ func makeStatefulSet(
 	ruleConfigMapNames []string,
 	inputHash string,
 ) (*appsv1.StatefulSet, error) {
+	// p is passed in by value, not by reference. But p contains references like
+	// to annotation map, that do not get copied on function invocation. Ensure to
+	// prevent side effects before editing p by creating a deep copy. For more
+	// details see https://github.com/coreos/prometheus-operator/issues/1659.
+	p = *p.DeepCopy()
+
 	// TODO(fabxc): is this the right point to inject defaults?
 	// Ideally we would do it before storing but that's currently not possible.
 	// Potentially an update handler on first insertion.

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -54,8 +54,21 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 
 	require.NoError(t, err)
 
-	if !reflect.DeepEqual(labels, sset.Labels) || !reflect.DeepEqual(annotations, sset.Annotations) {
-		t.Fatal("Labels or Annotations are not properly being propagated to the StatefulSet")
+	if !reflect.DeepEqual(labels, sset.Labels) {
+		fmt.Println(pretty.Compare(labels, sset.Labels))
+		t.Fatal("Labels are not properly being propagated to the StatefulSet")
+	}
+
+	expectedAnnotations := map[string]string{
+		"prometheus-operator-input-hash": "",
+	}
+	for k, v := range annotations {
+		expectedAnnotations[k] = v
+	}
+
+	if !reflect.DeepEqual(expectedAnnotations, sset.Annotations) {
+		fmt.Println(pretty.Compare(expectedAnnotations, sset.Annotations))
+		t.Fatal("Annotations are not properly being propagated to the StatefulSet")
 	}
 }
 

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -693,6 +693,12 @@ func TestPrometheusOnlyUpdatedOnRelevantChanges(t *testing.T) {
 	name := "test"
 	prometheus := framework.MakeBasicPrometheus(ns, name, name, 1)
 
+	// Adding an annotation to Prometheus lead to high CPU usage in the past
+	// updating the Prometheus StatefulSet in a loop (See
+	// https://github.com/coreos/prometheus-operator/issues/1659). Added here to
+	// prevent a regression.
+	prometheus.Annotations["test-annotation"] = "test-value"
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	type versionedResource interface {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -88,6 +88,22 @@ func TestPrometheusScaleUpDownCluster(t *testing.T) {
 	}
 }
 
+func TestPrometheusNoServiceMonitorSelector(t *testing.T) {
+	t.Parallel()
+
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+	ns := ctx.CreateNamespace(t, framework.KubeClient)
+	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+
+	name := "test"
+	p := framework.MakeBasicPrometheus(ns, name, name, 1)
+	p.Spec.ServiceMonitorSelector = nil
+	if err := framework.CreatePrometheusAndWaitUntilReady(ns, p); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPrometheusVersionMigration(t *testing.T) {
 	t.Parallel()
 

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -35,8 +35,9 @@ import (
 func (f *Framework) MakeBasicPrometheus(ns, name, group string, replicas int32) *monitoringv1.Prometheus {
 	return &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
+			Name:        name,
+			Namespace:   ns,
+			Annotations: map[string]string{},
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			Replicas: &replicas,
@@ -235,11 +236,11 @@ func (f *Framework) WaitForPrometheusReady(p *monitoringv1.Prometheus, timeout t
 func (f *Framework) DeletePrometheusAndWaitUntilGone(ns, name string) error {
 	_, err := f.MonClientV1.Prometheuses(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("requesting Prometheus tpr %v failed", name))
+		return errors.Wrap(err, fmt.Sprintf("requesting Prometheus custom resource %v failed", name))
 	}
 
 	if err := f.MonClientV1.Prometheuses(ns).Delete(name, nil); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("deleting Prometheus tpr %v failed", name))
+		return errors.Wrap(err, fmt.Sprintf("deleting Prometheus custom resource %v failed", name))
 	}
 
 	if err := WaitForPodsReady(
@@ -249,7 +250,10 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(ns, name string) error {
 		0,
 		prometheus.ListOptions(name),
 	); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("waiting for Prometheus tpr (%s) to vanish timed out", name))
+		return errors.Wrap(
+			err,
+			fmt.Sprintf("waiting for Prometheus custom resource (%s) to vanish timed out", name),
+		)
 	}
 
 	return nil


### PR DESCRIPTION
With https://github.com/coreos/prometheus-operator/issues/1659 fixed I would like to cut a new patch release (`v0.23.1`). As there are no new features in `master`, only bug fixes, merging `master` into `release-0.23`.

I will follow up with a CHANGELOG and VERSION update PR.