### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ kubectl delete --ignore-not-found customresourcedefinitions \
 #### Running *end-to-end* tests on local minikube cluster:
 
 1. `minikube start --kubernetes-version=v1.10.0 --memory=4096
-    --extra-config=apiserver.Authorization.Mode=RBAC`
+    --extra-config=apiserver.authorization-mode=RBAC`
 2. `eval $(minikube docker-env) && make image` - build Prometheus Operator
     docker image on minikube's docker
 3. `make test-e2e`


### PR DESCRIPTION
Capitalization and hyphen change. Using the old example results in a broken minikube:

```
✗ minikube status
host: Running
kubelet: Running
apiserver: Stopped
```
https://github.com/kubernetes/minikube/issues/2798