### PR TITLE
 exporter-node chart: Set rollingUpdate release strategy 

### DIFF
--- a/helm/exporter-node/Chart.yaml
+++ b/helm/exporter-node/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes node exporter
 name: exporter-node
-version: 0.4.6
+version: 0.4.7
 maintainers:
   - name: Giancarlo Rubio
     email: gianrubio@gmail.com
-appVersion: "0.14.0"
+appVersion: "0.15.2"
 home: https://github.com/prometheus/node-exporter
 sources:
   - https://github.com/prometheus/node-exporter

--- a/helm/exporter-node/templates/daemonset.yaml
+++ b/helm/exporter-node/templates/daemonset.yaml
@@ -10,6 +10,10 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "exporter-node.fullname" . }}
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -58,7 +58,7 @@ dependencies:
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
   - name: exporter-node
-    version: 0.4.6
+    version: 0.4.7
     #e2e-repository: file://../exporter-node
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
     condition: deployExporterNode


### PR DESCRIPTION
This helps ensure that when we make a change it actually gets deployed.

bump the chart version to indicate this change; bump the appVersion to
reflect the version of node-exporter being deployed.