### PR TITLE
kube-prometheus: bind mount host rootfs into node exporter

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -166,6 +166,8 @@ spec:
         - --web.listen-address=127.0.0.1:9101
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
         image: quay.io/prometheus/node-exporter:v0.15.2
         name: node-exporter
         resources:
@@ -182,6 +184,10 @@ spec:
         - mountPath: /host/sys
           name: sys
           readOnly: false
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
       - args:
         - --secure-listen-address=:9100
         - --upstream=http://127.0.0.1:9101/
@@ -216,6 +222,9 @@ spec:
       - hostPath:
           path: /sys
         name: sys
+      - hostPath:
+          path: /root
+        name: root
 ```
 
 The respective `ServiceAccount` manifest:

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -73,14 +73,26 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local sysVolume = volume.fromHostPath(sysVolumeName, '/sys');
       local sysVolumeMount = containerVolumeMount.new(sysVolumeName, '/host/sys');
 
+      local rootVolumeName = 'root';
+      local rootVolume = volume.fromHostPath(rootVolumeName, '/root');
+      local rootVolumeMount = containerVolumeMount.new(rootVolumeName, '/host/root').
+        withMountPropagation('HostToContainer').
+        withReadOnly(true);
+
       local nodeExporter =
         container.new('node-exporter', $._config.imageRepos.nodeExporter + ':' + $._config.versions.nodeExporter) +
         container.withArgs([
           '--web.listen-address=127.0.0.1:9101',
           '--path.procfs=/host/proc',
           '--path.sysfs=/host/sys',
+
+          // The following settings have been taken from
+          // https://github.com/prometheus/node_exporter/blob/0662673/collector/filesystem_linux.go#L30-L31
+          // Once node exporter is being released with those settings, this can be removed.
+          '--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)',
+          '--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$',
         ]) +
-        container.withVolumeMounts([procVolumeMount, sysVolumeMount]) +
+        container.withVolumeMounts([procVolumeMount, sysVolumeMount, rootVolumeMount]) +
         container.mixin.resources.withRequests({ cpu: '102m', memory: '180Mi' }) +
         container.mixin.resources.withLimits({ cpu: '102m', memory: '180Mi' });
 
@@ -105,7 +117,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       daemonset.mixin.spec.template.spec.withTolerations([masterToleration]) +
       daemonset.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/os': 'linux' }) +
       daemonset.mixin.spec.template.spec.withContainers(c) +
-      daemonset.mixin.spec.template.spec.withVolumes([procVolume, sysVolume]) +
+      daemonset.mixin.spec.template.spec.withVolumes([procVolume, sysVolume, rootVolume]) +
       daemonset.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
       daemonset.mixin.spec.template.spec.securityContext.withRunAsUser(65534) +
       daemonset.mixin.spec.template.spec.withServiceAccountName('node-exporter') +

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "7a050d711ce4c4704bef5f139aacefb2b75f8cf3"
+            "version": "383cee46d2eab2dc477c8f4b1526b4f93f993280"
         },
         {
             "name": "ksonnet",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "2a6bc7d1130d2fa3336af5ffa2bcf82d760c945e"
+            "version": "6890a9e633b0cdccdeaf65ccda3d84fb0838801f"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
+++ b/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
@@ -19,6 +19,8 @@ spec:
         - --web.listen-address=127.0.0.1:9101
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
         image: quay.io/prometheus/node-exporter:v0.15.2
         name: node-exporter
         resources:
@@ -35,6 +37,10 @@ spec:
         - mountPath: /host/sys
           name: sys
           readOnly: false
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
       - args:
         - --secure-listen-address=:9100
         - --upstream=http://127.0.0.1:9101/
@@ -69,3 +75,6 @@ spec:
       - hostPath:
           path: /sys
         name: sys
+      - hostPath:
+          path: /root
+        name: root


### PR DESCRIPTION
Fixes https://github.com/prometheus/node_exporter/issues/474 in the operator
Fixes #569 (by making the mount explicit)