### PR TITLE
node-exporter RBAC proxy listen on Pod IP

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -163,7 +163,7 @@ spec:
     spec:
       containers:
       - args:
-        - --web.listen-address=127.0.0.1:9101
+        - --web.listen-address=127.0.0.1:9100
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
@@ -189,8 +189,13 @@ spec:
           name: root
           readOnly: true
       - args:
-        - --secure-listen-address=:9100
-        - --upstream=http://127.0.0.1:9101/
+        - --secure-listen-address=$(IP):9100
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: quay.io/coreos/kube-rbac-proxy:v0.4.0
         name: kube-rbac-proxy
         ports:

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "677cb68995f2632cd5a1ecb26e52e3a7c743322b"
+            "version": "f2724c252dad424580f3d5061304f88b4e1a2bb5"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
+++ b/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - args:
-        - --web.listen-address=127.0.0.1:9101
+        - --web.listen-address=127.0.0.1:9100
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
@@ -42,8 +42,13 @@ spec:
           name: root
           readOnly: true
       - args:
-        - --secure-listen-address=:9100
-        - --upstream=http://127.0.0.1:9101/
+        - --secure-listen-address=$(IP):9100
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: quay.io/coreos/kube-rbac-proxy:v0.4.0
         name: kube-rbac-proxy
         ports:


### PR DESCRIPTION
This commit adjusts the RBAC proxy for the node-exporter DaemonSet to
only listen on the Pod IP. It also adjusts the ports used by the
node-exporter Pod so that both containers are listening on 9100. The
actual node-exporter listens on 127.0.0.1:9100, while the RBAC proxy
listens on <PODIP>:9100. This ensures that port 9101 is not taken on
the host networking namespace.

cc @brancz @s-urbaniak re: our conversation from earlier in the day.
I think that putting the node-exporter on hostPort 9100 and exposing
the RBAC proxy on the containerPort 9100 is a better option than
taking up another port for the proxy. With this new configuration, the
proxy listens on the Pod IP (i.e. the node's IP since we are on host network)
and the node exporter listen's on the node's localhost. The service NATs
to podIP:9100 so it connects to the RBAC proxy. I tested this on my cluster
and Prometheus correctly scrapes the proxy on HTTPS.