### PR TITLE
Use Parallel podManagementPolicy in the alert manager

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -405,8 +405,9 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	terminationGracePeriod := int64(0)
 	finalLabels := config.Labels.Merge(podLabels)
 	return &appsv1.StatefulSetSpec{
-		ServiceName: governingServiceName,
-		Replicas:    a.Spec.Replicas,
+		ServiceName:         governingServiceName,
+		Replicas:            a.Spec.Replicas,
+		PodManagementPolicy: appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,
 		},


### PR DESCRIPTION
@squat this is one change. It seems that prometheus already uses Parallel in master. Now, how can I make the v3.11 version of the monitoring operator use Parallel for both statefulsets?