### PR TITLE
Use nobody

### DIFF
--- a/cmd/prometheus-config-reloader/Dockerfile
+++ b/cmd/prometheus-config-reloader/Dockerfile
@@ -2,4 +2,8 @@ FROM quay.io/prometheus/busybox:latest
 
 ADD prometheus-config-reloader /bin/prometheus-config-reloader
 
+RUN chown nobody:nogroup /bin/prometheus-config-reloader
+
+USER nobody
+
 ENTRYPOINT ["/bin/prometheus-config-reloader"]


### PR DESCRIPTION
For kubernetes clusters which do not allow running images as root user this is required. 
For all others it does not hurt though.