### PR TITLE
contrib/kube-prometheus: Fix AlertmanagerConfigInconsistent alert

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/alertmanager.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/alerts/alertmanager.libsonnet
@@ -10,7 +10,7 @@
               message: 'The configuration of the instances of the Alertmanager cluster `{{$labels.service}}` are out of sync.',
             },
             expr: |||
-              count_values("config_hash", alertmanager_config_hash{%(alertmanagerSelector)s}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{%(prometheusOperatorSelector)s}, "service", "alertmanager-$1", "alertmanager", "(.*)") != 1
+              count_values("config_hash", alertmanager_config_hash{%(alertmanagerSelector)s}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{%(prometheusOperatorSelector)s,controller="alertmanager"}, "service", "alertmanager-$1", "name", "(.*)") != 1
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "13cb3c515152fb8495cdc6364938f19bff860e70"
+            "version": "949ffab68a175c0100cb5b9ac84a47d19752f868"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -947,7 +947,7 @@ spec:
         message: The configuration of the instances of the Alertmanager cluster `{{$labels.service}}`
           are out of sync.
       expr: |
-        count_values("config_hash", alertmanager_config_hash{job="alertmanager-main"}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{job="prometheus-operator"}, "service", "alertmanager-$1", "alertmanager", "(.*)") != 1
+        count_values("config_hash", alertmanager_config_hash{job="alertmanager-main"}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{job="prometheus-operator",controller="alertmanager"}, "service", "alertmanager-$1", "name", "(.*)") != 1
       for: 5m
       labels:
         severity: critical


### PR DESCRIPTION
The problem was two folded as far as I can see:
`label_replace()` replaced a no longer existing label and has been updated. The `GROUP_LEFT()` failed because there were multiple time series with both `controller="alertmanager"` and `controller="promethus"`. I've therefore added the `controller="alertmanager"` matcher.

Fixes #2000

Simply update your kube-prometheus stack from master for this fix.

/cc @squat 