### PR TITLE
contrib/kube-prometheus: Update to use prometheus-operator v0.24

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -61,8 +61,8 @@ spec:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.2
-        image: quay.io/coreos/prometheus-operator:v0.23.2
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.24.0
+        image: quay.io/coreos/prometheus-operator:v0.24.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -222,7 +222,7 @@ These are the available fields with their respective default values:
         kubeStateMetrics: "v1.3.1",
         kubeRbacProxy: "v0.3.1",
         addonResizer: "1.0",
-        prometheusOperator: "v0.24.2",
+        prometheusOperator: "v0.24.0",
         prometheus: "v2.4.3",
     },
 

--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -222,7 +222,7 @@ These are the available fields with their respective default values:
         kubeStateMetrics: "v1.3.1",
         kubeRbacProxy: "v0.3.1",
         addonResizer: "1.0",
-        prometheusOperator: "v0.23.2",
+        prometheusOperator: "v0.24.2",
         prometheus: "v2.4.3",
     },
 

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/jsonnetfile.json
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "v0.23.2"
+            "version": "v0.24.0"
         },
         {
             "name": "etcd-mixin",

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "e316fd4c4d1d39a5490c02a2b76e239a5378a8f2"
+            "version": "13cb3c515152fb8495cdc6364938f19bff860e70"
         },
         {
             "name": "ksonnet",
@@ -68,7 +68,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "27b1eb72d9d93e5ab447121e2b884bc558bde01d"
+            "version": "4a7fea51ab3f10329472c07028354617fb6635fe"
         },
         {
             "name": "etcd-mixin",

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
@@ -26,6 +26,12 @@ spec:
           description: 'AlertmanagerSpec is a specification of the desired behavior
             of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
+            additionalPeers:
+              description: AdditionalPeers allows injecting a set of additional Alertmanagers
+                to peer with to form a highly available cluster.
+              items:
+                type: string
+              type: array
             affinity:
               description: Affinity is a group of affinity scheduling rules.
               properties:
@@ -1668,6 +1674,9 @@ spec:
 
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                   type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
             replicas:
               description: Size is the expected size of the alertmanager cluster.
                 The controller will eventually make the size of the running cluster
@@ -1689,7 +1698,8 @@ spec:
                   type: object
             retention:
               description: Time duration Alertmanager shall retain data for. Default
-                is '120h'.
+                is '120h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)`
+                (milliseconds seconds minutes hours days weeks years).
               type: string
             routePrefix:
               description: The route prefix Alertmanager registers HTTP handlers for.
@@ -1793,14 +1803,22 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the Prometheus Pods.
               type: string
+            sha:
+              description: SHA of Alertmanager container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
             storage:
               description: StorageSpec defines the configured storage for a group
-                Prometheus servers.
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
               properties:
                 class:
                   description: 'Name of the StorageClass to use when requesting storage
                     provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
-                    DEPRECATED'
+                    (DEPRECATED - instead use `volumeClaimTemplate.spec.storageClassName`)'
                   type: string
                 emptyDir:
                   description: Represents an empty directory for a pod. Empty directory
@@ -2331,7 +2349,7 @@ spec:
                           type: string
             tag:
               description: Tag of Alertmanager container image to be deployed. Defaults
-                to the value of `version`.
+                to the value of `version`. Version is ignored if Tag is set.
               type: string
             tolerations:
               description: If specified, the pod's tolerations.

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
@@ -1830,6 +1830,9 @@ spec:
 
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                   type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
             remoteRead:
               description: If specified, the remote_read spec. This is an experimental
                 feature, it may change in any upcoming release in a breaking way.
@@ -2095,7 +2098,8 @@ spec:
                   type: object
             retention:
               description: Time duration Prometheus shall retain data for. Default
-                is '24h'.
+                is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)`
+                (milliseconds seconds minutes hours days weeks years).
               type: string
             routePrefix:
               description: The route prefix Prometheus registers HTTP handlers for.
@@ -2374,14 +2378,22 @@ spec:
                     "In", and the values array contains only "value". The requirements
                     are ANDed.
                   type: object
+            sha:
+              description: SHA of Prometheus container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
             storage:
               description: StorageSpec defines the configured storage for a group
-                Prometheus servers.
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
               properties:
                 class:
                   description: 'Name of the StorageClass to use when requesting storage
                     provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
-                    DEPRECATED'
+                    (DEPRECATED - instead use `volumeClaimTemplate.spec.storageClassName`)'
                   type: string
                 emptyDir:
                   description: Represents an empty directory for a pod. Empty directory
@@ -2912,7 +2924,7 @@ spec:
                           type: string
             tag:
               description: Tag of Prometheus container image to be deployed. Defaults
-                to the value of `version`.
+                to the value of `version`. Version is ignored if Tag is set.
               type: string
             thanos:
               description: ThanosSpec defines parameters for a Prometheus server within
@@ -3015,9 +3027,16 @@ spec:
                       description: Whether to use S3 Signature Version 2; otherwise
                         Signature Version 4 will be used.
                       type: boolean
+                sha:
+                  description: SHA of Thanos container image to be deployed. Defaults
+                    to the value of `version`. Similar to a tag, but the SHA explicitly
+                    deploys an immutable container image. Version and Tag are ignored
+                    if SHA is set.
+                  type: string
                 tag:
                   description: Tag of Thanos sidecar container image to be deployed.
-                    Defaults to the value of `version`.
+                    Defaults to the value of `version`. Version is ignored if Tag
+                    is set.
                   type: string
                 version:
                   description: Version describes the version of Thanos to use.

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
@@ -322,7 +322,9 @@ spec:
                         annotations:
                           type: object
                         expr:
-                          type: string
+                          anyOf:
+                          - type: string
+                          - type: integer
                         for:
                           type: string
                         labels:

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
@@ -136,6 +136,51 @@ spec:
                     description: ProxyURL eg http://proxyserver:2195 Directs scrapes
                       to proxy through this endpoint.
                     type: string
+                  relabelings:
+                    description: 'RelabelConfigs to apply to samples before ingestion.
+                      More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<relabel_config>'
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
                   scheme:
                     description: HTTP scheme to use for scraping.
                     type: string
@@ -181,6 +226,17 @@ spec:
                   items:
                     type: string
                   type: array
+            podTargetLabels:
+              description: PodTargetLabels transfers labels on the Kubernetes Pod
+                onto the target.
+              items:
+                type: string
+              type: array
+            sampleLimit:
+              description: SampleLimit defines per-scrape limit on number of scraped
+                samples that will be accepted.
+              format: int64
+              type: integer
             selector:
               description: A label selector is a label query over a set of resources.
                 The result of matchLabels and matchExpressions are ANDed. An empty

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-clusterRole.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-clusterRole.yaml
@@ -61,5 +61,6 @@ rules:
   resources:
   - namespaces
   verbs:
+  - get
   - list
   - watch

--- a/contrib/kube-prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -20,8 +20,8 @@ spec:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.2
-        image: quay.io/coreos/prometheus-operator:v0.23.2
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.24.0
+        image: quay.io/coreos/prometheus-operator:v0.24.0
         name: prometheus-operator
         ports:
         - containerPort: 8080


### PR DESCRIPTION
After releasing the operator yesterday kube-prometheus also should use the new operator version.

/cc @squat 