### PR TITLE
contrib/kube-prometheus: Bump the prometheus-operator jsonnet dep

### DIFF
--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -68,7 +68,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "4a7fea51ab3f10329472c07028354617fb6635fe"
+            "version": "8c6a68760010347134e41f3aa3d73c68eb094a1b"
         },
         {
             "name": "etcd-mixin",


### PR DESCRIPTION
kube-prometheus now contains a script, sync-to-internal-registry.jsonnet, that
depends on commit 8c6a68760010347134e41f3aa3d73c68eb094a1b to work. Bump the prometheus-operator hash accordingly.

EDIT: removed the kube-prometheus bump and amended the commit, because it was actually a downgrade, not a bump.