### PR TITLE
Changelog: Add note about changed namespaces flag in v0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ Alertmanager controller.
 
 For a full description see: https://github.com/coreos/prometheus-operator/pull/1984#issue-221139702
 
+In order to support multiple namespaces, the `--namespace` flag changed to `--namespaces`
+and accepts and comma-separated list of namespaces as a string.
+
 * [CHANGE] Default to Node Exporter v0.16.0 (#1812)
 * [CHANGE] Update to Go 1.11 (#1855)
 * [CHANGE] Default to Prometheus v2.4.3 (#1929) (#1983)
 * [CHANGE] Default to Thanos v0.1.0 (#1954)
 * [CHANGE] Overhaul metrics while adding triggerBy metric for Alertmanager (#1984)
-* [FEATURE] Add multi namespace support (#1813)
+* [CHANGE] Add multi namespace support (#1813)
 * [FEATURE] Add SHA field to Prometheus, Alertmanager and Thanos for images (#1847) (#1854)
 * [FEATURE] Add configuration for priority class to be assigned to Pods (#1875)
 * [FEATURE] Configure sampleLimit per ServiceMonitor (#1895)


### PR DESCRIPTION
As @squat mentioned in https://github.com/coreos/prometheus-operator/pull/1995#discussion_r224437818 we should make it obvious that the `--namespace` flag changed to `--namespaces` and now takes a comma-separated list of namespaces as string.

/cc @squat @mxinden 