### PR TITLE
Add `scheme` to exporter-kube-controller-manager ServiceMonitor

### DIFF
--- a/helm/exporter-kube-controller-manager/templates/servicemonitor.yaml
+++ b/helm/exporter-kube-controller-manager/templates/servicemonitor.yaml
@@ -23,6 +23,7 @@ spec:
       - "kube-system"
   endpoints:
   - port: http-metrics
+    scheme: {{ .Values.scheme }}
     interval: 15s
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt


### PR DESCRIPTION
Allows us to properly monitor a secured kube-controller-manager