### PR TITLE
kube-prometheus: support Kubernetes installs sourcing all images from an internal repository

### DIFF
--- a/contrib/kube-prometheus/examples/internal-registry.jsonnet
+++ b/contrib/kube-prometheus/examples/internal-registry.jsonnet
@@ -1,0 +1,14 @@
+local mixin = import 'kube-prometheus/kube-prometheus-config-mixins.libsonnet';
+local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') + {
+  _config+:: {
+    namespace: 'monitoring',
+  },
+} + mixin.withImageRepository('internal-registry.com/organization');
+
+{ ['00namespace-' + name]: kp.kubePrometheus[name] for name in std.objectFields(kp.kubePrometheus) } +
+{ ['0prometheus-operator-' + name]: kp.prometheusOperator[name] for name in std.objectFields(kp.prometheusOperator) } +
+{ ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
+{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
+{ ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
+{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) }

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-config-mixins.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-config-mixins.libsonnet
@@ -1,0 +1,20 @@
+local l = import 'lib/lib.libsonnet';
+
+// withImageRepository is a mixin that replaces all images prefixes by repository. eg.
+// quay.io/coreos/addon-resizer -> $repository/addon-resizer
+// grafana/grafana -> grafana $repository/grafana
+local withImageRepository(repository) = {
+  local oldRepos = super._config.imageRepos,
+  local substituteRepository(image, repository) =
+    if repository == null then image else repository + '/' + l.imageName(image),
+  _config+:: {
+    imageRepos:: {
+      [field]: substituteRepository(oldRepos[field], repository),
+      for field in std.objectFields(oldRepos)
+    }
+  },
+};
+
+{
+  withImageRepository:: withImageRepository,
+}

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/lib/image.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/lib/image.libsonnet
@@ -1,0 +1,21 @@
+// imageName extracts the image name from a fully qualified image string. eg.
+// quay.io/coreos/addon-resizer -> addon-resizer
+// grafana/grafana -> grafana
+local imageName(image) =
+  local parts = std.split(image, '/');
+  local len = std.length(parts);
+  if len == 3 then
+    # registry.com/org/image
+    parts[2]
+  else if len == 2 then
+    # org/image
+    parts[1]
+  else if len == 1 then
+    # image, ie. busybox
+    parts[0]
+  else
+      error 'unknown image format: ' + image;
+
+{
+  imageName:: imageName,
+}

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/lib/lib.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/lib/lib.libsonnet
@@ -1,0 +1,1 @@
+(import 'image.libsonnet')

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "949ffab68a175c0100cb5b9ac84a47d19752f868"
+            "version": "b0fb3d478adaf8a9749137921642d4c794a66bbd"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/sync-to-internal-registry.jsonnet
+++ b/contrib/kube-prometheus/sync-to-internal-registry.jsonnet
@@ -1,0 +1,30 @@
+local kp = import 'kube-prometheus/kube-prometheus.libsonnet';
+local l = import 'kube-prometheus/lib/lib.libsonnet';
+local config = kp._config;
+
+local makeImages(config) = [
+    {
+        name: config.imageRepos[image],
+        tag: config.versions[image],
+    }
+    for image in std.objectFields(config.imageRepos)
+];
+
+local upstreamImage(image) = '%s:%s' % [image.name, image.tag];
+local downstreamImage(registry, image) = '%s/%s:%s' % [registry, l.imageName(image.name), image.tag];
+
+local pullPush(image, newRegistry) = [
+    'docker pull %s' % upstreamImage(image),
+    'docker tag %s %s' % [upstreamImage(image), downstreamImage(newRegistry, image)],
+    'docker push %s' % downstreamImage(newRegistry, image),
+];
+
+local images = makeImages(config);
+
+local output(repository) = std.flattenArrays([
+  pullPush(image, repository)
+  for image in images
+]);
+
+function(repository="my-registry.com/repository")
+    std.join('\n', output(repository))

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -6,6 +6,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
     versions+:: {
       prometheusOperator: 'v0.24.0',
+      prometheusConfigReloader: self.prometheusOperator,
       configmapReloader: 'v0.0.1',
     },
 
@@ -123,7 +124,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           // default glog saves logfiles to /tmp. Make it log to stderr instead.
           '--logtostderr=true',
           '--config-reloader-image=' + $._config.imageRepos.configmapReloader + ':' + $._config.versions.configmapReloader,
-          '--prometheus-config-reloader=' + $._config.imageRepos.prometheusConfigReloader + ':' + $._config.versions.prometheusOperator,
+          '--prometheus-config-reloader=' + $._config.imageRepos.prometheusConfigReloader + ':' + $._config.versions.prometheusConfigReloader,
         ]) +
         container.mixin.securityContext.withAllowPrivilegeEscalation(false) +
         container.mixin.securityContext.withReadOnlyRootFilesystem(true) +


### PR DESCRIPTION
Some people have Kubernetes deployments in restricted environments without internet access and need to source images from internal repositories.

This PR introduced such support in kube-prometheus:
- A jsonnet script to output docker pull/tag/push commands to synchronize upstream images used by kube-prometheus to an internal registry.
- A mixin to mutate `_config.imageRepos` to point images at that internal registry.
- Document those two points above.