### PR TITLE
*: Remove attempting to set "secure" security context

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -128,7 +128,6 @@ func init() {
 	flagset.StringVar(&cfg.CrdGroup, "crd-apigroup", monitoringv1.Group, "prometheus CRD  API group name")
 	flagset.Var(&cfg.CrdKinds, "crd-kinds", " - EXPERIMENTAL (could be removed in future releases) - customize CRD kind names")
 	flagset.BoolVar(&cfg.EnableValidation, "with-validation", true, "Include the validation spec in the CRD")
-	flagset.BoolVar(&cfg.DisableAutoUserGroup, "disable-auto-user-group", false, "Disables the Prometheus Operator setting the `runAsUser` and `fsGroup` fields in Pods.")
 	flagset.StringVar(&cfg.LocalHost, "localhost", "localhost", "EXPERIMENTAL (could be removed in future releases) - Host used to communicate between local services on a pod. Fixes issues where localhost resolves incorrectly.")
 	flagset.StringVar(&cfg.LogLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(availableLogLevels, ", ")))
 	flagset.StringVar(&cfg.LogFormat, "log-format", logFormatLogfmt, fmt.Sprintf("Log format to use. Possible values: %s", strings.Join(availableLogFormats, ", ")))

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -79,7 +79,6 @@ type Config struct {
 	CrdKinds                     monitoringv1.CrdKinds
 	CrdGroup                     string
 	EnableValidation             bool
-	DisableAutoUserGroup         bool
 	ManageCRDs                   bool
 }
 
@@ -121,7 +120,6 @@ func New(c prometheusoperator.Config, logger log.Logger) (*Operator, error) {
 			CrdKinds:                     c.CrdKinds,
 			Labels:                       c.Labels,
 			EnableValidation:             c.EnableValidation,
-			DisableAutoUserGroup:         c.DisableAutoUserGroup,
 			ManageCRDs:                   c.ManageCRDs,
 		},
 	}

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -303,16 +303,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 		}, ports...)
 	}
 
-	gid := int64(2000)
-	uid := int64(1000)
-	nr := true
-	securityContext := &v1.PodSecurityContext{
-		RunAsNonRoot: &nr,
-	}
-	if !config.DisableAutoUserGroup {
-		securityContext.FSGroup = &gid
-		securityContext.RunAsUser = &uid
-	}
+	var securityContext *v1.PodSecurityContext = nil
 	if a.Spec.SecurityContext != nil {
 		securityContext = a.Spec.SecurityContext
 	}

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -143,7 +143,6 @@ type Config struct {
 	CrdGroup                     string
 	CrdKinds                     monitoringv1.CrdKinds
 	EnableValidation             bool
-	DisableAutoUserGroup         bool
 	LocalHost                    string
 	LogLevel                     string
 	LogFormat                    string


### PR DESCRIPTION
This was previously a very poor attempt at achieving something similar to what PodSecurityPolicies are for, therefore I am removing this code. There are no compatibility issues, as for any supported volume types, the kubelet sets the ownership recursively for all files of a volume before mounting.

Fixes #2102

@mxinden @metalmatze @squat @s-urbaniak '

/cc @ctron