### PR TITLE
Replace SharedIndexInformers with nonshared version of them

### DIFF
--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -169,7 +169,7 @@ func (c *Operator) selectRules(p *monitoringv1.Prometheus, namespaces []string) 
 
 	for _, ns := range namespaces {
 		var marshalErr error
-		err := cache.ListAllByNamespace(c.ruleInf.GetIndexer(), ns, ruleSelector, func(obj interface{}) {
+		err := cache.ListAllByNamespace(c.ruleInf.index, ns, ruleSelector, func(obj interface{}) {
 			rule := obj.(*monitoringv1.PrometheusRule)
 			content, err := yaml.Marshal(rule.Spec)
 			if err != nil {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -167,6 +167,11 @@ func testPromResourceUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+        if len(pods.Items) != 1 {
+                t.Fatalf("Expected single pod to be found, got %d pods instead", len(pods.Items))
+        }
+
 	res := pods.Items[0].Spec.Containers[0].Resources
 
 	if !reflect.DeepEqual(res, p.Spec.Resources) {


### PR DESCRIPTION
Informers were not really shared at all, so to convey
what is  actually happening clearer, use of less powerfull
abstractions is desirable.