### PR TITLE
kube-prometheus/README.md:  Add jb update to contrib guide

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -497,5 +497,7 @@ the following process:
 1. Make your changes in the respective `*.jsonnet` file.
 2. Commit your changes (This is currently necessary due to our vendoring
    process. This is likely to change in the future).
+3. Update the pinned kube-prometheus dependency in `jsonnetfile.lock.json`: `jb
+   update`.
 3. Generate dependent `*.yaml` files: `make generate-in-docker`.
 4. Commit the generated changes.


### PR DESCRIPTION
With pinning the kube-prometheus dependency for the generated
`/manifest` folder, one needs to update the `jsonnetfile.lock.json` on
`*.jsonnet` file changes.

Originated from: https://github.com/coreos/prometheus-operator/pull/1983