### PR TITLE
Make kube-prometheus chart compatible with `helm template`

### DIFF
--- a/helm/kube-prometheus/templates/_helpers.tpl
+++ b/helm/kube-prometheus/templates/_helpers.tpl
@@ -28,9 +28,5 @@ If release name contains chart name it will be used as a full name.
 Return the appropriate apiVersion value to use for the prometheus-operator managed k8s resources
 */}}
 {{- define "prometheus-operator.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
 {{- printf "%s" "monitoring.coreos.com/v1" -}}
-{{- else -}}
-{{- printf "%s" "monitoring.coreos.com/v1alpha1" -}}
-{{- end -}}
 {{- end -}}

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -128,7 +128,7 @@ alertmanager:
 
     ## Cluster-internal IP address for Alertmanager Service
     ##
-    clusterIP: ""
+    clusterIP: null
 
     ## List of external IP addresses at which the Alertmanager Service will be available
     ##
@@ -306,7 +306,7 @@ prometheus:
 
     ## Cluster-internal IP address for Prometheus Service
     ##
-    clusterIP: ""
+    clusterIP: null
 
     ## List of external IP addresses at which the Prometheus Service will be available
     ##


### PR DESCRIPTION
The kube-prometheus chart currently does two things that make it very
difficult to use with `helm template`:

  1. Defaults to `monitoring.coreos.v1alpha1` for the CRD apiVersion
     depending on the the `.Capabilities`. This is set in _helpers.yaml,
     so `helm template` does not have the opportunity to set the
     apiVersion correctly.
  2. Sets the `.spec.clusterIP` field of several services to "" rather
     than `null`. This means that if any of those services are ever
     updated for any reason, we will get an error, because this field is
     immutable.

This commit will correct both of these things by substituting sensible
defaults instead.

In the case of the first issue, we'll simply default to
`monitoring.coreos.v1`, since (1) that is what the vast majority of
users will be using anyway, and (2) defaulting to v1alpha1 is arbitrary
anyway.

In the case of the second, we'll default to `null` which has the same
effect (i.e., the API server will automatically assign a ClusterIP), but
also makes it safe to update the resource and call `kubectl apply` on
the result.