### PR TITLE
kube-prometheus: Add poddisruptionbudgets to ksm cluster role 

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -41,11 +41,11 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
     clusterRole:
       local clusterRole = k.rbac.v1.clusterRole;
-      local policyRule = clusterRole.rulesType;
+      local rulesType = clusterRole.rulesType;
 
-      local coreRule = policyRule.new() +
-                       policyRule.withApiGroups(['']) +
-                       policyRule.withResources([
+      local coreRule = rulesType.new() +
+                       rulesType.withApiGroups(['']) +
+                       rulesType.withResources([
                          'configmaps',
                          'secrets',
                          'nodes',
@@ -59,57 +59,64 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                          'namespaces',
                          'endpoints',
                        ]) +
-                       policyRule.withVerbs(['list', 'watch']);
+                       rulesType.withVerbs(['list', 'watch']);
 
-      local extensionsRule = policyRule.new() +
-                             policyRule.withApiGroups(['extensions']) +
-                             policyRule.withResources([
+      local extensionsRule = rulesType.new() +
+                             rulesType.withApiGroups(['extensions']) +
+                             rulesType.withResources([
                                'daemonsets',
                                'deployments',
                                'replicasets',
                              ]) +
-                             policyRule.withVerbs(['list', 'watch']);
+                             rulesType.withVerbs(['list', 'watch']);
 
-      local appsRule = policyRule.new() +
-                       policyRule.withApiGroups(['apps']) +
-                       policyRule.withResources([
+      local appsRule = rulesType.new() +
+                       rulesType.withApiGroups(['apps']) +
+                       rulesType.withResources([
                          'statefulsets',
                          'daemonsets',
                          'deployments',
                          'replicasets',
                        ]) +
-                       policyRule.withVerbs(['list', 'watch']);
+                       rulesType.withVerbs(['list', 'watch']);
 
-      local batchRule = policyRule.new() +
-                        policyRule.withApiGroups(['batch']) +
-                        policyRule.withResources([
+      local batchRule = rulesType.new() +
+                        rulesType.withApiGroups(['batch']) +
+                        rulesType.withResources([
                           'cronjobs',
                           'jobs',
                         ]) +
-                        policyRule.withVerbs(['list', 'watch']);
+                        rulesType.withVerbs(['list', 'watch']);
 
-      local autoscalingRule = policyRule.new() +
-                              policyRule.withApiGroups(['autoscaling']) +
-                              policyRule.withResources([
+      local autoscalingRule = rulesType.new() +
+                              rulesType.withApiGroups(['autoscaling']) +
+                              rulesType.withResources([
                                 'horizontalpodautoscalers',
                               ]) +
-                              policyRule.withVerbs(['list', 'watch']);
+                              rulesType.withVerbs(['list', 'watch']);
 
-      local authenticationRole = policyRule.new() +
-                                 policyRule.withApiGroups(['authentication.k8s.io']) +
-                                 policyRule.withResources([
+      local authenticationRole = rulesType.new() +
+                                 rulesType.withApiGroups(['authentication.k8s.io']) +
+                                 rulesType.withResources([
                                    'tokenreviews',
                                  ]) +
-                                 policyRule.withVerbs(['create']);
+                                 rulesType.withVerbs(['create']);
 
-      local authorizationRole = policyRule.new() +
-                                policyRule.withApiGroups(['authorization.k8s.io']) +
-                                policyRule.withResources([
+      local authorizationRole = rulesType.new() +
+                                rulesType.withApiGroups(['authorization.k8s.io']) +
+                                rulesType.withResources([
                                   'subjectaccessreviews',
                                 ]) +
-                                policyRule.withVerbs(['create']);
+                                rulesType.withVerbs(['create']);
 
-      local rules = [coreRule, extensionsRule, appsRule, batchRule, autoscalingRule, authenticationRole, authorizationRole];
+      local policyRule = rulesType.new() +
+                                rulesType.withApiGroups(['policy']) +
+                                rulesType.withResources([
+                                  'poddisruptionbudgets',
+                                ]) +
+                                rulesType.withVerbs(['list', 'watch']);
+
+      local rules = [coreRule, extensionsRule, appsRule, batchRule, autoscalingRule, authenticationRole, authorizationRole, policyRule];
 
       clusterRole.new() +
       clusterRole.mixin.metadata.withName('kube-state-metrics') +
@@ -208,30 +215,30 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
     role:
       local role = k.rbac.v1.role;
-      local policyRule = role.rulesType;
+      local rulesType = role.rulesType;
 
-      local coreRule = policyRule.new() +
-                       policyRule.withApiGroups(['']) +
-                       policyRule.withResources([
+      local coreRule = rulesType.new() +
+                       rulesType.withApiGroups(['']) +
+                       rulesType.withResources([
                          'pods',
                        ]) +
-                       policyRule.withVerbs(['get']);
+                       rulesType.withVerbs(['get']);
 
-      local extensionsRule = policyRule.new() +
-                             policyRule.withApiGroups(['extensions']) +
-                             policyRule.withResources([
+      local extensionsRule = rulesType.new() +
+                             rulesType.withApiGroups(['extensions']) +
+                             rulesType.withResources([
                                'deployments',
                              ]) +
-                             policyRule.withVerbs(['get', 'update']) +
-                             policyRule.withResourceNames(['kube-state-metrics']);
+                             rulesType.withVerbs(['get', 'update']) +
+                             rulesType.withResourceNames(['kube-state-metrics']);
 
-      local appsRule = policyRule.new() +
-                       policyRule.withApiGroups(['apps']) +
-                       policyRule.withResources([
+      local appsRule = rulesType.new() +
+                       rulesType.withApiGroups(['apps']) +
+                       rulesType.withResources([
                          'deployments',
                        ]) +
-                       policyRule.withVerbs(['get', 'update']) +
-                       policyRule.withResourceNames(['kube-state-metrics']);
+                       rulesType.withVerbs(['get', 'update']) +
+                       rulesType.withResourceNames(['kube-state-metrics']);
 
       local rules = [coreRule, extensionsRule, appsRule];
 

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "920b29babc4f4e490170b73aba2f9de86e0a08b6"
+            "version": "9a1c77489e72ef80fcd29bd11d10d173db78b6c8"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
@@ -67,3 +67,10 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch


### PR DESCRIPTION
With https://github.com/kubernetes/kube-state-metrics/commit/40f293dbde2f69ad0b5ae5875e2f19fed0b749e5 kube-state-metrics exposes metrics about poddisruptionbudgets. Hence kube-state-metrics needs the permissions to collect those metrics via its cluster role.

Thanks @metalmatze for the hint!