### PR TITLE
Fix node exporter crash looping

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -5,7 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
     namespace: 'default',
 
     versions+:: {
-      nodeExporter: 'v0.16.0',
+      nodeExporter: 'v0.17.0',
       kubeRbacProxy: 'v0.4.0',
     },
 


### PR DESCRIPTION
Seeing this error on all the node_exporter pods after updating kube-prometheus:
`node_exporter: error: unknown long flag '--path.rootfs', try --help`

https://github.com/coreos/prometheus-operator/pull/2285 added `--path.rootfs=/host/root` to the nodeExporter args, however the nodeExporter default version is `v0.16.0` which doesn't support this flag. 

Support for `--path.rootfs` was added in node exporter v0.17.0 https://github.com/prometheus/node_exporter/pull/1058.