### PR TITLE
hack/generate: simplify jsonnet build loop

### DIFF
--- a/hack/generate/build-rbac-prometheus-operator.sh
+++ b/hack/generate/build-rbac-prometheus-operator.sh
@@ -9,8 +9,7 @@ set -u
 rm -rf tmp
 mkdir tmp
 jsonnet -J hack/generate/vendor hack/generate/prometheus-operator-rbac.jsonnet > tmp/po.json
-mapfile -t files < <(jq -r 'keys[]' tmp/po.json)
-for file in "${files[@]}"
+jq -r 'keys[]' tmp/po.json | while read -r file
 do
     jq -r ".[\"${file}\"]" tmp/po.json | gojsontoyaml > "example/rbac/prometheus-operator/${file}"
 done


### PR DESCRIPTION
This commit simplifies the build-rbac-... script
to directly loop over the output of `jq` rather than build a
bash-specific array variable using `mapfile`.

xref: https://github.com/openshift/cluster-monitoring-operator/pull/150

cc @metalmatze 