### PR TITLE
Don't abort kubelet endpoints update because of nodes without addresses

### DIFF
--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -15,9 +15,14 @@
 package prometheus
 
 import (
+	"reflect"
 	"testing"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestListOptions(t *testing.T) {
@@ -47,5 +52,88 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 
 	if p1Hash == p2Hash {
 		t.Fatal("expected two different Prometheus CRDs to result in two different hash but got equal hash")
+	}
+}
+
+func TestGetNodeAddresses(t *testing.T) {
+	cases := []struct {
+		name              string
+		nodes             *v1.NodeList
+		expectedAddresses []string
+		expectedErrors    int
+	}{
+		{
+			name: "simple",
+			nodes: &v1.NodeList{
+				Items: []v1.Node{
+					v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-0",
+						},
+						Status: v1.NodeStatus{
+							Addresses: []v1.NodeAddress{
+								v1.NodeAddress{
+									Address: "10.0.0.1",
+									Type:    v1.NodeInternalIP,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []string{"10.0.0.1"},
+			expectedErrors:    0,
+		},
+		{
+			// Replicates #1815
+			name: "missing ip on one node",
+			nodes: &v1.NodeList{
+				Items: []v1.Node{
+					v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-0",
+						},
+						Status: v1.NodeStatus{
+							Addresses: []v1.NodeAddress{
+								v1.NodeAddress{
+									Address: "node-0",
+									Type:    v1.NodeHostName,
+								},
+							},
+						},
+					},
+					v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+						},
+						Status: v1.NodeStatus{
+							Addresses: []v1.NodeAddress{
+								v1.NodeAddress{
+									Address: "10.0.0.1",
+									Type:    v1.NodeInternalIP,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []string{"10.0.0.1"},
+			expectedErrors:    1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			addrs, errs := getNodeAddresses(c.nodes)
+			if len(errs) != c.expectedErrors {
+				t.Errorf("Expected %d errors, got %d. Errors: %v", c.expectedErrors, len(errs), errs)
+			}
+			ips := make([]string, 0)
+			for _, addr := range addrs {
+				ips = append(ips, addr.IP)
+			}
+			if !reflect.DeepEqual(ips, c.expectedAddresses) {
+				t.Error(pretty.Compare(ips, c.expectedAddresses))
+			}
+		})
 	}
 }


### PR DESCRIPTION
If a node doesn't have an IP address, currently all endpoint updating is
aborted. This change lets the addressable nodes get updated, and increments an
error counter for alerting on this condition.

Fixes #1815 