### PR TITLE
contrib/kube-prometheus: Add kops CoreDNS prometheus discovery service

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -359,6 +359,17 @@ kops:
 (import 'kube-prometheus/kube-prometheus-kops.libsonnet')
 ```
 
+kops with CoreDNS:
+
+If your kops cluster is using CoreDNS, there is an additional mixin to import.
+
+[embedmd]:# (examples/jsonnet-snippets/kops-coredns.jsonnet)
+```jsonnet
+(import 'kube-prometheus/kube-prometheus.libsonnet') +
+(import 'kube-prometheus/kube-prometheus-kops.libsonnet') + 
+(import 'kube-prometheus/kube-prometheus-kops-coredns.libsonnet')
+```
+
 kubespray:
 
 [embedmd]:# (examples/jsonnet-snippets/kubespray.jsonnet)

--- a/contrib/kube-prometheus/examples/jsonnet-snippets/kops-coredns.jsonnet
+++ b/contrib/kube-prometheus/examples/jsonnet-snippets/kops-coredns.jsonnet
@@ -1,0 +1,3 @@
+(import 'kube-prometheus/kube-prometheus.libsonnet') +
+(import 'kube-prometheus/kube-prometheus-kops.libsonnet') + 
+(import 'kube-prometheus/kube-prometheus-kops-coredns.libsonnet') 

--- a/contrib/kube-prometheus/examples/jsonnet-snippets/kops-coredns.jsonnet
+++ b/contrib/kube-prometheus/examples/jsonnet-snippets/kops-coredns.jsonnet
@@ -1,3 +1,3 @@
 (import 'kube-prometheus/kube-prometheus.libsonnet') +
 (import 'kube-prometheus/kube-prometheus-kops.libsonnet') + 
-(import 'kube-prometheus/kube-prometheus-kops-coredns.libsonnet') 
+(import 'kube-prometheus/kube-prometheus-kops-coredns.libsonnet')

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kops-coredns.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kops-coredns.libsonnet
@@ -1,0 +1,13 @@
+local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local service = k.core.v1.service;
+local servicePort = k.core.v1.service.mixin.spec.portsType;
+
+{
+  prometheus+:: {
+      kubeDnsPrometheusDiscoveryService:
+      service.new('kube-dns-prometheus-discovery', { 'k8s-app': 'kube-dns' }, [servicePort.newNamed('metrics', 9153, 9153)]) +
+      service.mixin.metadata.withNamespace('kube-system') +
+      service.mixin.metadata.withLabels({ 'k8s-app': 'kube-dns' }) +
+      service.mixin.spec.withClusterIp('None'),
+  },
+}

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "ef7b7f4941e117223cbef3e278b9161736a302a5"
+            "version": "0d011e48ab48a9e624347d82b7f8ecdcfe6bb5dd"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "e26f80aca8c9b021245ed3a62bb6c4d23be25786"
+            "version": "ef7b7f4941e117223cbef3e278b9161736a302a5"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "0d011e48ab48a9e624347d82b7f8ecdcfe6bb5dd"
+            "version": "acd31e80dcddd7ce11fd3b715d5bfe179a95474e"
         },
         {
             "name": "ksonnet",


### PR DESCRIPTION
This adds a mixin to fix the metrics ingestion for CoreDNS on kops.
The [`kubeDnsPrometheusDiscoveryService`](https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet#L17:L21) from the `kube-prometheus-kops` mixin is optionally overridden to replace the kube-dns ports with the correct ones for CoreDNS metrics.

CoreDNS uses port `metrics: 9153` to expose prometheus metrics. 
kube-dns used `'http-metrics-skydns: 10055` and `http-metrics-dnsmasq: 10054`. 

With #2233 now merged this should make the `CoreDNSDown` alert work out of the box on kops + CoreDNS.

It's not entirely clear to me if the kube-dns metrics ingestion on kops is working out of the box. If not, perhaps this change can be made the default and the legacy kube-dns ports removed instead.