### PR TITLE
helm/prometheus: Add targetLabels support for servicemonitors under Prometheus chart

### DIFF
--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -349,6 +349,11 @@ prometheus:
       ##
       # jobLabel: ""
 
+      ## TargetLabels for transfering labels on the Kubernetes Service onto the target
+      ## If no label is specified, it is ignored
+      ##
+      # targetLabels: []
+
       ## Label selector for services to which this ServiceMonitor applies
       ##
       # selector: {}

--- a/helm/prometheus/templates/servicemonitors.yaml
+++ b/helm/prometheus/templates/servicemonitors.yaml
@@ -31,6 +31,10 @@ items:
       namespaceSelector:
 {{ toYaml .namespaceSelector | indent 8 }}
     {{- end }}
+    {{- if .targetLabels }}
+      targetLabels:
+{{ toYaml .targetLabels | indent 8 }}
+    {{- end}}
       selector:
 {{ toYaml .selector | indent 8 }}
 {{- end }}

--- a/helm/prometheus/values.yaml
+++ b/helm/prometheus/values.yaml
@@ -265,6 +265,11 @@ serviceMonitors: []
     ##
     # jobLabel: ""
 
+    ## TargetLabels for transfering labels on the Kubernetes Service onto the target
+    ## If no label is specified, it is ignored
+    ##
+    # targetLabels: []
+
     ## Label selector for services to which this ServiceMonitor applies
     ##
     # selector: {}


### PR DESCRIPTION
Add targetLabels to prometheus chart based on ServiceMonitorSpec