### PR TITLE
Fix APIServerErrorsHigh alert rule

### DIFF
--- a/helm/exporter-kubernetes/templates/kubernetes.rules.yaml
+++ b/helm/exporter-kubernetes/templates/kubernetes.rules.yaml
@@ -64,7 +64,8 @@ groups:
         for {{`{{$labels.verb}}`}} {{`{{$labels.resource}}`}}
       summary: API server high latency
   - alert: APIServerErrorsHigh
-    expr: rate(apiserver_request_count{code=~"^(?:5..)$"}[5m]) / rate(apiserver_request_count[5m])
+    expr: sum(rate(apiserver_request_count{code=~"^(?:5..)$"}[5m])) without(instance, pod)
+      / sum(rate(apiserver_request_count[5m])) without(instance, pod)
       * 100 > 2
     for: 10m
     labels:
@@ -73,7 +74,8 @@ groups:
       description: API server returns errors for {{`{{ $value }}`}}% of requests
       summary: API server request errors
   - alert: APIServerErrorsHigh
-    expr: rate(apiserver_request_count{code=~"^(?:5..)$"}[5m]) / rate(apiserver_request_count[5m])
+    expr: sum(rate(apiserver_request_count{code=~"^(?:5..)$"}[5m])) without(instance, pod)
+      / sum(rate(apiserver_request_count[5m])) without(instance, pod)
       * 100 > 5
     for: 10m
     labels:


### PR DESCRIPTION
Pull changes from upstream
( https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/alerts/system_alerts.libsonnet#L104-L106 )
to fix the APIServerErrorsHigh alert's rule.

The rule's expression was:
    rate(apiserver_request_count{code=~"^(?:5..)$"}[5m]) / rate(apiserver_request_count[5m]) * 100 > 2

The intent was to "alarm if 5xx status codes make up greater than 2% of
all requests", however, in practice, the $value of the expression was
only ever empty or 100. It never had a value in the range of 0 through
99.

The denominator didn't sum up the request rates across all codes, it
produced a vector of rates for each input time series (eg at least one
per code) and then the division operator matched only those time series
that had the 5xx codes selected for in the numerator. This resulted
exclusively values of 1 (* 100).

Because of the above, a few 5xx codes spread over 10 minutes would cause
the alert to fire even if they really only made up a tiny fraction of
the overall number of requests.

Fixes #1777.