### PR TITLE
pkg/prometheus: add node_name to labels

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -403,6 +403,10 @@ func (cg *configGenerator) generateServiceMonitorConfig(version semver.Version, 
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_service_name"}},
 			{Key: "target_label", Value: "service"},
 		},
+		{
+			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_node_name"}},
+			{Key: "target_label", Value: "node"},
+		},
 	}...)
 
 	// Relabel targetLabels from Service onto target.


### PR DESCRIPTION
As per @huydinhle's suggestion in #1463 :

When doing Prometheus debugging, correlating the pod with the host node is useful for disk metrics. To do this it is necessary to get information about the node name.