### PR TITLE
contrib/kube-prometheus: Add jobLabel to ServiceMonitorCoreDNS

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -391,6 +391,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           },
         },
         spec: {
+          jobLabel: 'k8s-app',
           selector: {
             matchLabels: {
               'k8s-app': 'kube-dns',


### PR DESCRIPTION
Presently `jobLabel` is missing from to the ServiceMonitor for CoreDNS. This results in a prometheus job name matching the name of the selected service, for example `kube-dns-prometheus-discovery` with [kube-prometheus-kops](https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet#L17:L21).

The result is that the CoreDNS absent AlertRule does not work out of the box, because it is matching a jobLabel of `kube-dns`. 

Had to hunt down how this works, the Absent alerts are dynamically generated from [monitoring-mixins/alerts/absent_alerts.libsonnet](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/alerts/absent_alerts.libsonnet), which iterates through `_config.jobs`.

A manual workaround is to change [`_config.coreDNSSelector`](https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus.libsonnet#L32) to a value that matches the discovery service.