### PR TITLE
Prometheus Helm Chart: Added permissions to access ingress permission…

### DIFF
--- a/helm/prometheus/templates/clusterrole.yaml
+++ b/helm/prometheus/templates/clusterrole.yaml
@@ -21,6 +21,7 @@ rules:
   - services
   - endpoints
   - pods
+  - ingresses
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources:


### PR DESCRIPTION
…s to ClusterRole

This change allows the Prometheus instance created by the Helm Chart to retrieve Kubernetes ingress resources by using the kubernetes_sd.role: ingress scrape config option.