### PR TITLE
contrib/kube-prometheus: thanos-peers service misses namespace

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-thanos.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-thanos.libsonnet
@@ -57,8 +57,8 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
     thanosPeerService:
       local thanosPeerPort = servicePort.newNamed('cluster', 10900, 'cluster');
       service.new('thanos-peers', { 'thanos-peer': 'true' }, thanosPeerPort) +
+      service.mixin.metadata.withNamespace($._config.namespace) +
       service.mixin.spec.withType('ClusterIP') +
       service.mixin.spec.withClusterIp('None'),
-
   },
 }


### PR DESCRIPTION
If this Service is in the wrong namespace none of the peers are able to find each other.