### PR TITLE
contrib/kube-prometheus: Update kube-prometheus-thanos for Thanos v0.2

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-thanos.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-thanos.libsonnet
@@ -2,14 +2,19 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 
-
 {
   _config+:: {
     versions+:: {
-      thanos: 'v0.1.0',
+      thanos: 'v0.2.1',
     },
     imageRepos+:: {
       thanos: 'improbable/thanos',
+    },
+    thanos+:: {
+      objectStorageConfig: {
+        key: 'thanos.yaml', # How the file inside the secret is called
+        name: 'thanos-objstore-config', # This is the name of your Kubernetes secret with the config
+      },
     },
   },
   prometheus+:: {
@@ -22,6 +27,7 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
           peers: 'thanos-peers.' + $._config.namespace + '.svc:10900',
           version: $._config.versions.thanos,
           baseImage: $._config.imageRepos.thanos,
+          objectStorageConfig: $._config.thanos.objectStorageConfig,
         },
       },
     },


### PR DESCRIPTION
This updates the default kube-prometheus Thanos extension to v0.2. 
By default it will reference a Secret that users then have to create with their config.
More documentation will be added later once #2264 has been merged.

These changes are currently tested together with #2264 on my personal Thanos setup, looking good so far. :+1: 

With the Thanos v0.2 being out, I think we can finally merge an updated version #2039, as the StatefulSet is now agnostic to a object storage provider.

/cc @brancz @abursavich