### PR TITLE
example: capitalise network policies protocol

### DIFF
--- a/Documentation/network-policies.md
+++ b/Documentation/network-policies.md
@@ -62,7 +62,7 @@ spec:
   - from:
     ports:
     - port: 9093
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       alertmanager: main
@@ -87,7 +87,7 @@ spec:
           - main
     ports:
     - port: 6783
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       alertmanager: main
@@ -108,7 +108,7 @@ spec:
   ingress:
   - ports:
     - port: 3000
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       app: grafana
@@ -128,7 +128,7 @@ spec:
   ingress:
   - ports:
     - port: 9090
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       app: prometheus
@@ -160,7 +160,7 @@ spec:
           - k8s
     ports:
     - port: 9100
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       app: node-exporter
@@ -191,7 +191,7 @@ spec:
           - k8s
     ports:
     - port: 8080
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       app: kube-state-metrics

--- a/example/networkpolicies/alertmanager.yaml
+++ b/example/networkpolicies/alertmanager.yaml
@@ -7,7 +7,7 @@ spec:
   - from:
     ports:
     - port: 9093
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       alertmanager: main
@@ -32,7 +32,7 @@ spec:
           - main
     ports:
     - port: 6783
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       alertmanager: main

--- a/example/networkpolicies/grafana.yaml
+++ b/example/networkpolicies/grafana.yaml
@@ -6,7 +6,7 @@ spec:
   ingress:
   - ports:
     - port: 3000
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       app: grafana

--- a/example/networkpolicies/kube-state-metrics.yaml
+++ b/example/networkpolicies/kube-state-metrics.yaml
@@ -17,7 +17,7 @@ spec:
           - k8s
     ports:
     - port: 8080
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       app: kube-state-metrics

--- a/example/networkpolicies/node-exporter.yaml
+++ b/example/networkpolicies/node-exporter.yaml
@@ -17,7 +17,7 @@ spec:
           - k8s
     ports:
     - port: 9100
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       app: node-exporter

--- a/example/networkpolicies/prometheus.yaml
+++ b/example/networkpolicies/prometheus.yaml
@@ -6,7 +6,7 @@ spec:
   ingress:
   - ports:
     - port: 9090
-      protocol: tcp
+      protocol: TCP
   podSelector:
     matchLabels:
       app: prometheus


### PR DESCRIPTION
Kubernetes spec requires protocol to be capitalized, eg: `TCP` not `tcp`

Before:
```
Error from server (Invalid): error when creating "prometheus-network-policies.yaml": NetworkPolicy.extensions "alertmanager-web" is invalid: spec.ingress[0].ports[0].protocol: Unsupported value: "tcp": supported values: "TCP", "UDP"
Error from server (Invalid): error when creating "prometheus-network-policies.yaml": NetworkPolicy.extensions "alertmanager-mesh" is invalid: spec.ingress[0].ports[0].protocol: Unsupported value: "tcp": supported values: "TCP", "UDP"
Error from server (Invalid): error when creating "prometheus-network-policies.yaml": NetworkPolicy.extensions "grafana" is invalid: spec.ingress[0].ports[0].protocol: Unsupported value: "tcp": supported values: "TCP", "UDP"
Error from server (Invalid): error when creating "prometheus-network-policies.yaml": NetworkPolicy.extensions "kube-state-metrics" is invalid: spec.ingress[0].ports[0].protocol: Unsupported value: "tcp": supported values: "TCP", "UDP"
Error from server (Invalid): error when creating "prometheus-network-policies.yaml": NetworkPolicy.extensions "node-exporter" is invalid: spec.ingress[0].ports[0].protocol: Unsupported value: "tcp": supported values: "TCP", "UDP"
Error from server (Invalid): error when creating "prometheus-network-policies.yaml": NetworkPolicy.extensions "prometheus" is invalid: spec.ingress[0].ports[0].protocol: Unsupported value: "tcp": supported values: "TCP", "UDP"
```

After:
```
networkpolicy.extensions/alertmanager-web created
networkpolicy.extensions/alertmanager-mesh created
networkpolicy.extensions/grafana created
networkpolicy.extensions/kube-state-metrics created
networkpolicy.extensions/node-exporter created
networkpolicy.extensions/prometheus created
```