### PR TITLE
Add square brackets around pod IPs

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -195,7 +195,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 
 	amArgs := []string{
 		fmt.Sprintf("--config.file=%s", alertmanagerConfFile),
-		fmt.Sprintf("--cluster.listen-address=$(POD_IP):%d", 6783),
+		fmt.Sprintf("--cluster.listen-address=[$(POD_IP)]:%d", 6783),
 		fmt.Sprintf("--storage.path=%s", alertmanagerStorageDir),
 		fmt.Sprintf("--data.retention=%s", a.Spec.Retention),
 	}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -599,8 +599,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 			"sidecar",
 			fmt.Sprintf("--prometheus.url=http://%s:9090", c.LocalHost),
 			fmt.Sprintf("--tsdb.path=%s", storageDir),
-			fmt.Sprintf("--cluster.address=$(POD_IP):%d", 10900),
-			fmt.Sprintf("--grpc-address=$(POD_IP):%d", 10901),
+			fmt.Sprintf("--cluster.address=[$(POD_IP)]:%d", 10900),
+			fmt.Sprintf("--grpc-address=[$(POD_IP)]:%d", 10901),
 		}
 
 		if p.Spec.Thanos.Peers != nil {


### PR DESCRIPTION
IPv6 pod IPs need to be enclosed in square brackets.  This closes #1858.