### PR TITLE
kube-prometheus: Added ability to configure nodeExporter port

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -312,6 +312,10 @@ These are the available fields with their respective default values:
       cpuPerNode: '2m',
       memoryPerNode: '30Mi',
     },
+
+    nodeExporter+:: {
+      port: 9100,
+    },
 	},
 }
 ```


### PR DESCRIPTION
We have a conflict on port 9100 so we must change the port which node exporter runs on. I've not used jsonnet before so there is a good change I've done something silly but this seems to wfm.  