### PR TITLE
Fix generate-in-docker when selinux is in enforcing mode on host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,11 +89,7 @@ generate: pkg/client/monitoring/v1/zz_generated.deepcopy.go pkg/client/monitorin
 
 .PHONY: generate-in-docker
 generate-in-docker: hack/jsonnet-docker-image
-	docker run \
-	--rm \
-	-u=$(shell id -u $(USER)):$(shell id -g $(USER)) \
-	-v `pwd`:/go/src/github.com/coreos/prometheus-operator \
-	po-jsonnet make $(MFLAGS) generate # MFLAGS are the parent make call's flags
+	hack/generate-in-docker.sh $(MFLAGS) # MFLAGS are the parent make call's flags
 
 .PHONY: kube-prometheus
 kube-prometheus:

--- a/hack/generate-in-docker.sh
+++ b/hack/generate-in-docker.sh
@@ -6,7 +6,7 @@ set -o pipefail
 # error on unset variables
 set -u
 
-MFLAGS=${@:-} # MFLAGS are the parent make call's flags (see Makefile)
+MFLAGS=${*:-} # MFLAGS are the parent make call's flags (see Makefile)
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 # Detect selinux and set docker run volume :Z option so we can write the generated files
@@ -15,8 +15,8 @@ if hash getenforce 2> /dev/null && getenforce | grep 'Enforcing' > /dev/null; th
   VOLUME_OPTIONS=":Z"
 fi
 
-docker run \
+echo docker run \
     --rm \
-    -u=$(id -u $USER):$(id -g $USER) \
-    -v $SCRIPTDIR/..:/go/src/github.com/coreos/prometheus-operator${VOLUME_OPTIONS} \
-    po-jsonnet make $MFLAGS generate
+    -u="$(id -u "$USER")":"$(id -g "$USER")" \
+    -v "${SCRIPTDIR}/..:/go/src/github.com/coreos/prometheus-operator${VOLUME_OPTIONS}" \
+    po-jsonnet make "${MFLAGS}" generate

--- a/hack/generate-in-docker.sh
+++ b/hack/generate-in-docker.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+MFLAGS=${@:-} # MFLAGS are the parent make call's flags (see Makefile)
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+
+# Detect selinux and set docker run volume :Z option so we can write the generated files
+VOLUME_OPTIONS=""
+if hash getenforce 2> /dev/null && getenforce | grep 'Enforcing' > /dev/null; then
+  VOLUME_OPTIONS=":Z"
+fi
+
+docker run \
+    --rm \
+    -u=$(id -u $USER):$(id -g $USER) \
+    -v $SCRIPTDIR/..:/go/src/github.com/coreos/prometheus-operator${VOLUME_OPTIONS} \
+    po-jsonnet make $MFLAGS generate


### PR DESCRIPTION
This PR attempts to fix an issue that arises when running `make generate-in-docker` on a host where SELinux is in `Enforcing` mode. The `:Z` mount option is needed so docker labels the files appropriately to allow the container to write to the volume.

Using this flag comes with a notable warning as seen here: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

> If you use selinux you can add the z or Z options to modify the selinux label of the host file or directory being mounted into the container. This affects the file or directory on the host machine itself and can have consequences outside of the scope of Docker.

Moving the generate-in-docker command outside of Makefile into it's own script in `hack/` allows for more flexibility in detecting SElinux.

I have validated that this change works by running `make generate-in-docker` on my local machine where SElinux is enabled. The docs were generated as expected without resulting in a write permission denied error. The command still works after disabling SElinux temporarily.

Question to reviewers: the `generate-in-docker.sh` script can be changed to attempt to check if a file or file content is present to make sure `$SCRIPTDIR` is really set to the expected path to avoid bind-mounting and setting SElinux labels on files outside of the repo. I was thinking about checking for the existence of `$SCRIPTDIR/../pkg/prometheus/operator.go` which would confirm we're in the right directory. Thoughts?