### PR TITLE
README.md: Clarify quickstart vs. kube-prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ at the [design doc](Documentation/design.md).
 
 ## Quickstart
 
-Note that this quickstart does not provision an entire monitoring stack, if that is what you are looking for see the [kube-prometheus](contrib/kube-prometheus) sub-project. If you awant the whole stack, but have already applied the `bundle.yaml`, just delete the bundle (`kubectl delete -f bundle.yaml`).
+Note that this quickstart does not provision an entire monitoring stack, if that is what you are looking for see the [kube-prometheus](contrib/kube-prometheus) sub-project. If you want the whole stack, but have already applied the `bundle.yaml`, just delete the bundle (`kubectl delete -f bundle.yaml`).
 
 To quickly try out _just_ the Prometheus Operator inside a cluster by running the following command:
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ The Operator acts on the following [custom resource definitions (CRDs)](https://
 To learn more about the CRDs introduced by the Prometheus Operator have a look
 at the [design doc](Documentation/design.md).
 
-## Installation
+## Quickstart
 
-Install the Operator inside a cluster by running the following command:
+Note that this quickstart does not provision an entire monitoring stack, if that is what you are looking for see the [kube-prometheus](contrib/kube-prometheus) sub-project. If you awant the whole stack, but have already applied the `bundle.yaml`, just delete the bundle (`kubectl delete -f bundle.yaml`).
+
+To quickly try out _just_ the Prometheus Operator inside a cluster by running the following command:
 
 ```sh
 kubectl apply -f bundle.yaml


### PR DESCRIPTION
We often get users, that first install the bundle and then helm or the jsonnet based kube-prometheus stack, which collides with the quickstart bundle (eg. https://github.com/coreos/prometheus-operator/issues/2084). Therefore clarifying here.

@mxinden @squat @metalmatze @s-urbaniak 