### PR TITLE
Avoids values from other namespaces in pods graphs

### DIFF
--- a/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
@@ -6195,7 +6195,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum by (container_name) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod_name=\"$pod\"}[1m]))",
+                                  "expr": "sum by (container_name) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", namespace=\"$namespace\", image!=\"\",container_name!=\"POD\",pod_name=\"$pod\"}[1m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{ container_name }}",
@@ -6298,7 +6298,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{job=\"kubelet\", pod_name=\"$pod\"}[1m])))",
+                                  "expr": "sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{job=\"kubelet\", namespace=\"$namespace\", pod_name=\"$pod\"}[1m])))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{ pod_name }}",

--- a/helm/grafana/dashboards/pods-dashboard.json
+++ b/helm/grafana/dashboards/pods-dashboard.json
@@ -67,7 +67,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum by(container_name) (container_memory_usage_bytes{pod_name=\"$pod\", container_name=~\"$container\", container_name!=\"POD\"})",
+                                "expr": "sum by(container_name) (container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\", container_name=~\"$container\", container_name!=\"POD\"})",
                                 "interval": "10s",
                                 "intervalFactor": 1,
                                 "legendFormat": "Current: {{ container_name }}",
@@ -76,7 +76,7 @@
                                 "step": 15
                             },
                             {
-                                "expr": "kube_pod_container_resource_requests_memory_bytes{pod=\"$pod\", container=~\"$container\"}",
+                                "expr": "kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\"}",
                                 "interval": "10s",
                                 "intervalFactor": 2,
                                 "legendFormat": "Requested: {{ container }}",
@@ -85,7 +85,7 @@
                                 "step": 20
                             },
                             {
-                                "expr": "kube_pod_container_resource_limits_memory_bytes{pod=\"$pod\", container=~\"$container\"}",
+                                "expr": "kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\"}",
                                 "interval": "10s",
                                 "intervalFactor": 2,
                                 "legendFormat": "Limit: {{ container }}",
@@ -173,14 +173,14 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum by (container_name)(rate(container_cpu_usage_seconds_total{image!=\"\",container_name!=\"POD\",pod_name=\"$pod\"}[1m]))",
+                                "expr": "sum by (container_name)(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",image!=\"\",container_name!=\"POD\",pod_name=\"$pod\"}[1m]))",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{ container_name }}",
                                 "refId": "A",
                                 "step": 30
                             },
                             {
-                                "expr": "kube_pod_container_resource_requests_cpu_cores{pod=\"$pod\", container=~\"$container\"}",
+                                "expr": "kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\"}",
                                 "interval": "10s",
                                 "intervalFactor": 2,
                                 "legendFormat": "Requested: {{ container }}",
@@ -189,7 +189,7 @@
                                 "step": 20
                             },
                             {
-                                "expr": "kube_pod_container_resource_limits_cpu_cores{pod=\"$pod\", container=~\"$container\"}",
+                                "expr": "kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\"}",
                                 "interval": "10s",
                                 "intervalFactor": 2,
                                 "legendFormat": "Limit: {{ container }}",
@@ -277,7 +277,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{pod_name=\"$pod\"}[1m])))",
+                                "expr": "sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod_name=\"$pod\"}[1m])))",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{ pod_name }}",
                                 "refId": "A",


### PR DESCRIPTION
For example if the same StatefulSet name is used in different namespaces,
graphs could show resources from one namespace with requests or limits from another.