### PR TITLE
fix syntax error in prometheus.libsonnet

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -40,7 +40,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       service.new('prometheus-' + $._config.prometheus.name, { app: 'prometheus', prometheus: $._config.prometheus.name }, prometheusPort) +
       service.mixin.metadata.withNamespace($._config.namespace) +
       service.mixin.metadata.withLabels({ prometheus: $._config.prometheus.name }),
-    [if $._config.prometheus.rules != null and $._config.prometheus.rules != {} then "rules"]:
+    [if $._config.prometheus.rules != null && $._config.prometheus.rules != {} then "rules"]:
       {
         apiVersion: 'monitoring.coreos.com/v1',
         kind: 'PrometheusRule',


### PR DESCRIPTION
Got the following error when calling jsonnet:

```
vendor/kube-prometheus/prometheus/prometheus.libsonnet:43:44-47 Expected token then but got (IDENTIFIER, "and")

    [if $._config.prometheus.rules != null and $._config.prometheus.rules != {} then "rules"]:
```

Changing `and` to `&&` fixes that.