### PR TITLE
helm: Param to scope Operator to release namespace

### DIFF
--- a/helm/prometheus-operator/README.md
+++ b/helm/prometheus-operator/README.md
@@ -71,6 +71,7 @@ Parameter | Description | Default
 `kubeletService.enable` | If true, the operator will create a service for scraping kubelets | `true`
 `kubeletService.namespace` | The namespace in which the kubelet service should be created | `kube-system`
 `kubeletService.name` | The name of the kubelet service to be created | `kubelet`
+`limitNamespace` | Limit the interaction of the Prometheus Operator to the release namespace | `false`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `prometheusConfigReloader.repository` | prometheus-config-reloader image | `quay.io/coreos/prometheus-config-reloader`
 `prometheusConfigReloader.tag` | prometheus-config-reloader tag | `v0.0.4`

--- a/helm/prometheus-operator/templates/deployment.yaml
+++ b/helm/prometheus-operator/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
           {{- if .Values.logFormat }}
             - --log-format= {{ .Values.logFormat }}
           {{- end }}
+          {{- if .Values.limitNamespace }}
+            - --namespace={{ .Release.Namespace }}
+          {{- end }}
             - --prometheus-config-reloader={{ .Values.prometheusConfigReloader.repository }}:{{ .Values.prometheusConfigReloader.tag }}
             - --config-reloader-image={{ .Values.configmapReload.repository }}:{{ .Values.configmapReload.tag }}
           ports:

--- a/helm/prometheus-operator/values.yaml
+++ b/helm/prometheus-operator/values.yaml
@@ -48,6 +48,9 @@ rbacEnable: true
 ## If true, create Pod Security Policy resources
 pspEnable: true
 
+# Limit the interaction of the Prometheus Operator to the release namespace
+limitNamespace: false
+
 # Reference to one or more secrets to be used when pulling images
 imagePullSecrets: []
 #  - name: "image-pull-secret"


### PR DESCRIPTION
This PR adds the ability to scope the interaction of the operator to the namespace of the Helm release.