### PR TITLE
kube-prometheus: Fix ExternalUrl key typo in ingress example

### DIFF
--- a/contrib/kube-prometheus/examples/ingress.jsonnet
+++ b/contrib/kube-prometheus/examples/ingress.jsonnet
@@ -15,7 +15,7 @@ local kp =
     alertmanager+:: {
       alertmanager+: {
         spec+: {
-          externalURL: 'http://alertmanager.example.com',
+          externalUrl: 'http://alertmanager.example.com',
         },
       },
     },
@@ -31,7 +31,7 @@ local kp =
     prometheus+:: {
       prometheus+: {
         spec+: {
-          externalURL: 'http://prometheus.example.com',
+          externalUrl: 'http://prometheus.example.com',
         },
       },
     },


### PR DESCRIPTION
Per: https://github.com/coreos/prometheus-operator/pull/2172