### PR TITLE
*: add multi-namespace support to Prometheus Operator

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -263,8 +263,8 @@ func (c *Operator) getObject(obj interface{}) (metav1.Object, bool) {
 	return o, true
 }
 
-// enqueue adds a key to the queue. If obj is a key already it gets added directly.
-// Otherwise, the key is extracted via keyFunc.
+// enqueue adds a key to the queue. If obj is a key already it gets added
+// directly. Otherwise, the key is extracted via keyFunc.
 func (c *Operator) enqueue(obj interface{}) {
 	if obj == nil {
 		return
@@ -281,7 +281,8 @@ func (c *Operator) enqueue(obj interface{}) {
 	c.queue.Add(key)
 }
 
-// enqueueForNamespace enqueues all Alertmanager object keys that belong to the given namespace.
+// enqueueForNamespace enqueues all Alertmanager object keys that belong to the
+// given namespace.
 func (c *Operator) enqueueForNamespace(ns string) {
 	cache.ListAll(c.alrtInf.GetStore(), labels.Everything(), func(obj interface{}) {
 		am := obj.(*monitoringv1.Alertmanager)
@@ -291,8 +292,9 @@ func (c *Operator) enqueueForNamespace(ns string) {
 	})
 }
 
-// worker runs a worker thread that just dequeues items, processes them, and marks them done.
-// It enforces that the syncHandler is never invoked concurrently with the same key.
+// worker runs a worker thread that just dequeues items, processes them
+// and marks them done. It enforces that the syncHandler is never invoked
+// concurrently with the same key.
 func (c *Operator) worker() {
 	for c.processNextWorkItem() {
 	}
@@ -420,14 +422,18 @@ func (c *Operator) sync(key string) error {
 		return err
 	}
 	if !exists {
-		// TODO(fabxc): we want to do server side deletion due to the variety of
-		// resources we create.
+		// TODO(fabxc): we want to do server side deletion due to the
+		// variety of resources we create.
 		// Doing so just based on the deletion event is not reliable, so
-		// we have to garbage collect the controller-created resources in some other way.
+		// we have to garbage collect the controller-created resources
+		// in some other way.
 		//
-		// Let's rely on the index key matching that of the created configmap and replica
-		// set for now. This does not work if we delete Alertmanager resources as the
-		// controller is not running – that could be solved via garbage collection later.
+		// Let's rely on the index key matching that of the created
+		// configmap and replica
+		// set for now. This does not work if we delete Alertmanager
+		// resources as the
+		// controller is not running – that could be solved via garbage
+		// collection later.
 		return c.destroyAlertmanager(key)
 	}
 
@@ -504,7 +510,8 @@ func AlertmanagerStatus(kclient kubernetes.Interface, a *monitoringv1.Alertmanag
 		}
 		if ready {
 			res.AvailableReplicas++
-			// TODO(fabxc): detect other fields of the pod template that are mutable.
+			// TODO(fabxc): detect other fields of the pod template
+			// that are mutable.
 			if needsUpdate(&pod, sset.Spec.Template) {
 				oldPods = append(oldPods, pod)
 			} else {
@@ -533,7 +540,8 @@ func needsUpdate(pod *v1.Pod, tmpl v1.PodTemplateSpec) bool {
 	return false
 }
 
-// TODO(brancz): Remove this function once Kubernetes 1.7 compatibility is dropped.
+// TODO(brancz): Remove this function once Kubernetes 1.7 compatibility is
+// dropped.
 // Starting with Kubernetes 1.8 OwnerReferences are properly handled for CRDs.
 func (c *Operator) destroyAlertmanager(key string) error {
 	ssetKey := alertmanagerKeyToStatefulSetKey(key)
@@ -556,8 +564,8 @@ func (c *Operator) destroyAlertmanager(key string) error {
 
 	podClient := c.kclient.Core().Pods(sset.Namespace)
 
-	// TODO(fabxc): temporary solution until StatefulSet status provides necessary info to know
-	// whether scale-down completed.
+	// TODO(fabxc): temporary solution until StatefulSet status provides
+	// necessary info to know whether scale-down completed.
 	for {
 		pods, err := podClient.List(ListOptions(alertmanagerNameFromStatefulSetName(sset.Name)))
 		if err != nil {

--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -1,0 +1,204 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package listwatch
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewUnprivilegedNamespaceListWatchFromClient mimics cache.NewListWatchFromClient.
+// It allows for the creation of a cache.ListWatch for namespaces from a client that does not have `List` privileges.
+// If the slice of namespaces contains only v1.NamespaceAll, then this func assumes that the client
+// has List and Watch privileges and returns a regular cache.ListWatch, since there is no other way to get all namespaces.
+func NewUnprivilegedNamespaceListWatchFromClient(c cache.Getter, namespaces []string, fieldSelector fields.Selector) *cache.ListWatch {
+	optionsModifier := func(options *metav1.ListOptions) {
+		options.FieldSelector = fieldSelector.String()
+	}
+	return NewFilteredUnprivilegedNamespaceListWatchFromClient(c, namespaces, optionsModifier)
+}
+
+// NewFilteredUnprivilegedNamespaceListWatchFromClient mimics cache.NewUnprivilegedNamespaceListWatchFromClient.
+// It allows for the creation of a cache.ListWatch for namespaces from a client that does not have `List` privileges.
+// If the slice of namespaces contains only v1.NamespaceAll, then this func assumes that the client
+// has List and Watch privileges and returns a regular cache.ListWatch, since there is no other way to get all namespaces.
+func NewFilteredUnprivilegedNamespaceListWatchFromClient(c cache.Getter, namespaces []string, optionsModifier func(options *metav1.ListOptions)) *cache.ListWatch {
+	// If the only namespace given is `v1.NamespaceAll`, then this cache.ListWatch must be privileged.
+	// In this case, return a regular cache.ListWatch.
+	if IsAllNamespaces(namespaces) {
+		return cache.NewFilteredListWatchFromClient(c, "namespaces", metav1.NamespaceAll, optionsModifier)
+	}
+	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
+		optionsModifier(&options)
+		list := &v1.NamespaceList{}
+		for _, name := range namespaces {
+			result := &v1.Namespace{}
+			err := c.Get().
+				Resource("namespaces").
+				Name(name).
+				VersionedParams(&options, scheme.ParameterCodec).
+				Do().
+				Into(result)
+			if err != nil {
+				return nil, err
+			}
+			list.Items = append(list.Items, *result)
+		}
+		return list, nil
+	}
+	watchFunc := func(_ metav1.ListOptions) (watch.Interface, error) {
+		// Since the client does not have Watch privileges, do not actually watch anything.
+		// Use a watch.FakeWatcher here to implement watch.Interface but not send any events.
+		return watch.NewFake(), nil
+	}
+	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+}
+
+// MultiNamespaceListerWatcher takes a list of namespaces and a cache.ListerWatcher generator func
+// and returns a single cache.ListerWatcher capable of operating on multiple namespaces.
+func MultiNamespaceListerWatcher(namespaces []string, f func(string) cache.ListerWatcher) cache.ListerWatcher {
+	// If there is only one namespace then there is no need to create a proxy.
+	if len(namespaces) == 1 {
+		return f(namespaces[0])
+	}
+	var lws []cache.ListerWatcher
+	for _, n := range namespaces {
+		lws = append(lws, f(n))
+	}
+	return multiListerWatcher(lws)
+}
+
+// multiListerWatcher abstracts several cache.ListerWatchers, allowing them
+// to be treated as a single cache.ListerWatcher.
+type multiListerWatcher []cache.ListerWatcher
+
+// List implements the ListerWatcher interface.
+// It combines the output of the List method of every ListerWatcher into
+// a single result.
+func (mlw multiListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
+	l := metav1.List{}
+	var resourceVersions []string
+	for _, lw := range mlw {
+		list, err := lw.List(options)
+		if err != nil {
+			return nil, err
+		}
+		items, err := meta.ExtractList(list)
+		if err != nil {
+			return nil, err
+		}
+		metaObj, err := meta.ListAccessor(list)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range items {
+			l.Items = append(l.Items, runtime.RawExtension{Object: item.DeepCopyObject()})
+		}
+		resourceVersions = append(resourceVersions, metaObj.GetResourceVersion())
+	}
+	// Combine the resource versions so that the composite Watch method can
+	// distribute appropriate versions to each underlying Watch func.
+	l.ListMeta.ResourceVersion = strings.Join(resourceVersions, "/")
+	return &l, nil
+}
+
+// Watch implements the ListerWatcher interface.
+// It returns a watch.Interface that combines the output from the watch.Interface
+// of every cache.ListerWatcher into a single result chan.
+func (mlw multiListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	resourceVersions := make([]string, len(mlw))
+	// Allow resource versions to be "".
+	if options.ResourceVersion != "" {
+		rvs := strings.Split(options.ResourceVersion, "/")
+		if len(rvs) != len(mlw) {
+			return nil, fmt.Errorf("expected resource version to have %d parts to match the number of ListerWatchers", len(mlw))
+		}
+		resourceVersions = rvs
+	}
+	return newMultiWatch(mlw, resourceVersions, options)
+}
+
+// multiWatch abstracts multiple watch.Interface's, allowing them
+// to be treated as a single watch.Interface.
+type multiWatch struct {
+	mu       sync.Mutex
+	result   chan watch.Event
+	stopped  bool
+	stoppers []func()
+}
+
+// newMultiWatch returns a new multiWatch or an error if one of the underlying Watch funcs errored.
+// The length of []cache.ListerWatcher and []string must match.
+func newMultiWatch(lws []cache.ListerWatcher, resourceVersions []string, options metav1.ListOptions) (*multiWatch, error) {
+	ch := make(chan watch.Event)
+	var stoppers []func()
+	for i, lw := range lws {
+		o := options.DeepCopy()
+		o.ResourceVersion = resourceVersions[i]
+		w, err := lw.Watch(*o)
+		if err != nil {
+			return nil, err
+		}
+		go func() {
+			for {
+				event, ok := <-w.ResultChan()
+				if !ok {
+					break
+				}
+				ch <- event
+			}
+		}()
+		stoppers = append(stoppers, w.Stop)
+	}
+	return &multiWatch{result: ch, stoppers: stoppers}, nil
+}
+
+// ResultChan implements the watch.Interface interface.
+func (mw *multiWatch) ResultChan() <-chan watch.Event {
+	return mw.result
+}
+
+// Stop implements the watch.Interface interface.
+// It stops all of the underlying watch.Interfaces and closes
+// the backing chan.
+// Can safely be called more than once.
+func (mw *multiWatch) Stop() {
+	mw.mu.Lock()
+	defer mw.mu.Unlock()
+	if !mw.stopped {
+		for _, stop := range mw.stoppers {
+			stop()
+		}
+		close(mw.result)
+		mw.stopped = true
+	}
+	return
+}
+
+// IsAllNamespaces checks if the given slice of namespaces
+// contains only v1.NamespaceAll.
+func IsAllNamespaces(namespaces []string) bool {
+	return len(namespaces) == 1 && namespaces[0] == v1.NamespaceAll
+}

--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -143,7 +143,7 @@ func (c *Operator) selectRuleNamespaces(p *monitoringv1.Prometheus) ([]string, e
 			return namespaces, errors.Wrap(err, "convert rule namespace label selector to selector")
 		}
 
-		namespaces, err = c.listNamespaces(ruleNamespaceSelector)
+		namespaces, err = c.listMatchingNamespaces(ruleNamespaceSelector)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is a large PR broken into two logical commits that can be separate PRs if needed.
I have tested these changes on an Openshift cluster as part of https://github.com/openshift/cluster-monitoring-operator with several different configurations:
* single namespace, i.e. `--namespaces=x`
* multiple namespaces, i.e. `--namespaces=x,y` and `--namespaces=x --namespaces=y`
* all namespaces, i.e. no `--namespaces` flag so `v1.NamespaceAll` is used

First:
This commit adds multi-namespace support to the Prometheus Operator. PO
now allows all informers to react to changes to multiple, individually
configured, namespaces, i.e. without specifying v1.NamespaceAll. This is
important for cases where the Prometheus Operator does not have
privileges to List all namespaces but should still administer multiple
namespaces. This capability is accomplished by abstracting the
cache.ListerWatchers for the various informers the PO uses.

Second:
This commit ensures that all informer caches are synced before the
eventhandlers are added. This is important whenever one informer's
eventhandler depends on the cache of a different informer. Without this,
eventhandlers will complain that certain objects don't exist. This is
important now that the namespace informer still runs for a single
namespace, where previously it was only run for v1.NamespaceAll.
Otherwise, e.g. the secret eventhandler could fail until the namespace
handler had synced.

cc @brancz @mxinden @s-urbaniak 