### PR TITLE
Increase CPU limits for small containers to not being throttled as often

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -172,7 +172,7 @@ spec:
         name: node-exporter
         resources:
           limits:
-            cpu: 102m
+            cpu: 250m
             memory: 180Mi
           requests:
             cpu: 102m
@@ -355,7 +355,7 @@ spec:
         name: addon-resizer
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 30Mi
           requests:
             cpu: 10m

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -182,7 +182,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           },
         ]) +
         container.mixin.resources.withRequests({ cpu: '10m', memory: '30Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '10m', memory: '30Mi' });
+        container.mixin.resources.withLimits({ cpu: '50m', memory: '30Mi' });
 
       local c = [proxyClusterMetrics, proxySelfMetrics, kubeStateMetrics, addonResizer];
 

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -95,7 +95,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         ]) +
         container.withVolumeMounts([procVolumeMount, sysVolumeMount, rootVolumeMount]) +
         container.mixin.resources.withRequests({ cpu: '102m', memory: '180Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '102m', memory: '180Mi' });
+        container.mixin.resources.withLimits({ cpu: '250m', memory: '180Mi' });
 
       local ip = containerEnv.fromFieldPath('IP', 'status.podIP');
       local proxy =

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "9cc151ced4308573a91f4cc3fcdbc951213b03e0"
+            "version": "606a53d42a836baa950f138be43fae7ae98821cd"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
@@ -84,7 +84,7 @@ spec:
         name: addon-resizer
         resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 30Mi
           requests:
             cpu: 10m

--- a/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
+++ b/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
         name: node-exporter
         resources:
           limits:
-            cpu: 102m
+            cpu: 250m
             memory: 180Mi
           requests:
             cpu: 102m

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -459,7 +459,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 						},
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("5m"),
+								v1.ResourceCPU:    resource.MustParse("50m"),
 								v1.ResourceMemory: resource.MustParse("10Mi"),
 							},
 						},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -578,7 +578,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 			VolumeMounts: []v1.VolumeMount{},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("5m"),
+					v1.ResourceCPU:    resource.MustParse("25m"),
 					v1.ResourceMemory: resource.MustParse("10Mi"),
 				},
 			},
@@ -794,7 +794,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 						VolumeMounts: configReloadVolumeMounts,
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("10m"),
+								v1.ResourceCPU:    resource.MustParse("50m"),
 								v1.ResourceMemory: resource.MustParse("50Mi"),
 							},
 						},


### PR DESCRIPTION
As kube-prometheus depends on the [kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin) and that ships with the _CPUThrottlingHigh_ alert we should at least increase the CPU limits for our small container sidecars.

I've measured these proposed values in my personal cluster and they do not get throttled more than 50% for more than 15min anymore and are therefore less noisy, but are still within some decent limit margin.

/cc @brancz @mxinden 

Note: I yet need to create the updated `jsonnetfile.lock.json` with re-generated manifest. But I'll do that once we have decided on the values.