### PR TITLE
contrib: add quotes when value begins with colon

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -129,7 +129,7 @@ spec:
       record: node:node_num_cpu:sum
     - expr: |
         1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m]))
-      record: :node_cpu_utilisation:avg1m
+      record: ':node_cpu_utilisation:avg1m'
     - expr: |
         1 - avg by (node) (
           rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m])
@@ -158,10 +158,10 @@ spec:
       record: ':node_memory_utilisation:'
     - expr: |
         sum(node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
-      record: :node_memory_MemFreeCachedBuffers_bytes:sum
+      record: ':node_memory_MemFreeCachedBuffers_bytes:sum'
     - expr: |
         sum(node_memory_MemTotal_bytes{job="node-exporter"})
-      record: :node_memory_MemTotal_bytes:sum
+      record: ':node_memory_MemTotal_bytes:sum'
     - expr: |
         sum by (node) (
           (node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
@@ -186,7 +186,7 @@ spec:
           (rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
          + rate(node_vmstat_pgpgout{job="node-exporter"}[1m]))
         )
-      record: :node_memory_swap_io_bytes:sum_rate
+      record: ':node_memory_swap_io_bytes:sum_rate'
     - expr: |
         1 -
         sum by (node) (
@@ -214,17 +214,17 @@ spec:
       record: node:node_memory_swap_io_bytes:sum_rate
     - expr: |
         avg(irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]))
-      record: :node_disk_utilisation:avg_irate
+      record: ':node_disk_utilisation:avg_irate'
     - expr: |
         avg by (node) (
           irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m])
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )
-      record: node:node_disk_utilisation:avg_irate
+      record: 'node:node_disk_utilisation:avg_irate'
     - expr: |
         avg(irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]) / 1e3)
-      record: :node_disk_saturation:avg_irate
+      record: ':node_disk_saturation:avg_irate'
     - expr: |
         avg by (node) (
           irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]) / 1e3
@@ -243,7 +243,7 @@ spec:
     - expr: |
         sum(irate(node_network_receive_bytes_total{job="node-exporter",device="eth0"}[1m])) +
         sum(irate(node_network_transmit_bytes_total{job="node-exporter",device="eth0"}[1m]))
-      record: :node_net_utilisation:sum_irate
+      record: ':node_net_utilisation:sum_irate'
     - expr: |
         sum by (node) (
           (irate(node_network_receive_bytes_total{job="node-exporter",device="eth0"}[1m]) +
@@ -255,7 +255,7 @@ spec:
     - expr: |
         sum(irate(node_network_receive_drop_total{job="node-exporter",device="eth0"}[1m])) +
         sum(irate(node_network_transmit_drop_total{job="node-exporter",device="eth0"}[1m]))
-      record: :node_net_saturation:sum_irate
+      record: ':node_net_saturation:sum_irate'
     - expr: |
         sum by (node) (
           (irate(node_network_receive_drop_total{job="node-exporter",device="eth0"}[1m]) +


### PR DESCRIPTION
This makes the yaml parsable by ruby which tries to interpret strings
beginning with : as symbols