### PR TITLE
contrib/kube-prometheus: Add prometheusURL to adapter's jsonnet config

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -15,6 +15,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
     prometheusAdapter+:: {
       name: 'prometheus-adapter',
       labels: { name: $._config.prometheusAdapter.name },
+      prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc:9090/',
       config: |||
         resourceRules:
           cpu:
@@ -98,7 +99,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           '--config=/etc/adapter/config.yaml',
           '--logtostderr=true',
           '--metrics-relist-interval=1m',
-          '--prometheus-url=http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc:9090/',
+          '--prometheus-url=' + $._config.prometheusAdapter.prometheusURL,
           '--secure-port=6443',
         ]) +
         container.withPorts([{ containerPort: 6443 }]) +


### PR DESCRIPTION
It should be easier to configure the Prometheus Adapater's prometheusURL from jsonnet. Hence, we move the prometheusURL into the _config and reference it as argument in the Deployment.

As this is a nop for the manifests themselves, nothing needs to be generated.

/cc @s-urbaniak @brancz 