### PR TITLE
cmd/operator: add http client timeout

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	alertmanagercontroller "github.com/coreos/prometheus-operator/pkg/alertmanager"
 	"github.com/coreos/prometheus-operator/pkg/api"
@@ -132,6 +133,7 @@ func init() {
 	flagset.StringVar(&cfg.LogLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(availableLogLevels, ", ")))
 	flagset.StringVar(&cfg.LogFormat, "log-format", logFormatLogfmt, fmt.Sprintf("Log format to use. Possible values: %s", strings.Join(availableLogFormats, ", ")))
 	flagset.BoolVar(&cfg.ManageCRDs, "manage-crds", true, "Manage all CRDs with the Prometheus Operator.")
+	flagset.DurationVar(&cfg.Timeout, "timeout", 32*time.Second, "The timeout for remote calls against the Kubernetes API.")
 	flagset.Parse(os.Args[1:])
 	cfg.Namespaces = ns.asSlice()
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -40,6 +40,8 @@ func New(conf prometheus.Config, l log.Logger) (*API, error) {
 		return nil, err
 	}
 
+	cfg.Timeout = conf.Timeout
+
 	kclient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -147,6 +147,11 @@ type Config struct {
 	LogLevel                     string
 	LogFormat                    string
 	ManageCRDs                   bool
+
+	// The maximum length of time to wait before giving up on a server request against the k8s API.
+	// A value of zero means no timeout.
+	// Internally this sets net/http#Client.Timeout in k8s's REST http client.
+	Timeout time.Duration
 }
 
 type BasicAuthCredentials struct {
@@ -160,6 +165,9 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	cfg.Timeout = conf.Timeout
+
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is the lightweight version of
https://github.com/coreos/prometheus-operator/pull/2154.

This should be good enough for http client based timeouts.