### PR TITLE
pkg/prometheus: fix marshalling of additionalAlertManagerConfig when building the prometheus config

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -183,13 +183,15 @@ func (cg *configGenerator) generateConfig(
 		Value: append(scrapeConfigs, additionalScrapeConfigsYaml...),
 	})
 
-	var additionalAlertManagerConfigsYaml []yaml.MapSlice
+	var additionalAlertManagerConfigsYaml yaml.MapSlice
 	err = yaml.Unmarshal([]byte(additionalAlertManagerConfigs), &additionalAlertManagerConfigsYaml)
 	if err != nil {
+		fmt.Println(string(additionalAlertManagerConfigs))
 		return nil, errors.Wrap(err, "unmarshalling additional alert manager configs failed")
 	}
-
-	alertmanagerConfigs = append(alertmanagerConfigs, additionalAlertManagerConfigsYaml...)
+	if len(additionalAlertManagerConfigsYaml) > 0 {
+		alertmanagerConfigs = append(alertmanagerConfigs, additionalAlertManagerConfigsYaml)
+	}
 
 	var alertRelabelConfigs []yaml.MapSlice
 


### PR DESCRIPTION
While trying to use the `additionalAlertManagers` field, I noticed this error from the operator:
```
E0821 18:48:21.780219       1 operator.go:798] Sync "my-namespace/my-prometheus" failed: creating config failed: generating config failed: unmarshalling additional alert manager configs failed: yaml: unmarshal errors:
  line 1: cannot unmarshal !!map into []yaml.MapSlice
```
Added a test and fixed the marshalling bug.