### PR TITLE
Lint YAML against our CRD defintions

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/ghodss/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func main() {
+	files := os.Args[1:]
+
+	for _, filename := range files {
+		content, err := ioutil.ReadFile(filename)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var meta metav1.TypeMeta
+
+		err = yaml.Unmarshal(content, &meta)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		switch meta.Kind {
+		case v1.AlertmanagersKind:
+			var alertmanager v1.Alertmanager
+			err := yaml.Unmarshal(content, &alertmanager)
+			if err != nil {
+				log.Fatal(fmt.Errorf("alertmanager is invalid: %v", err))
+			}
+		case v1.PrometheusesKind:
+			var prometheus v1.Prometheus
+			err := yaml.Unmarshal(content, &prometheus)
+			if err != nil {
+				log.Fatal(fmt.Errorf("prometheus is invalid: %v", err))
+			}
+		case v1.PrometheusRuleKind:
+			var rule v1.PrometheusRule
+			err := yaml.Unmarshal(content, &rule)
+			if err != nil {
+				log.Fatal(fmt.Errorf("prometheus rule is invalid: %v", err))
+			}
+		case v1.ServiceMonitorsKind:
+			var serviceMonitor v1.ServiceMonitor
+			err := yaml.Unmarshal(content, &serviceMonitor)
+			if err != nil {
+				log.Fatal(fmt.Errorf("serviceMonitor is invalid: %v", err))
+			}
+		default:
+			log.Fatal("MetaType is unknown to linter. Not in Alertmanager, Prometheus, PrometheusRule, ServiceMonitor")
+		}
+	}
+}

--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"fmt"
+	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"log"
 	"os"
@@ -29,28 +30,60 @@ func main() {
 
 		switch meta.Kind {
 		case v1.AlertmanagersKind:
-			var alertmanager v1.Alertmanager
-			err := yaml.Unmarshal(content, &alertmanager)
+			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
-				log.Fatal(fmt.Errorf("alertmanager is invalid: %v", err))
+				log.Fatalf("unable to convert YAML to JSON: %v", err)
+			}
+
+			decoder := json.NewDecoder(bytes.NewBuffer(j))
+			decoder.DisallowUnknownFields()
+
+			var alertmanager v1.Alertmanager
+			err = decoder.Decode(&alertmanager)
+			if err != nil {
+				log.Fatalf("alertmanager is invalid: %v", err)
 			}
 		case v1.PrometheusesKind:
-			var prometheus v1.Prometheus
-			err := yaml.Unmarshal(content, &prometheus)
+			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
-				log.Fatal(fmt.Errorf("prometheus is invalid: %v", err))
+				log.Fatalf("unable to convert YAML to JSON: %v", err)
+			}
+
+			decoder := json.NewDecoder(bytes.NewBuffer(j))
+			decoder.DisallowUnknownFields()
+
+			var prometheus v1.Prometheus
+			err = decoder.Decode(&prometheus)
+			if err != nil {
+				log.Fatalf("prometheus is invalid: %v", err)
 			}
 		case v1.PrometheusRuleKind:
-			var rule v1.PrometheusRule
-			err := yaml.Unmarshal(content, &rule)
+			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
-				log.Fatal(fmt.Errorf("prometheus rule is invalid: %v", err))
+				log.Fatalf("unable to convert YALM to JSON: %v", err)
+			}
+
+			decoder := json.NewDecoder(bytes.NewBuffer(j))
+			decoder.DisallowUnknownFields()
+
+			var rule v1.PrometheusRule
+			err = decoder.Decode(&rule)
+			if err != nil {
+				log.Fatalf("prometheus rule is invalid: %v", err)
 			}
 		case v1.ServiceMonitorsKind:
-			var serviceMonitor v1.ServiceMonitor
-			err := yaml.Unmarshal(content, &serviceMonitor)
+			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
-				log.Fatal(fmt.Errorf("serviceMonitor is invalid: %v", err))
+				log.Fatalf("unable to convert YALM to JSON: %v", err)
+			}
+
+			decoder := json.NewDecoder(bytes.NewBuffer(j))
+			decoder.DisallowUnknownFields()
+
+			var serviceMonitor v1.ServiceMonitor
+			err = decoder.Decode(&serviceMonitor)
+			if err != nil {
+				log.Fatalf("serviceMonitor is invalid: %v", err)
 			}
 		default:
 			log.Fatal("MetaType is unknown to linter. Not in Alertmanager, Prometheus, PrometheusRule, ServiceMonitor")

--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (


### PR DESCRIPTION
For now this is a standalone binary that I simply use by running `go run ./cmd/lint prometheus.yaml`.
It will then log errors if the YAML (that is first converted to JSON so that we can use `decoder.
DisallowUnknownFields()`) find something that is wrong.

Example:
```
$ go run ./cmd/lint contrib/kube-prometheus/manifests/prometheus-prometheus.yaml                                                                                                  

2019/01/08 12:40:18 prometheus is invalid: json: unknown field "nodeSelectors"
exit status 1
```

It should help us debug and identify typos and other mistakes more quickly.
We can also integrate the functionality some other place, but I also like the standalone binary.

/cc @brancz @s-urbaniak  @squat 