### PR TITLE
contrib/kube-prometheus: Mount tmpfs to /tmp in Prometheus Adapter

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -103,6 +103,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         ]) +
         container.withPorts([{ containerPort: 6443 }]) +
         container.withVolumeMounts([
+          containerVolumeMount.new('tmpfs', '/tmp'),
           containerVolumeMount.new('volume-serving-cert', '/var/run/serving-cert'),
           containerVolumeMount.new('config', '/etc/adapter'),
         ],);
@@ -112,7 +113,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       deployment.mixin.spec.selector.withMatchLabels($._config.prometheusAdapter.labels) +
       deployment.mixin.spec.template.spec.withServiceAccountName($.prometheusAdapter.serviceAccount.metadata.name) +
       deployment.mixin.spec.template.spec.withVolumes([
-        // volume.fromSecret('volume-serving-cert', 'cm-adapter-serving-certs'),
+        volume.fromEmptyDir(name='tmpfs'),
         volume.fromEmptyDir(name='volume-serving-cert'),
         { name: 'config', configMap: { name: 'adapter-config' } },
       ]),

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "556153e077ed61c4567ae1aa920903d2c7920c23"
+            "version": "5185231304f688cf127bf235a4dfdf9f4f9e7821"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/prometheus-adapter-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-adapter-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         ports:
         - containerPort: 6443
         volumeMounts:
+        - mountPath: /tmp
+          name: tmpfs
+          readOnly: false
         - mountPath: /var/run/serving-cert
           name: volume-serving-cert
           readOnly: false
@@ -34,6 +37,8 @@ spec:
           readOnly: false
       serviceAccountName: prometheus-adapter
       volumes:
+      - emptyDir: {}
+        name: tmpfs
       - emptyDir: {}
         name: volume-serving-cert
       - configMap:


### PR DESCRIPTION
This will make sure that there's always a /tmp in the container.

Related to https://github.com/coreos/prometheus-operator/issues/2116.

/cc @s-urbaniak @brancz 