### PR TITLE
Fix broken cluster role

### DIFF
--- a/Documentation/rbac-crd.md
+++ b/Documentation/rbac-crd.md
@@ -26,7 +26,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["monitoring.coreos.com"]
-  resources: ["alertmanagers, prometheuses, prometheusrules, servicemonitors"]
+  resources: ["alertmanagers", "prometheuses", "prometheusrules", "servicemonitors"]
   verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRole
@@ -38,6 +38,6 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups: ["monitoring.coreos.com"]
-  resources: ["alertmanagers, prometheuses, prometheusrules, servicemonitors"]
+  resources: ["alertmanagers", "prometheuses", "prometheusrules", "servicemonitors"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ```

--- a/example/rbac/prometheus-operator-crd/prometheus-operator-crd-cluster-roles.yaml
+++ b/example/rbac/prometheus-operator-crd/prometheus-operator-crd-cluster-roles.yaml
@@ -6,7 +6,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["monitoring.coreos.com"]
-  resources: ["alertmanagers, prometheuses, prometheusrules, servicemonitors"]
+  resources: ["alertmanagers", "prometheuses", "prometheusrules", "servicemonitors"]
   verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRole
@@ -18,5 +18,5 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups: ["monitoring.coreos.com"]
-  resources: ["alertmanagers, prometheuses, prometheusrules, servicemonitors"]
+  resources: ["alertmanagers", "prometheuses", "prometheusrules", "servicemonitors"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
The cluster role is broken. The items in the list must be quoted individually.
See https://kubernetes.slack.com/archives/C09NXKJKA/p1543244788508000.