### PR TITLE
etcd3.rules.yaml: Modified InsufficientMembers rule to preserve labels

### DIFF
--- a/helm/exporter-kube-etcd/templates/etcd3.rules.yaml
+++ b/helm/exporter-kube-etcd/templates/etcd3.rules.yaml
@@ -3,7 +3,7 @@ groups:
 - name: ./etcd3.rules
   rules:
   - alert: InsufficientMembers
-    expr: count(up{job="kube-etcd"} == 0) > (count(up{job="kube-etcd"}) / 2 - 1)
+    expr: count(up{job="kube-etcd"} == 0) without (instance, pod) > (count(up{job="kube-etcd"}) without (instance, pod) / 2 - 1)
     for: 3m
     labels:
       severity: critical


### PR DESCRIPTION
Modified the rule for insufficient members to preserve labels which
allows grouping of alerts & more effective silences.