### PR TITLE
helm - condition for exporter-kubernetes deployment

### DIFF
--- a/helm/kube-prometheus/requirements.yaml
+++ b/helm/kube-prometheus/requirements.yaml
@@ -56,6 +56,7 @@ dependencies:
     version: 0.1.10
     #e2e-repository: file://../exporter-kubernetes
     repository: https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+    condition: deployExporterKubernetes
 
   - name: exporter-node
     version: 0.4.6

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -16,6 +16,9 @@ deployKubeControllerManager: True
 # Kube state
 deployKubeState: True
 
+#Kubernetes
+deployExporterKubernetes: True
+
 ## If true, create & use RBAC resources resp. Pod Security Policies
 ##
 global:

--- a/helm/kube-prometheus/values.yaml
+++ b/helm/kube-prometheus/values.yaml
@@ -16,7 +16,7 @@ deployKubeControllerManager: True
 # Kube state
 deployKubeState: True
 
-#Kubernetes
+#Kubernetes rules
 deployExporterKubernetes: True
 
 ## If true, create & use RBAC resources resp. Pod Security Policies
@@ -24,7 +24,7 @@ deployExporterKubernetes: True
 global:
   rbacEnable: true
   pspEnable: true
-  
+
   # Reference to one or more secrets to be used when pulling images
   imagePullSecrets: []
   #  - name: "image-pull-secret"


### PR DESCRIPTION
When running Prometheus Operator on Azure, Kubernetes exporter is not necessary.
This Pr give the capability to make it optional