### PR TITLE
operator: Add watch-secrets flag to enable/disable secret watching

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -61,6 +61,12 @@ rules:
   - ""
   resources:
   - configmaps
+  # You may choose to restrict this to the namespaces the Prometheus objects are in instead of all the namespaces
+  # by setting --watch-secrets=false in the operator and configuring the proper RBAC in a Role. The operator will need
+  # access to all verbs for the Secrets in the namespaces that the Prometheus objects are in, and view acces in namespaces
+  # where ServiceMonitors specify Basic Auth configurations.
+  # By doing so, the operator will not watch secrets in all namespaces at the cost of not refreshing the Prometheus configuration
+  # upon relevant secret changes, such as when a Basic Auth secret is altered.
   - secrets
   verbs:
   - '*'

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -133,6 +133,7 @@ func init() {
 	flagset.StringVar(&cfg.LogLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(availableLogLevels, ", ")))
 	flagset.StringVar(&cfg.LogFormat, "log-format", logFormatLogfmt, fmt.Sprintf("Log format to use. Possible values: %s", strings.Join(availableLogFormats, ", ")))
 	flagset.BoolVar(&cfg.ManageCRDs, "manage-crds", true, "Manage all CRDs with the Prometheus Operator.")
+	flagset.BoolVar(&cfg.WatchSecrets, "watch-secrets", true, "Watching secrets with the Prometheus Operator. Disable if you wish to restrict secrets viewing and accept that updating relevant secrets will require manual refreshing of the Operator.")
 	flagset.Parse(os.Args[1:])
 	cfg.Namespaces = ns.asSlice()
 }

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -148,6 +148,7 @@ type Config struct {
 	LogLevel                     string
 	LogFormat                    string
 	ManageCRDs                   bool
+	WatchSecrets                 bool
 }
 
 type BasicAuthCredentials struct {
@@ -305,17 +306,21 @@ func (c *Operator) RegisterMetrics(r prometheus.Registerer) {
 // waitForCacheSync waits for the informers' caches to be synced.
 func (c *Operator) waitForCacheSync(stopc <-chan struct{}) error {
 	ok := true
-	informers := []struct {
-		name     string
+
+	type informerStruct struct {
+		name	 string
 		informer cache.SharedIndexInformer
-	}{
+	}
+	informers := []informerStruct {
 		{"Prometheus", c.promInf},
 		{"ServiceMonitor", c.smonInf},
 		{"PrometheusRule", c.ruleInf},
 		{"ConfigMap", c.cmapInf},
-		{"Secret", c.secrInf},
 		{"StatefulSet", c.ssetInf},
 		{"Namespace", c.nsInf},
+	}
+	if c.config.WatchSecrets {
+		informers = append(informers, informerStruct{name: "Secret", informer: c.secrInf})
 	}
 	for _, inf := range informers {
 		if !cache.WaitForCacheSync(stopc, inf.informer.HasSynced) {
@@ -354,11 +359,13 @@ func (c *Operator) addHandlers() {
 		DeleteFunc: c.handleConfigMapDelete,
 		UpdateFunc: c.handleConfigMapUpdate,
 	})
-	c.secrInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.handleSecretAdd,
-		DeleteFunc: c.handleSecretDelete,
-		UpdateFunc: c.handleSecretUpdate,
-	})
+	if c.config.WatchSecrets {
+		c.secrInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    c.handleSecretAdd,
+			DeleteFunc: c.handleSecretDelete,
+			UpdateFunc: c.handleSecretUpdate,
+		})
+	}
 	c.ssetInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.handleStatefulSetAdd,
 		DeleteFunc: c.handleStatefulSetDelete,
@@ -404,7 +411,9 @@ func (c *Operator) Run(stopc <-chan struct{}) error {
 	go c.smonInf.Run(stopc)
 	go c.ruleInf.Run(stopc)
 	go c.cmapInf.Run(stopc)
-	go c.secrInf.Run(stopc)
+	if c.config.WatchSecrets {
+		go c.secrInf.Run(stopc)
+	}
 	go c.ssetInf.Run(stopc)
 	go c.nsInf.Run(stopc)
 	if err := c.waitForCacheSync(stopc); err != nil {
@@ -1205,24 +1214,23 @@ func (c *Operator) loadBasicAuthSecrets(
 ) (map[string]BasicAuthCredentials, error) {
 
 	sMonSecretMap := make(map[string]*v1.SecretList)
-	for _, mon := range mons {
-		smNamespace := mon.Namespace
-		if sMonSecretMap[smNamespace] == nil {
-			msClient := c.kclient.CoreV1().Secrets(smNamespace)
-			listSecrets, err := msClient.List(metav1.ListOptions{})
-
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to retrieve secrets in namespace '%v' for servicemonitor '%v'", smNamespace, mon.Name)
-			}
-			sMonSecretMap[smNamespace] = listSecrets
-		}
-	}
-
 	secrets := map[string]BasicAuthCredentials{}
 	for _, mon := range mons {
 		for i, ep := range mon.Spec.Endpoints {
 			if ep.BasicAuth != nil {
-				credentials, err := loadBasicAuthSecret(ep.BasicAuth, sMonSecretMap[mon.Namespace])
+				smNamespace := mon.Namespace
+				// Load namespace's secrets if not previously fetched
+				if sMonSecretMap[smNamespace] == nil {
+					msClient := c.kclient.CoreV1().Secrets(smNamespace)
+					listSecrets, err := msClient.List(metav1.ListOptions{})
+
+					if err != nil {
+						return nil, errors.Wrapf(err, "failed to retrieve secrets in namespace '%v' for servicemonitor '%v'", smNamespace, mon.Name)
+					}
+					sMonSecretMap[smNamespace] = listSecrets
+				}
+
+				credentials, err := loadBasicAuthSecret(ep.BasicAuth, sMonSecretMap[smNamespace])
 				if err != nil {
 					return nil, fmt.Errorf("could not generate basicAuth for servicemonitor %s. %s", mon.Name, err)
 				}


### PR DESCRIPTION
This allows for more restricted RBAC in which the Prometheus Operator does not have
view access to all secrets in the cluster.

We would like to use the Prometheus Operator with an RBAC scheme that more strictly regulates what secrets the Operator can view/watch. There were two key places I found where Secrets viewing weren't necessary for those who don't use Basic Auth:
 - Listing secrets in namespaces containing ServiceMonitors, regardless of whether any of the ServiceMonitors specify any basic auth configs.
- Watching secrets for updates to trigger a Prometheus refresh

The first point's behavior has been changed to looping through the service monitors, and if basic auth is configured, list the secrets for the namespace like before. This allows us to minimize how many namespace's secrets we list, and ultimately avoid it entirely if no ServiceMonitors specify basic auth configs.

The second point is addressed by adding a flag to toggle watching secrets. Setting --watch-secrets to false means that the operator will not attempt to watch all the secrets, at the cost of the Prometheus Operator not triggering a refresh if a secret is updated. This cost is documented in the Getting Started guide, and it's a cost we're willing to take in exchange for restricting the Operator's RBAC permissions.

In the long-run, it might be better to watch/stop watching namespace secrets as service monitors with basic auth configs come and go, but that'll require mucking around with the multi-namespace logic and keeping track of when we can stop watching a namespace