### PR TITLE
truncate volume name when it exceed 63 chars

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -461,7 +461,11 @@ func configSecretName(name string) string {
 }
 
 func volumeName(name string) string {
-	return fmt.Sprintf("%s-db", prefixedName(name))
+	// full name example: alertmanager-releasename-alertmanager-db
+	fullName := prefixedName(name) + "-db"
+
+	// after trancate: alertmanager-releasename-db
+	return k8sutil.TruncateVolumeName(fullName)
 }
 
 func prefixedName(name string) string {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -464,8 +464,8 @@ func volumeName(name string) string {
 	// full name example: alertmanager-releasename-alertmanager-db
 	fullName := prefixedName(name) + "-db"
 
-	// after trancate: alertmanager-releasename-db
-	return k8sutil.TruncateVolumeName(fullName)
+	// after sanitization: alertmanager-releasename-db
+	return k8sutil.SanitizeVolumeName(fullName)
 }
 
 func prefixedName(name string) string {

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -199,14 +199,12 @@ func NewCustomResourceDefinition(crdKind monitoringv1.CrdKind, group string, lab
 func SanitizeVolumeName(name string) string {
 	name = strings.ToLower(name)
 	name = invalidDNS1123Characters.ReplaceAllString(name, "-")
-	if len(name) > validation.DNS1123LabelMaxLength {
-		name = name[0:validation.DNS1123LabelMaxLength]
-	}
-	return strings.Trim(name, "-")
+
+	return truncateVolumeName(name)
 }
 
-// TruncateVolumeName truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
-func TruncateVolumeName(name string) string {
+// Truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
+func truncateVolumeName(name string) string {
 
 	const NameDelimeter = "-"
 
@@ -258,10 +256,5 @@ func TruncateVolumeName(name string) string {
 		name = name[:validation.DNS1123LabelMaxLength]
 	}
 
-	// remove  delimeters from the end
-	for len(name) > 0 && string(name[len(name)-1]) == NameDelimeter {
-		name = name[:len(name)-1]
-	}
-
-	return name
+	return strings.Trim(name, NameDelimeter)
 }

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -56,6 +57,75 @@ func Test_SanitizeVolumeName(t *testing.T) {
 		out := SanitizeVolumeName(c.name)
 		if c.expected != out {
 			t.Errorf("expected test case %d to be %q but got %q", i, c.expected, out)
+		}
+	}
+}
+
+func TestTruncateVolumeName(t *testing.T) {
+
+	require.Equal(t, "name", TruncateVolumeName("name"))
+
+	{
+		// name without duplicates substrings
+		val := TruncateVolumeName(strings.Repeat("a", validation.DNS1123LabelMaxLength+1))
+		require.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", val)
+		require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
+	}
+
+	{
+		// name with duplicate substrings
+		val := TruncateVolumeName(`glusterfs-dynamic-prometheus-release-prometheus-db-prometheus-release-prometheus-0`)
+		require.Equal(t, "glusterfs-dynamic-prometheus-release-db-0", val)
+		require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
+	}
+
+	{
+		// name with duplicate substrings in the end of string
+		var src string
+		for i := 0; i < 5; i++ {
+			if len(src) > 0 {
+				src += "-"
+			}
+			src += strings.Repeat("a", 10)
+		}
+
+		val := TruncateVolumeName(src)
+		require.Equal(t, "aaaaaaaaaa", val)
+		require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
+	}
+
+	{
+		// '-' in the end of the name
+		val := TruncateVolumeName(`glusterfs-dynamic-prometheus-release-prometheus-db-prometheus-release-prometheus-0-`)
+		require.Equal(t, "glusterfs-dynamic-prometheus-release-db-0", val)
+		require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
+	}
+
+	// remove duplicates delimiters
+	for _, substr := range []string{
+		"--",
+		"---",
+		"----",
+		"-----",
+		"------",
+	} {
+		{
+			// name with duplicates delimiters
+			src := `glusterfs` + substr + `dynamic-prometheus-release-veryveryveryveryverylongname-db` + substr + `0`
+			val := TruncateVolumeName(src)
+			require.Equal(t, "glusterfs-dynamic-prometheus-release-veryveryveryveryverylongna", val)
+			require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
+		}
+
+		{
+			// '-' in the end of the name
+			part1 := strings.Repeat("a", validation.DNS1123LabelMaxLength/2)
+			part2 := strings.Repeat("b", validation.DNS1123LabelMaxLength/2)
+
+			src := part1 + substr + part2 + substr // example: "a--b--"
+			val := TruncateVolumeName(src)
+			require.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", val)
+			require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
 		}
 	}
 }

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -63,18 +63,18 @@ func Test_SanitizeVolumeName(t *testing.T) {
 
 func TestTruncateVolumeName(t *testing.T) {
 
-	require.Equal(t, "name", TruncateVolumeName("name"))
+	require.Equal(t, "name", truncateVolumeName("name"))
 
 	{
 		// name without duplicates substrings
-		val := TruncateVolumeName(strings.Repeat("a", validation.DNS1123LabelMaxLength+1))
+		val := truncateVolumeName(strings.Repeat("a", validation.DNS1123LabelMaxLength+1))
 		require.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", val)
 		require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
 	}
 
 	{
 		// name with duplicate substrings
-		val := TruncateVolumeName(`glusterfs-dynamic-prometheus-release-prometheus-db-prometheus-release-prometheus-0`)
+		val := truncateVolumeName(`glusterfs-dynamic-prometheus-release-prometheus-db-prometheus-release-prometheus-0`)
 		require.Equal(t, "glusterfs-dynamic-prometheus-release-db-0", val)
 		require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
 	}
@@ -89,14 +89,14 @@ func TestTruncateVolumeName(t *testing.T) {
 			src += strings.Repeat("a", 10)
 		}
 
-		val := TruncateVolumeName(src)
+		val := truncateVolumeName(src)
 		require.Equal(t, "aaaaaaaaaa", val)
 		require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
 	}
 
 	{
 		// '-' in the end of the name
-		val := TruncateVolumeName(`glusterfs-dynamic-prometheus-release-prometheus-db-prometheus-release-prometheus-0-`)
+		val := truncateVolumeName(`glusterfs-dynamic-prometheus-release-prometheus-db-prometheus-release-prometheus-0-`)
 		require.Equal(t, "glusterfs-dynamic-prometheus-release-db-0", val)
 		require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
 	}
@@ -112,7 +112,7 @@ func TestTruncateVolumeName(t *testing.T) {
 		{
 			// name with duplicates delimiters
 			src := `glusterfs` + substr + `dynamic-prometheus-release-veryveryveryveryverylongname-db` + substr + `0`
-			val := TruncateVolumeName(src)
+			val := truncateVolumeName(src)
 			require.Equal(t, "glusterfs-dynamic-prometheus-release-veryveryveryveryverylongna", val)
 			require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
 		}
@@ -123,7 +123,7 @@ func TestTruncateVolumeName(t *testing.T) {
 			part2 := strings.Repeat("b", validation.DNS1123LabelMaxLength/2)
 
 			src := part1 + substr + part2 + substr // example: "a--b--"
-			val := TruncateVolumeName(src)
+			val := truncateVolumeName(src)
 			require.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", val)
 			require.True(t, len(val) <= validation.DNS1123LabelMaxLength)
 		}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -804,7 +804,11 @@ func configSecretName(name string) string {
 }
 
 func volumeName(name string) string {
-	return fmt.Sprintf("%s-db", prefixedName(name))
+	// full name example: prometheus-releasename-prometheus-db
+	fullName := prefixedName(name) + "-db"
+
+	// after trancate: prometheus-releasename-db
+	return k8sutil.TruncateVolumeName(fullName)
 }
 
 func prefixedName(name string) string {

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -807,8 +807,8 @@ func volumeName(name string) string {
 	// full name example: prometheus-releasename-prometheus-db
 	fullName := prefixedName(name) + "-db"
 
-	// after trancate: prometheus-releasename-db
-	return k8sutil.TruncateVolumeName(fullName)
+	// after sanitization: prometheus-releasename-db
+	return k8sutil.SanitizeVolumeName(fullName)
 }
 
 func prefixedName(name string) string {


### PR DESCRIPTION
Failed to create a pvc(gluster)
```
Warning

ProvisioningFailed  3s    persistentvolume-controller  
Failed to provision volume with StorageClass "gluster": 
failed to create volume: failed to create endpoint/service monitoring/glusterfs-dynamic-prometheus-mon-prometheus-db-prometheus-mon-prometheus-0: 
error creating service: Service "glusterfs-dynamic-prometheus-mon-prometheus-db-prometheus-mon-prometheus-0" is invalid: 
metadata.name: Invalid value: "glusterfs-dynamic-prometheus-mon-prometheus-db-prometheus-mon-prometheus-0": 
must be no more than 63 characters
```