### PR TITLE
kube-prometheus: Example jsonnet ingress, add externalURL

### DIFF
--- a/contrib/kube-prometheus/docs/exposing-prometheus-alertmanager-grafana-ingress.md
+++ b/contrib/kube-prometheus/docs/exposing-prometheus-alertmanager-grafana-ingress.md
@@ -24,7 +24,8 @@ htpasswd -c auth <username>
 
 In order to use this a secret needs to be created containing the name of the `htpasswd`, and with annotations on the Ingress object basic auth can be configured.
 
-[embedmd]:# (../examples/ingress.jsonnet)
+Also, the applications provide external links to themselves in alerts and various places. When an ingress is used in front of the applications these links need to be based on the external URL's. This can be configured for each application in jsonnet.
+
 ```jsonnet
 local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 local secret = k.core.v1.secret;
@@ -38,6 +39,13 @@ local kp =
   {
     _config+:: {
       namespace: 'monitoring',
+    },
+    prometheus+:: {
+      prometheus+: {
+        spec+: {
+          externalURL: 'http://prometheus.example.com',
+        },
+      },
     },
     ingress+:: {
       'prometheus-k8s':
@@ -73,7 +81,7 @@ k.core.v1.list.new([
 ])
 ```
 
-In order to expose Alertmanager and Grafana, simply create additional fields containing an ingress object, but simply pointing at the `alertmanager` or `grafana` instead of the `prometheus-k8s` Service. Make sure to also use the correct port respectively, for Alertmanager it is also `web`, for Grafana it is `http`.
+In order to expose Alertmanager and Grafana, simply create additional fields containing an ingress object, but simply pointing at the `alertmanager` or `grafana` instead of the `prometheus-k8s` Service. Make sure to also use the correct port respectively, for Alertmanager it is also `web`, for Grafana it is `http`. Be sure to also specify the appropriate external URL. 
 
 In order to render the ingress objects similar to the other objects use as demonstrated in the [main readme](../README.md#usage):
 
@@ -89,3 +97,5 @@ In order to render the ingress objects similar to the other objects use as demon
 ```
 
 Note, that in comparison only the last line was added, the rest is identical to the original.
+
+See (../examples/ingress.jsonnet) for an example implementation.

--- a/contrib/kube-prometheus/examples/ingress.jsonnet
+++ b/contrib/kube-prometheus/examples/ingress.jsonnet
@@ -11,6 +11,23 @@ local kp =
     _config+:: {
       namespace: 'monitoring',
     },
+    // Configure External URL's per application
+    alertmanager+:: {
+      alertmanager+: {
+        spec+: {
+          externalURL: 'http://alertmanager.example.com',
+        },
+      },
+    },
+    grafana+:: {
+      config: {
+        sections: {
+          server: {
+            root_url: 'http://grafana.example.com/',
+          },
+        },
+      },
+    },
     prometheus+:: {
       prometheus+: {
         spec+: {
@@ -18,10 +35,47 @@ local kp =
         },
       },
     },
+    // Create ingress objects per application
     ingress+:: {
-      'prometheus-k8s':
+      alertmanager:
         ingress.new() +
-        ingress.mixin.metadata.withName('prometheus-k8s') +
+        ingress.mixin.metadata.withName('alertmanager-main') +
+        ingress.mixin.metadata.withNamespace($._config.namespace) +
+        ingress.mixin.metadata.withAnnotations({
+          'nginx.ingress.kubernetes.io/auth-type': 'basic',
+          'nginx.ingress.kubernetes.io/auth-secret': 'basic-auth',
+          'nginx.ingress.kubernetes.io/auth-realm': 'Authentication Required',
+        }) +
+        ingress.mixin.spec.withRules(
+          ingressRule.new() +
+          ingressRule.withHost('alertmanager.example.com') +
+          ingressRule.mixin.http.withPaths(
+            httpIngressPath.new() +
+            httpIngressPath.mixin.backend.withServiceName('alertmanager-main') +
+            httpIngressPath.mixin.backend.withServicePort('web')
+          ),
+        ),
+      grafana:
+        ingress.new() +
+        ingress.mixin.metadata.withName('grafana') +
+        ingress.mixin.metadata.withNamespace($._config.namespace) +
+        ingress.mixin.metadata.withAnnotations({
+          'nginx.ingress.kubernetes.io/auth-type': 'basic',
+          'nginx.ingress.kubernetes.io/auth-secret': 'basic-auth',
+          'nginx.ingress.kubernetes.io/auth-realm': 'Authentication Required',
+        }) +
+        ingress.mixin.spec.withRules(
+          ingressRule.new() +
+          ingressRule.withHost('grafana.example.com') +
+          ingressRule.mixin.http.withPaths(
+            httpIngressPath.new() +
+            httpIngressPath.mixin.backend.withServiceName('grafana') +
+            httpIngressPath.mixin.backend.withServicePort('http')
+          ),
+        ),
+      prometheus:
+        ingress.new() +
+        ingress.mixin.metadata.withName('prometheus') +
         ingress.mixin.metadata.withNamespace($._config.namespace) +
         ingress.mixin.metadata.withAnnotations({
           'nginx.ingress.kubernetes.io/auth-type': 'basic',
@@ -39,6 +93,7 @@ local kp =
         ),
     },
   } + {
+    // Create basic auth secret - replace 'auth' file with your own
     ingress+:: {
       'basic-auth-secret':
         secret.new('basic-auth', { auth: std.base64(importstr 'auth') }) +
@@ -46,7 +101,4 @@ local kp =
     },
   };
 
-k.core.v1.list.new([
-  kp.ingress['prometheus-k8s'],
-  kp.ingress['basic-auth-secret'],
-])
+{ [name + '-ingress']: kp.ingress[name] for name in std.objectFields(kp.ingress) }

--- a/contrib/kube-prometheus/examples/ingress.jsonnet
+++ b/contrib/kube-prometheus/examples/ingress.jsonnet
@@ -20,9 +20,9 @@ local kp =
       },
     },
     grafana+:: {
-      config: {
-        sections: {
-          server: {
+      config+: {
+        sections+: {
+          server+: {
             root_url: 'http://grafana.example.com/',
           },
         },

--- a/contrib/kube-prometheus/examples/ingress.jsonnet
+++ b/contrib/kube-prometheus/examples/ingress.jsonnet
@@ -11,6 +11,13 @@ local kp =
     _config+:: {
       namespace: 'monitoring',
     },
+    prometheus+:: {
+      prometheus+: {
+        spec+: {
+          externalURL: 'http://prometheus.example.com',
+        },
+      },
+    },
     ingress+:: {
       'prometheus-k8s':
         ingress.new() +

--- a/contrib/kube-prometheus/examples/ingress.jsonnet
+++ b/contrib/kube-prometheus/examples/ingress.jsonnet
@@ -37,7 +37,7 @@ local kp =
     },
     // Create ingress objects per application
     ingress+:: {
-      alertmanager:
+      'alertmanager-main':
         ingress.new() +
         ingress.mixin.metadata.withName('alertmanager-main') +
         ingress.mixin.metadata.withNamespace($._config.namespace) +
@@ -73,9 +73,9 @@ local kp =
             httpIngressPath.mixin.backend.withServicePort('http')
           ),
         ),
-      prometheus:
+      'prometheus-k8s':
         ingress.new() +
-        ingress.mixin.metadata.withName('prometheus') +
+        ingress.mixin.metadata.withName('prometheus-k8s') +
         ingress.mixin.metadata.withNamespace($._config.namespace) +
         ingress.mixin.metadata.withAnnotations({
           'nginx.ingress.kubernetes.io/auth-type': 'basic',


### PR DESCRIPTION
It took me a bit of searching to find that `externalURL` is set in the `prometheus` object/kind spec.
Per the comment below have added the suggested merge into the example ingress.
https://github.com/coreos/prometheus-operator/pull/1838#issuecomment-417747427

One could then duplicate the whole lot for alertmanager. I can add Alertmanager to PR if not too verbose?