### PR TITLE
contrib/kube-prometheus: Set antiAffinity for Prometheus & Alertmanager

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-anti-affinity.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-anti-affinity.libsonnet
@@ -1,0 +1,39 @@
+local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local statefulSet = k.apps.v1beta2.statefulSet;
+local affinity = statefulSet.mixin.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecutionType;
+local matchExpression = affinity.mixin.podAffinityTerm.labelSelector.matchExpressionsType;
+
+{
+  local antiaffinity(key, values) = {
+    affinity: {
+      podAntiAffinity: {
+        preferredDuringSchedulingIgnoredDuringExecution: [
+          affinity.new() +
+          affinity.withWeight(100) +
+          affinity.mixin.podAffinityTerm.withNamespaces($._config.namespace) +
+          affinity.mixin.podAffinityTerm.withTopologyKey('kubernetes.io/hostname') +
+          affinity.mixin.podAffinityTerm.labelSelector.withMatchExpressions([
+            matchExpression.new() +
+            matchExpression.withKey(key) +
+            matchExpression.withOperator('In') +
+            matchExpression.withValues(values),
+          ]),
+        ],
+      },
+    },
+  },
+
+  alertmanager+:: {
+    alertmanager+: {
+      spec+:
+        antiaffinity('alertmanager', [$._config.alertmanager.name]),
+    },
+  },
+
+  prometheus+: {
+    prometheus+: {
+      spec+:
+        antiaffinity('prometheus', [$._config.prometheus.name]),
+    },
+  },
+}

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -144,12 +144,14 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local roleList = k.rbac.v1.roleList;
       roleList.new([newSpecificRole(x) for x in $._config.prometheus.namespaces]),
     prometheus:
-      local container = k.core.v1.pod.mixin.spec.containersType;
+      local statefulSet = k.apps.v1beta2.statefulSet;
+      local container = statefulSet.mixin.spec.template.spec.containersType;
       local resourceRequirements = container.mixin.resourcesType;
-      local selector = k.apps.v1beta2.deployment.mixin.spec.selectorType;
+      local selector = statefulSet.mixin.spec.selectorType;
 
-      local resources = resourceRequirements.new() +
-                        resourceRequirements.withRequests({ memory: '400Mi' });
+      local resources =
+        resourceRequirements.new() +
+        resourceRequirements.withRequests({ memory: '400Mi' });
 
       {
         apiVersion: 'monitoring.coreos.com/v1',


### PR DESCRIPTION
This will set podAntiAffinity for Prometheus & Alertmanager signaling the kube scheduler to schedule pods on different nodes.
I've tested these updated mixins in my private cluster. Works great and as expected.
I'm kind of suprised we didn't had this. 😇 

Closes #1930 

/cc @brancz 