### PR TITLE
exporter-node: namespace selector setting

### DIFF
--- a/helm/exporter-node/templates/servicemonitor.yaml
+++ b/helm/exporter-node/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     prometheus: {{ .Release.Name }}
     {{- if .Values.additionalServiceMonitorLabels }}
 {{ toYaml .Values.additionalServiceMonitorLabels | indent 4 }}
-    {{- end }}    
+    {{- end }}
   name: {{ template "exporter-node.fullname" . }}
 spec:
   jobLabel: component
@@ -20,7 +20,7 @@ spec:
       component: node-exporter
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace | quote }}
+      - {{ default .Release.Namespace .Values.namespaceSelector | quote }}
   endpoints:
   - port: metrics
     interval: 15s

--- a/helm/exporter-node/values.yaml
+++ b/helm/exporter-node/values.yaml
@@ -56,7 +56,7 @@ nodeSelector: []
 global:
   rbacEnable: true
   pspEnable: true
-  
+
   # Reference to one or more secrets to be used when pulling images
   imagePullSecrets: []
   #  - name: "image-pull-secret"
@@ -73,6 +73,8 @@ additionalRulesLabels: {}
 
 # deploy node_exporter as a DaemonSet
 enableDaemonSet: true
+# set to monitor exporter from a different namespace
+namespaceSelector:
 # for deployments that have node_exporter deployed outside of the cluster, list
 # their addresses here
 endpoints: []


### PR DESCRIPTION
Used for specifying in which namespace the exporters are running, since they can only be deployed once for each node.
In my case the operator and exporter-node runs in kube-system, prometheus and servicemonitor runs in foobar. ServiceMonitor defaults to looking in foobar, not kube-system. I can now override this by setting `namespaceSelector: kube-system` in helm values.