### PR TITLE
Set the securityContext for Prometheus and Alertmanager in manifests

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -424,6 +424,10 @@ spec:
     matchLabels:
       prometheus: k8s
       role: alert-rules
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
   serviceAccountName: prometheus-k8s
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
@@ -621,6 +625,10 @@ spec:
   nodeSelector:
     beta.kubernetes.io/os: linux
   replicas: 3
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
   serviceAccountName: alertmanager-main
   version: v0.15.3
 ```

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
@@ -113,6 +113,11 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           baseImage: $._config.imageRepos.alertmanager,
           nodeSelector: { 'beta.kubernetes.io/os': 'linux' },
           serviceAccountName: 'alertmanager-' + $._config.alertmanager.name,
+          securityContext: {
+            runAsUser: 1000,
+            runAsNonRoot: true,
+            fsGroup: 2000,
+          },
         },
       },
   },

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -40,7 +40,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       service.new('prometheus-' + $._config.prometheus.name, { app: 'prometheus', prometheus: $._config.prometheus.name }, prometheusPort) +
       service.mixin.metadata.withNamespace($._config.namespace) +
       service.mixin.metadata.withLabels({ prometheus: $._config.prometheus.name }),
-    [if $._config.prometheus.rules != null && $._config.prometheus.rules != {} then "rules"]:
+    [if $._config.prometheus.rules != null && $._config.prometheus.rules != {} then 'rules']:
       {
         apiVersion: 'monitoring.coreos.com/v1',
         kind: 'PrometheusRule',
@@ -184,6 +184,11 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                 port: 'web',
               },
             ],
+          },
+          securityContext: {
+            runAsUser: 1000,
+            runAsNonRoot: true,
+            fsGroup: 2000,
           },
         },
       },

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "433616b23b9c4bce759bc99c35ca2a66348c36b8"
+            "version": "cc1d3b421e00f8891582ba9692b78814220c69c6"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/alertmanager-alertmanager.yaml
+++ b/contrib/kube-prometheus/manifests/alertmanager-alertmanager.yaml
@@ -10,5 +10,9 @@ spec:
   nodeSelector:
     beta.kubernetes.io/os: linux
   replicas: 3
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
   serviceAccountName: alertmanager-main
   version: v0.15.3

--- a/contrib/kube-prometheus/manifests/prometheus-prometheus.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-prometheus.yaml
@@ -22,6 +22,10 @@ spec:
     matchLabels:
       prometheus: k8s
       role: alert-rules
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
   serviceAccountName: prometheus-k8s
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}


### PR DESCRIPTION
As #2109 removed setting the securityContext in the reconciliation loop of the operator and this broke quite a few people we want to set this as default in the manifests again.

/cc @brancz @squat 