### PR TITLE
Add support for Kubespray clusters

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -328,7 +328,7 @@ Jsonnet is a turing complete language, any logic can be reflected in it. It also
 
 ### Cluster Creation Tools
 
-A common example is that not all Kubernetes clusters are created exactly the same way, meaning the configuration to monitor them may be slightly different. For [kubeadm](examples/jsonnet-snippets/kubeadm.jsonnet) and [bootkube](examples/jsonnet-snippets/bootkube.jsonnet) and [kops](examples/jsonnet-snippets/kops.jsonnet) clusters there are mixins available to easily configure these:
+A common example is that not all Kubernetes clusters are created exactly the same way, meaning the configuration to monitor them may be slightly different. For [kubeadm](examples/jsonnet-snippets/kubeadm.jsonnet), [bootkube](examples/jsonnet-snippets/bootkube.jsonnet), [kops](examples/jsonnet-snippets/kops.jsonnet) and [kubespray](examples/jsonnet-snippets/kubespray.jsonnet) clusters there are mixins available to easily configure these:
 
 kubeadm:
 
@@ -352,6 +352,14 @@ kops:
 ```jsonnet
 (import 'kube-prometheus/kube-prometheus.libsonnet') +
 (import 'kube-prometheus/kube-prometheus-kops.libsonnet')
+```
+
+kubespray:
+
+[embedmd]:# (examples/jsonnet-snippets/kubespray.jsonnet)
+```jsonnet
+(import 'kube-prometheus/kube-prometheus.libsonnet') +
+(import 'kube-prometheus/kube-prometheus-kubespray.libsonnet')
 ```
 
 ### Internal Registry

--- a/contrib/kube-prometheus/examples/jsonnet-snippets/kubespray.jsonnet
+++ b/contrib/kube-prometheus/examples/jsonnet-snippets/kubespray.jsonnet
@@ -1,0 +1,2 @@
+(import 'kube-prometheus/kube-prometheus.libsonnet') +
+(import 'kube-prometheus/kube-prometheus-kubespray.libsonnet')

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
@@ -1,0 +1,18 @@
+local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local service = k.core.v1.service;
+local servicePort = k.core.v1.service.mixin.spec.portsType;
+
+{
+  prometheus+: {
+    kubeControllerManagerPrometheusDiscoveryService:
+      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.mixin.metadata.withNamespace('kube-system') +
+      service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
+      service.mixin.spec.withClusterIp('None'),
+    kubeSchedulerPrometheusDiscoveryService:
+      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.mixin.metadata.withNamespace('kube-system') +
+      service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
+      service.mixin.spec.withClusterIp('None'),
+  },
+}

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "04235fdb35f150a46d5aeefd72c995bf864d2a2f"
+            "version": "a9cb94d4f165f63e7b4094de1d087c5264667598"
         },
         {
             "name": "ksonnet",


### PR DESCRIPTION
Add config files and documentation for Kubespray clusters.

The discovery services are almost the same as the kubeadm ones, the only change is the selector's name. Maybe someone jsonnet fluent could factor them?