### PR TITLE
Change label k8s-app to component

### DIFF
--- a/helm/exporter-kube-controller-manager/values.yaml
+++ b/helm/exporter-kube-controller-manager/values.yaml
@@ -5,7 +5,7 @@ endpoints: []
 # Are we talking http or https?
 scheme: http
 # service selector label key to target kube controller manager pods
-serviceSelectorLabelKey: k8s-app
+serviceSelectorLabelKey: component
 # default rules are in templates/kube-controller-manager.rules.yaml
 # prometheusRules: {}
 ## Custom Labels to be added to ServiceMonitor

--- a/helm/exporter-kube-scheduler/values.yaml
+++ b/helm/exporter-kube-scheduler/values.yaml
@@ -5,7 +5,7 @@ endpoints: []
 # Are we talking http or https?
 scheme: http
 # service selector label key to target kube scheduler pods
-serviceSelectorLabelKey: k8s-app
+serviceSelectorLabelKey: component
 # default rules are in templates/kube-scheduler.rules.yaml
 # prometheusRules: {}
 ## Custom Labels to be added to ServiceMonitor


### PR DESCRIPTION
Kubernetes installed by kubeadm uses component label for scheduler and controller-manager.
Default label should be component instead of k8s-app.