### PR TITLE
update Thanos to v0.1.0

### DIFF
--- a/example/thanos/querier-deployment.yaml
+++ b/example/thanos/querier-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: thanos-query
-        image: improbable/thanos:v0.1.0-rc.2
+        image: improbable/thanos:v0.1.0
         args:
         - "query"
         - "--log.level=debug"

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -35,7 +35,7 @@ import (
 const (
 	governingServiceName     = "prometheus-operated"
 	DefaultPrometheusVersion = "v2.3.2"
-	DefaultThanosVersion     = "v0.1.0-rc.2"
+	DefaultThanosVersion     = "v0.1.0"
 	defaultRetention         = "24h"
 	storageDir               = "/prometheus"
 	confDir                  = "/etc/prometheus/config"
@@ -599,7 +599,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 		thanosArgs := []string{
 			"sidecar",
 			fmt.Sprintf("--prometheus.url=http://%s:9090", c.LocalHost),
-			fmt.Sprintf("--tsdb.path=%s", storageDir),
+			fmt.Sprintf("--data-dir=%s", storageDir),
 			fmt.Sprintf("--cluster.address=[$(POD_IP)]:%d", 10900),
 			fmt.Sprintf("--grpc-address=[$(POD_IP)]:%d", 10901),
 		}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -402,7 +402,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 func TestThanosTagAndShaAndVersion(t *testing.T) {
 	{
 		thanosTag := "my-unrelated-tag"
-		thanosVersion := "v0.1.0-rc.2"
+		thanosVersion := "v0.1.0"
 		sset, err := makeStatefulSet(monitoringv1.Prometheus{
 			Spec: monitoringv1.PrometheusSpec{
 				Thanos: &monitoringv1.ThanosSpec{

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1147,7 +1147,7 @@ func testThanos(t *testing.T) {
 	querierServiceName := "thanos-querier"
 	basicPrometheus := framework.MakeBasicPrometheus(ns, "basic-prometheus", "test-group", 1)
 	peerServiceDNS := fmt.Sprintf("%s.%s.svc:10900", peerServiceName, ns)
-	version := "v0.1.0-rc.1"
+	version := "v0.1.0"
 	basicPrometheus.Spec.Thanos = &monitoringv1.ThanosSpec{
 		Peers:   &peerServiceDNS,
 		Version: &version,


### PR DESCRIPTION
This updates default version of Thanos to v0.1.0. The update is motivated by the ability to use EC2 node's IAM policy to access S3 bucket rather than passing AWS Keys into the configuration.

v0.1.0 is not backward-compatible - see https://github.com/improbable-eng/thanos/releases/tag/v0.1.0