### PR TITLE
Better disk alert

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/node.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/node.libsonnet
@@ -7,11 +7,10 @@
           {
             alert: 'NodeDiskRunningFull',
             annotations: {
-              description: 'device {{$labels.device}} on node {{$labels.instance}} is running full within the next 24 hours (mounted at {{$labels.mountpoint}})',
-              summary: 'Node disk is running full within 24 hours',
+              message: 'Device {{ $labels.device }} of node-exporter {{ $labels.namespace }}/{{ $labels.pod }} is running full within the next 24 hours.',
             },
             expr: |||
-              predict_linear(node_filesystem_free{%(nodeExporterSelector)s,mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[6h], 3600 * 24) < 0 and on(instance) up{%(nodeExporterSelector)s}
+              (node:node_filesystem_usage: > 0.85) and (predict_linear(node:node_filesystem_avail:[6h], 3600 * 24) < 0)
             ||| % $._config,
             'for': '30m',
             labels: {
@@ -21,11 +20,10 @@
           {
             alert: 'NodeDiskRunningFull',
             annotations: {
-              description: 'device {{$labels.device}} on node {{$labels.instance}} is running full within the next 2 hours (mounted at {{$labels.mountpoint}})',
-              summary: 'Node disk is running full within 2 hours',
+              message: 'Device {{ $labels.device }} of node-exporter {{ $labels.namespace }}/{{ $labels.pod }} is running full within the next 2 hours.',
             },
             expr: |||
-              predict_linear(node_filesystem_free{%(nodeExporterSelector)s,mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[30m], 3600 * 2) < 0 and on(instance) up{%(nodeExporterSelector)s}
+              (node:node_filesystem_usage: > 0.85) and (predict_linear(node:node_filesystem_avail:[30m], 3600 * 2) < 0)
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "f6c5c4311b8c8ad699cfa718a6e1226780b8b3a5"
+            "version": "c22d20f7fc8eb359d4f99bc440175dee0d31c3cf"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": ""
                 }
             },
-            "version": "fee96cc51d22f196c982c6152cc8aee2585f65c0"
+            "version": "ab3d27befcdb31ec286790b8e0ca49bf1deecce5"
         },
         {
             "name": "grafonnet",

--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -781,10 +781,10 @@ spec:
       annotations:
         message: Based on recent sampling, the persistent volume claimed by {{ $labels.persistentvolumeclaim
           }} in namespace {{ $labels.namespace }} is expected to fill up within four
-          days.
+          days. Currently {{ $value }} bytes are available.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays
       expr: |
-        predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[1h], 4 * 24 * 3600) < 0
+        kubelet_volume_stats_available_bytes{job="kubelet"} and predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600) < 0
       for: 5m
       labels:
         severity: critical
@@ -954,21 +954,19 @@ spec:
     rules:
     - alert: NodeDiskRunningFull
       annotations:
-        description: device {{$labels.device}} on node {{$labels.instance}} is running
-          full within the next 24 hours (mounted at {{$labels.mountpoint}})
-        summary: Node disk is running full within 24 hours
+        message: Device {{ $labels.device }} of node-exporter {{ $labels.namespace
+          }}/{{ $labels.pod }} is running full within the next 24 hours.
       expr: |
-        predict_linear(node_filesystem_free{job="node-exporter",mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[6h], 3600 * 24) < 0 and on(instance) up{job="node-exporter"}
+        (node:node_filesystem_usage: > 0.85) and (predict_linear(node:node_filesystem_avail:[6h], 3600 * 24) < 0)
       for: 30m
       labels:
         severity: warning
     - alert: NodeDiskRunningFull
       annotations:
-        description: device {{$labels.device}} on node {{$labels.instance}} is running
-          full within the next 2 hours (mounted at {{$labels.mountpoint}})
-        summary: Node disk is running full within 2 hours
+        message: Device {{ $labels.device }} of node-exporter {{ $labels.namespace
+          }}/{{ $labels.pod }} is running full within the next 2 hours.
       expr: |
-        predict_linear(node_filesystem_free{job="node-exporter",mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[30m], 3600 * 2) < 0 and on(instance) up{job="node-exporter"}
+        (node:node_filesystem_usage: > 0.85) and (predict_linear(node:node_filesystem_avail:[30m], 3600 * 2) < 0)
       for: 10m
       labels:
         severity: critical


### PR DESCRIPTION
Only trigger disk running full alerts when the disk capacity is over 85%
and use recording rule of the kubernetes-mixin to only consider real
physical filesystems.

I chose 85% because the kubelet garbage collects unused container
images at 80% disk usage.

@mxinden @squat @s-urbaniak @metalmatze 