### PR TITLE
Fix for omitting source_labels where they are unnecessary

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -750,8 +750,10 @@ func (cg *configGenerator) generateRemoteWriteConfig(version semver.Version, spe
 		if spec.WriteRelabelConfigs != nil {
 			relabelings := []yaml.MapSlice{}
 			for _, c := range spec.WriteRelabelConfigs {
-				relabeling := yaml.MapSlice{
-					{Key: "source_labels", Value: c.SourceLabels},
+				relabeling := yaml.MapSlice{}
+
+				if c.SourceLabels != "" {
+					relabeling = append(relabeling, yaml.MapItem{Key: "source_labels", Value: c.SourceLabels})
 				}
 
 				if c.Separator != "" {

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -752,7 +752,7 @@ func (cg *configGenerator) generateRemoteWriteConfig(version semver.Version, spe
 			for _, c := range spec.WriteRelabelConfigs {
 				relabeling := yaml.MapSlice{}
 
-				if c.SourceLabels != "" {
+				if len(c.SourceLabels) > 0 {
 					relabeling = append(relabeling, yaml.MapItem{Key: "source_labels", Value: c.SourceLabels})
 				}
 


### PR DESCRIPTION
I've tried my hand at the go workflow and applied the fix outlined by @ViniciusSouza in https://github.com/coreos/prometheus-operator/issues/2218#issuecomment-449349056

Fixes #2218 