### PR TITLE
Incorrect message in alerts KubeJobFailed and KubeJobCompletion #2094

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -698,7 +698,7 @@ spec:
         severity: warning
     - alert: KubeJobCompletion
       annotations:
-        message: Job {{ $labels.namespaces }}/{{ $labels.job }} is taking more than
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than
           one hour to complete.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
       expr: |
@@ -708,7 +708,7 @@ spec:
         severity: warning
     - alert: KubeJobFailed
       annotations:
-        message: Job {{ $labels.namespaces }}/{{ $labels.job }} failed to complete.
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
       expr: |
         kube_job_status_failed{job="kube-state-metrics"}  > 0


### PR DESCRIPTION
Fixed message for alert KubeJobCompletion and KubeJobFailed.

The message was:
`Job /kube-state-metrics is taking more than 30 minutes to complete.`

The new message is:
`Job default/my-job is taking more than 30 minutes to complete.`