### PR TITLE
kube-prometheus: add externalUrl support

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -22,6 +22,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       rules: {},
       renderedRules: {},
       namespaces: ['default', 'kube-system', $._config.namespace],
+      externalUrl: null,
     },
   },
 
@@ -183,7 +184,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
               },
             ],
           },
-        },
+        } + if $._config.prometheus.externalUrl != null then {
+          externalUrl: $._config.prometheus.externalUrl,
+        } else {},
       },
     serviceMonitor:
       {


### PR DESCRIPTION
Currently, it is not possible to add an externalUrl setting for the
Prometheus CRD.

This fixes it by allowing to set the following configuration:

```
local kp =
  (import 'kube-prometheus/kube-prometheus.libsonnet') +
  {
    _config+:: {
      namespace: 'monitoring',
      prometheus+:: {
        externalUrl: 'https://<host>/prometheus',
      },
    },
```

/cc @brancz @mxinden

I have no idea if this "idiomatic" but it solves adding externalUrl
configuration to the Prometheus CRD :-)