### PR TITLE
remove duplicate alertmanager down alert

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/alertmanager.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/alertmanager.libsonnet
@@ -18,19 +18,6 @@
             },
           },
           {
-            alert: 'AlertmanagerDownOrMissing',
-            annotations: {
-              message: 'An unexpected number of Alertmanagers were scraped or disappeared from discovery.',
-            },
-            expr: |||
-              label_replace(prometheus_operator_alertmanager_spec_replicas{%(prometheusOperatorSelector)s}, "job", "alertmanager-$1", "alertmanager", "(.*)") / ON(job) GROUP_RIGHT() sum(up{%(alertmanagerSelector)s}) BY (job) != 1
-            ||| % $._config,
-            'for': '5m',
-            labels: {
-              severity: 'warning',
-            },
-          },
-          {
             alert: 'AlertmanagerFailedReload',
             annotations: {
               message: "Reloading Alertmanager's configuration has failed for {{ $labels.namespace }}/{{ $labels.pod}}.",

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "2694cabc85ed89b3c8ac0865bcbc29d72e52eb2f"
+            "version": "ad23783d41d47f04bb1262ab232d4a9c160570c6"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -934,15 +934,6 @@ spec:
       for: 5m
       labels:
         severity: critical
-    - alert: AlertmanagerDownOrMissing
-      annotations:
-        message: An unexpected number of Alertmanagers were scraped or disappeared
-          from discovery.
-      expr: |
-        label_replace(prometheus_operator_alertmanager_spec_replicas{job="prometheus-operator"}, "job", "alertmanager-$1", "alertmanager", "(.*)") / ON(job) GROUP_RIGHT() sum(up{job="alertmanager-main"}) BY (job) != 1
-      for: 5m
-      labels:
-        severity: warning
     - alert: AlertmanagerFailedReload
       annotations:
         message: Reloading Alertmanager's configuration has failed for {{ $labels.namespace


### PR DESCRIPTION
cc @brancz @sichvoge 

This commit removes the handwritten Alertmanager down alert since there is already an automatically generated `X down` alert for every job.