### PR TITLE
contrib/kube-prometheus: Drop etcd metrics by apiserver & kube controller

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -442,6 +442,11 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: etcd_(debugging|disk|request|server).*
+      sourceLabels:
+      - __name__
     port: https
     scheme: https
     tlsConfig:
@@ -504,6 +509,11 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: etcd_(debugging|disk|request|server).*
+      sourceLabels:
+      - __name__
     port: http-metrics
   jobLabel: k8s-app
   namespaceSelector:

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -308,6 +308,13 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
             {
               port: 'http-metrics',
               interval: '30s',
+              metricRelabelings: [
+                {
+                  sourceLabels: ['__name__'],
+                  regex: 'etcd_(debugging|disk|request|server).*',
+                  action: 'drop',
+                },
+              ],
             },
           ],
           selector: {
@@ -356,6 +363,13 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                 serverName: 'kubernetes',
               },
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+              metricRelabelings: [
+                {
+                  sourceLabels: ['__name__'],
+                  regex: 'etcd_(debugging|disk|request|server).*',
+                  action: 'drop',
+                },
+              ],
             },
           ],
         },

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "50b1dbe739d9e4a59fb936b1733f8e53c86de897"
+            "version": "004e648d186bc7be6f1f519da26f96bc2533f1b6"
         },
         {
             "name": "ksonnet",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "94aef231932810633416bfe596a41dbad2b1ebb9"
+            "version": "bce24b0b087f7dc09c9e9f066f3e554a851792e9"
         },
         {
             "name": "grafana",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "a3e242d80ae1a13ae57904fc12e91fe4c9ecf972"
+            "version": "c74998267c71ef4a0fa847ce16d620b7fe3580bf"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/prometheus-serviceMonitorApiserver.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-serviceMonitorApiserver.yaml
@@ -9,6 +9,11 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: etcd_(debugging|disk|request|server).*
+      sourceLabels:
+      - __name__
     port: https
     scheme: https
     tlsConfig:

--- a/contrib/kube-prometheus/manifests/prometheus-serviceMonitorKubeControllerManager.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-serviceMonitorKubeControllerManager.yaml
@@ -8,6 +8,11 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: etcd_(debugging|disk|request|server).*
+      sourceLabels:
+      - __name__
     port: http-metrics
   jobLabel: k8s-app
   namespaceSelector:


### PR DESCRIPTION
Recently, we received a bug report that the etcd dashboard shows clusters that aren't real clusters like apiserver and kube-controllers.

Screenshot: https://bugzilla.redhat.com/attachment.cgi?id=1485839
Bug Report: https://bugzilla.redhat.com/show_bug.cgi?id=1631926

Apparently some Kubernetes components expose the `etcd_server_has_leader` metric as well, as they are probably vendoring etcd as library which then registers these metrics.
You can take a look at all `etcd_` prefix metrics by running `kubectl proxy` in one terminal and then run `curl -s http://localhost:8001/metrics | grep etcd_` in another terminal.

This will eventually be fixed on the Kubernetes side with the metrics overhaul:
kubernetes/kubernetes#67476 (comment)

As a workaround, we propose to simply drop the `etcd_server_has_leader` metric for job apiserver & kube-controllers. More precisely I want to drop all metrics that these components expose and are useless like this `etcd_(debugging|disk|request|server).*` 

/cc @mxinden @brancz 