### PR TITLE
Makefile: Always generate api.md on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
   include:
   - stage: Sanity check and tests
   # Check generated contents are up to date and code is formatted.
-    script: make format generate-in-docker && git diff --exit-code
+    script: make -B format generate-in-docker && git diff --exit-code
   - script: cd contrib/kube-prometheus && make test-in-docker
   # Build Prometheus Operator rule config map to rule file crds cli tool
   - script: cd cmd/po-rule-migration && go install

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ generate-in-docker: hack/jsonnet-docker-image
 	--rm \
 	-u=$(shell id -u $(USER)):$(shell id -g $(USER)) \
 	-v `pwd`:/go/src/github.com/coreos/prometheus-operator \
-	po-jsonnet make generate
+	po-jsonnet make $(MFLAGS) generate
 
 .PHONY: kube-prometheus
 kube-prometheus:


### PR DESCRIPTION
In PR #1837 only the generated api.md has been changed. Everyone generating now will see a diff with the lines removed. 
To make sure we _always_ generate the api.md and similar docs on travis, we introduce the `-B` flag to the make target which will always run the task.
`$(MFLAGS)` passes the flags from make to its sub-make command.

https://stackoverflow.com/questions/816370/how-do-you-force-a-makefile-to-rebuild-a-target/816400#816400