### PR TITLE
Add SessionAffinity ClusterIP to prometheus service

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -38,6 +38,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local prometheusPort = servicePort.newNamed('web', 9090, 'web');
 
       service.new('prometheus-' + $._config.prometheus.name, { app: 'prometheus', prometheus: $._config.prometheus.name }, prometheusPort) +
+      service.mixin.spec.withSessionAffinity('ClientIP') +
       service.mixin.metadata.withNamespace($._config.namespace) +
       service.mixin.metadata.withLabels({ prometheus: $._config.prometheus.name }),
     [if $._config.prometheus.rules != null && $._config.prometheus.rules != {} then 'rules']:


### PR DESCRIPTION
This PR adds SessionAffinity ClusterIP to the prometheus service to prevent grafana from querying different instances when loading/updating metrics.