### PR TITLE
Makefile: Pass MFLAGS in kube-prometheus target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ generate-in-docker: hack/jsonnet-docker-image
 
 .PHONY: kube-prometheus
 kube-prometheus:
-	cd contrib/kube-prometheus && $(MAKE) generate
+	cd contrib/kube-prometheus && $(MAKE) $(MFLAGS) generate
 
 example/prometheus-operator-crd/**.crd.yaml: pkg/client/monitoring/v1/openapi_generated.go $(PO_CRDGEN_BINARY)
 	po-crdgen prometheus > example/prometheus-operator-crd/prometheus.crd.yaml


### PR DESCRIPTION
In .travis.yaml we are using the `--always-make` make flag to force a
regenerate on all dependencies. This should be passed down in the
kube-prometheus target.