### PR TITLE
Makefile: Add clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ pkgs = $(shell go list ./... | grep -v /vendor/ | grep -v /test/)
 .PHONY: all
 all: format generate build test
 
+.PHONY: clean
+clean:
+	# Remove all files and directories ignored by git.
+	git clean -Xfd .
+
 
 ############
 # Building #


### PR DESCRIPTION
Adding `make clean` target to main Makefile. This helps a lot debugging
jsonnet vendoring issues.

**Up for discussion. Let me know if you feel unsafe adding this.**

Relevant `git clean` manual entry:

```man
-d
Remove untracked directories in addition to untracked files.
If an untracked directory is managed by a different Git repository, it
is not removed by default. Use -f option twice if you really want to
remove such a directory.

-f, --force
If the Git configuration variable clean.requireForce is not set to
false, git clean will refuse to delete files or directories unless given
-f, -n or -i. Git will refuse to delete directories with .git sub
directory or file unless a second -f is given.

-X
Remove only files ignored by Git. This may be useful to rebuild
everything from scratch, but keep manually created files.
```