### PR TITLE
add ThanosSpec.ClusterAdvertisePort and ThanosSpec.GRPCAdvertisePort

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -514,5 +514,7 @@ ThanosSpec defines parameters for a Prometheus server within a Thanos deployment
 | resources | Resources defines the resource requirements for the Thanos sidecar. If not provided, no requests/limits will be set | [v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#resourcerequirements-v1-core) | false |
 | gcs | GCS configures use of GCS in Thanos. | *[ThanosGCSSpec](#thanosgcsspec) | false |
 | s3 | S3 configures use of S3 in Thanos. | *[ThanosS3Spec](#thanoss3spec) | false |
+| clusterAdvertisePort | ClusterAdvertisePort is the port of advertise address for gossip in gossip cluster. Will advertise `NodeIP:ClusterAdvertisePort`, use `service:[type=NodePort, nodePort=ClusterAdvertisePort, externalTrafficPolicy: Local]` to advertise the sidecar, to build a global scale Thanos cluster.[More Info](https://github.com/improbable-eng/thanos/issues/454) | int32 | false |
+| gRPCAdvertisePort | GRPCAdvertisePort is the port of advertise address for gRPC StoreAPI in gossip cluster. Will advertise `NodeIP:GRPCAdvertisePort`, use `service:[type=NodePort, nodePort=GRPCAdvertisePort, externalTrafficPolicy: Local]` to advertise the sidecar, build a global scale Thanos cluster.[More Info](https://github.com/improbable-eng/thanos/issues/454) | int32 | false |
 
 [Back to TOC](#table-of-contents)

--- a/pkg/client/monitoring/v1/openapi_generated.go
+++ b/pkg/client/monitoring/v1/openapi_generated.go
@@ -2302,14 +2302,16 @@ func schema_pkg_client_monitoring_v1_ThanosSpec(ref common.ReferenceCallback) co
 					},
 					"clusterAdvertisePort": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "ClusterAdvertisePort is the port of advertise address for gossip in gossip cluster",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"gRPCAdvertisePort": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "GRPCAdvertisePort is the port of advertise address for gRPC StoreAPI in gossip cluster",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"version": {

--- a/pkg/client/monitoring/v1/openapi_generated.go
+++ b/pkg/client/monitoring/v1/openapi_generated.go
@@ -2300,6 +2300,18 @@ func schema_pkg_client_monitoring_v1_ThanosSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"clusterAdvertisePort": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
+					"gRPCAdvertisePort": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Version describes the version of Thanos to use.",

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -248,6 +248,11 @@ type StorageSpec struct {
 type ThanosSpec struct {
 	// Peers is a DNS name for Thanos to discover peers through.
 	Peers *string `json:"peers,omitempty"`
+
+	// ClusterAdvertisePort is the port of advertise address for gossip in gossip cluster
+	ClusterAdvertisePort int32 `json:"clusterAdvertisePort,omitempty"`
+	// GRPCAdvertisePort is the port of advertise address for gRPC StoreAPI in gossip cluster
+	GRPCAdvertisePort int32 `json:"gRPCAdvertisePort,omitempty"`
 	// Version describes the version of Thanos to use.
 	Version *string `json:"version,omitempty"`
 	// Tag of Thanos sidecar container image to be deployed. Defaults to the value of `version`.


### PR DESCRIPTION
for advertise the sidecar via service:NodePort with `externalTrafficPolicy: Local`
for build a global scale thanos cluster on top of multiple k8s clusters
with prometheus-operator

------

relate to: https://github.com/improbable-eng/thanos/issues/454

- we have deployed the prometheus-operator in each k8s cluster, and we need to maintain all the prometheus via thanos.
- thanos is based on gossip, so the sidecar should advertise itself
- while all the components are not in the same cluster, the sidecar can advertise via NodePort. e.g. 
- use `service:[type=NodePort,  nodePort=AdvertisePort]`, use the `externalTrafficPolicy: Local`, the requests to `NodeIP:AdvertisePort` will route to the sidecar on the same Node.




