### PR TITLE
pkg/listwatch: fix racy multiwatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ test: test-unit test-e2e
 
 .PHONY: test-unit
 test-unit:
-	@go test $(TEST_RUN_ARGS) -short $(pkgs)
+	@go test -race $(TEST_RUN_ARGS) -short $(pkgs)
 
 .PHONY: test-e2e
 test-e2e: KUBECONFIG?=$(HOME)/.kube/config


### PR DESCRIPTION
Currently, listwatch is racy, as revealed by the following error, when
running in k8s:

```
W1128 16:49:11.288643       1 reflector.go:270] github.com/coreos/prometheus-operator/pkg/prometheus/operator.go:403: watch of *v1.ConfigMap ended with: too old resource version: 14464 (19288)
panic: send on closed channel

goroutine 1373 [running]:
github.com/coreos/prometheus-operator/pkg/listwatch.newMultiWatch.func1(0x17f1c00, 0xc00084cab0, 0xc0002bbce0)
    /home/sur/go/src/github.com/coreos/prometheus-operator/pkg/listwatch/listwatch.go:181 +0x4f
created by github.com/coreos/prometheus-operator/pkg/listwatch.newMultiWatch
    /home/sur/go/src/github.com/coreos/prometheus-operator/pkg/listwatch/listwatch.go:175 +0x298
```

This fixes it by ensuring that the event sender channel is closed,
once all sender dispatcher goroutines exited.

This also fixes a small concurrency issue in the tests and adds the
`-race` parameter to unit tests in the Makefile.

cc @brancz @squat