### PR TITLE
Gopkg.toml: Remove unnecessary override

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,10 +52,6 @@
   name = "k8s.io/kube-openapi"
   revision = "0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803"
 
-[[override]]
-  name = "github.com/ericchiang/k8s"
-  version = "v0.4.0"
-
 [[constraint]]
   branch = "master"
   name = "github.com/kylelemons/godebug"


### PR DESCRIPTION
'github.com/ericchiang/k8s' is not used anywhere, so the override is not
needed.