### PR TITLE
fix breaking typo

### DIFF
--- a/contrib/kube-prometheus/docs/exposing-prometheus-alertmanager-grafana-ingress.md
+++ b/contrib/kube-prometheus/docs/exposing-prometheus-alertmanager-grafana-ingress.md
@@ -43,7 +43,7 @@ local kp =
     prometheus+:: {
       prometheus+: {
         spec+: {
-          externalURL: 'http://prometheus.example.com',
+          externalUrl: 'http://prometheus.example.com',
         },
       },
     },


### PR DESCRIPTION
the operator spec key is named "externalUrl", rather than "externalURL"