### PR TITLE
contrib/kube-prometheus: Set Prometheus Adapter maxSurge

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -5,7 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
     namespace: 'default',
 
     versions+:: {
-      prometheusAdapter: 'v0.3.0',
+      prometheusAdapter: 'v0.4.0',
     },
 
     imageRepos+:: {
@@ -113,6 +113,8 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       deployment.mixin.metadata.withNamespace($._config.namespace) +
       deployment.mixin.spec.selector.withMatchLabels($._config.prometheusAdapter.labels) +
       deployment.mixin.spec.template.spec.withServiceAccountName($.prometheusAdapter.serviceAccount.metadata.name) +
+      deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(1) +
+      deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0) +
       deployment.mixin.spec.template.spec.withVolumes([
         volume.fromEmptyDir(name='tmpfs'),
         volume.fromEmptyDir(name='volume-serving-cert'),

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "cc1d3b421e00f8891582ba9692b78814220c69c6"
+            "version": "920b29babc4f4e490170b73aba2f9de86e0a08b6"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/prometheus-adapter-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-adapter-deployment.yaml
@@ -8,6 +8,10 @@ spec:
   selector:
     matchLabels:
       name: prometheus-adapter
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -21,7 +25,7 @@ spec:
         - --metrics-relist-interval=1m
         - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
         - --secure-port=6443
-        image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.3.0
+        image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.4.0
         name: prometheus-adapter
         ports:
         - containerPort: 6443


### PR DESCRIPTION
We want to make sure that at least one Prometheus Adapter is always running while the next one starts. Therefore we're setting the maxSurge to 1 and maxUnavailable to 0.

/cc @squat @brancz @s-urbaniak 