### PR TITLE
kube-prometheus fix coredns to work with default recommended setup

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -29,6 +29,7 @@ local configMapList = k.core.v1.configMapList;
     kubeSchedulerSelector: 'job="kube-scheduler"',
     kubeControllerManagerSelector: 'job="kube-controller-manager"',
     kubeApiserverSelector: 'job="apiserver"',
+    coreDNSSelector: 'job="kube-dns"',
     podLabel: 'pod',
 
     alertmanagerSelector: 'job="alertmanager-main"',
@@ -45,6 +46,7 @@ local configMapList = k.core.v1.configMapList;
       Alertmanager: $._config.alertmanagerSelector,
       Prometheus: $._config.prometheusSelector,
       PrometheusOperator: $._config.prometheusOperatorSelector,
+      CoreDNS: $._config.coreDNSSelector,
     },
 
     prometheus+:: {

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -386,11 +386,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           },
         },
         spec: {
-          jobLabel: 'k8s-app',
           selector: {
             matchLabels: {
-              'k8s-app': 'coredns',
-              component: 'metrics',
+              'k8s-app': 'kube-dns',
             },
           },
           namespaceSelector: {
@@ -400,7 +398,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           },
           endpoints: [
             {
-              port: 'http-metrics',
+              port: 'metrics',
               interval: '15s',
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
             },

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "f2724c252dad424580f3d5061304f88b4e1a2bb5"
+            "version": "dff8f44fbce268596c86b8d586c64c17953feab3"
         },
         {
             "name": "ksonnet",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "bb25891960b9ebbe0f526d1e067f94906d6fb58f"
+            "version": "02a9810a9e4e5c95feed4a6d6d2c5525fe2af1c1"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -293,6 +293,15 @@ spec:
       for: 15m
       labels:
         severity: critical
+    - alert: CoreDNSDown
+      annotations:
+        message: CoreDNS has disappeared from Prometheus target discovery.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-corednsdown
+      expr: |
+        absent(up{job="kube-dns"} == 1)
+      for: 15m
+      labels:
+        severity: critical
     - alert: KubeAPIDown
       annotations:
         message: KubeAPI has disappeared from Prometheus target discovery.

--- a/contrib/kube-prometheus/manifests/prometheus-serviceMonitorCoreDNS.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-serviceMonitorCoreDNS.yaml
@@ -9,12 +9,10 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 15s
-    port: http-metrics
-  jobLabel: k8s-app
+    port: metrics
   namespaceSelector:
     matchNames:
     - kube-system
   selector:
     matchLabels:
-      component: metrics
-      k8s-app: coredns
+      k8s-app: kube-dns


### PR DESCRIPTION
This PR adapts our default configuration for monitoring coredns to match the recommended default install on kubernetes as specified in the coredns repository: https://github.com/coredns/deployment/blob/master/kubernetes/coredns.yaml.sed#L150-L172

@metalmatze @squat @mxinden @s-urbaniak 