### PR TITLE
contrib: align kube job labels with kubernetes-mixin

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -102,7 +102,7 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: kube-system
-  name: kube-scheduler-prometheus-discovery
+  name: kube-scheduler
   labels:
     k8s-app: kube-scheduler
 spec:
@@ -124,7 +124,7 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: kube-system
-  name: kube-controller-manager-prometheus-discovery
+  name: kube-controller-manager
   labels:
     k8s-app: kube-controller-manager
 spec:

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-bootkube.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-bootkube.libsonnet
@@ -5,17 +5,17 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+:: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeDnsPrometheusDiscoveryService:
-      service.new('kube-dns-prometheus-discovery', { 'k8s-app': 'kube-dns' }, [servicePort.newNamed('http-metrics-skydns', 10055, 10055), servicePort.newNamed('http-metrics-dnsmasq', 10054, 10054)]) +
+      service.new('kube-dns', { 'k8s-app': 'kube-dns' }, [servicePort.newNamed('http-metrics-skydns', 10055, 10055), servicePort.newNamed('http-metrics-dnsmasq', 10054, 10054)]) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-dns' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
@@ -5,17 +5,17 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+:: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeDnsPrometheusDiscoveryService:
-      service.new('kube-dns-prometheus-discovery', { 'k8s-app': 'kube-dns' }, [servicePort.newNamed('http-metrics-skydns', 10055, 10055), servicePort.newNamed('http-metrics-dnsmasq', 10054, 10054)]) +
+      service.new('kube-dns', { 'k8s-app': 'kube-dns' }, [servicePort.newNamed('http-metrics-skydns', 10055, 10055), servicePort.newNamed('http-metrics-dnsmasq', 10054, 10054)]) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-dns' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kube-aws.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kube-aws.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kubeadm.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kubeadm.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { component: 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager', { component: 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { component: 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler', { component: 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),


### PR DESCRIPTION
This ensures the naming conventions of our kube-prometheus service
discovery matches the naming conventions of other discovery services
as well as the kubernetes-mixin project.

Fixes #2180