### PR TITLE
Fix grafana label

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -15,13 +15,7 @@ local configMapList = k.core.v1.configMapList;
     namespace: k.core.v1.namespace.new($._config.namespace),
   },
   grafana+:: {
-    local serviceLabels = {
-      app: 'grafana',
-    },
     dashboardDefinitions: configMapList.new(super.dashboardDefinitions),
-    service+: {
-      labels+: serviceLabels,
-    },
     serviceMonitor: {
       apiVersion: 'monitoring.coreos.com/v1',
       kind: 'ServiceMonitor',
@@ -31,7 +25,9 @@ local configMapList = k.core.v1.configMapList;
       },
       spec: {
         selector: {
-          matchLabels: serviceLabels,
+          matchLabels: {
+            app: 'grafana',
+          },
         },
         endpoints: [
           {

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -113,6 +113,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       deployment.mixin.metadata.withNamespace($._config.namespace) +
       deployment.mixin.spec.selector.withMatchLabels($._config.prometheusAdapter.labels) +
       deployment.mixin.spec.template.spec.withServiceAccountName($.prometheusAdapter.serviceAccount.metadata.name) +
+      deployment.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/os': 'linux' }) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(1) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0) +
       deployment.mixin.spec.template.spec.withVolumes([

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "d3b2645d2ace03b36ed7d86e5213c09c9e1bde67"
+            "version": "e26f80aca8c9b021245ed3a62bb6c4d23be25786"
         },
         {
             "name": "ksonnet",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "c6932cf90bce4fef218b4308effc9f15c4219a01"
+            "version": "d75c3b260c1077c924d7ea0240250afc235c4cb3"
         },
         {
             "name": "grafana",
@@ -58,7 +58,7 @@
                     "subdir": "grafana"
                 }
             },
-            "version": "3cab96409b2b4b8e8a87f768f1e2b063b1df7038"
+            "version": "9ddf5a198b0f7c898dc061158ea427112acbae11"
         },
         {
             "name": "prometheus-operator",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "b04633fd8e67c65d4fe4929333fb4856f25da189"
+            "version": "1e42503bea073b559fca682219242a801cf4d587"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-deployment.yaml
@@ -69,6 +69,8 @@ spec:
         - mountPath: /grafana-dashboard-definitions/0/statefulset
           name: grafana-dashboard-statefulset
           readOnly: false
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/contrib/kube-prometheus/manifests/grafana-service.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-service.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Service
-labels:
-  app: grafana
 metadata:
+  labels:
+    app: grafana
   name: grafana
   namespace: monitoring
 spec:

--- a/contrib/kube-prometheus/manifests/prometheus-adapter-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-adapter-deployment.yaml
@@ -39,6 +39,8 @@ spec:
         - mountPath: /etc/adapter
           name: config
           readOnly: false
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       serviceAccountName: prometheus-adapter
       volumes:
       - emptyDir: {}

--- a/contrib/kube-prometheus/manifests/prometheus-service.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-service.yaml
@@ -13,3 +13,4 @@ spec:
   selector:
     app: prometheus
     prometheus: k8s
+  sessionAffinity: ClientIP


### PR DESCRIPTION
This prevented the grafana service from being applied to a cluster as `labels` was not in metadata.

@metalmatze @squat @s-urbaniak @mxinden 