### PR TITLE
pkg/prometheus: guard against nil targetPort

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -382,18 +382,20 @@ func (cg *configGenerator) generateServiceMonitorConfig(version semver.Version, 
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_endpoint_port_name"}},
 			{Key: "regex", Value: ep.Port},
 		})
-	} else if ep.TargetPort.StrVal != "" {
-		relabelings = append(relabelings, yaml.MapSlice{
-			{Key: "action", Value: "keep"},
-			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_container_port_name"}},
-			{Key: "regex", Value: ep.TargetPort.String()},
-		})
-	} else if ep.TargetPort.IntVal != 0 {
-		relabelings = append(relabelings, yaml.MapSlice{
-			{Key: "action", Value: "keep"},
-			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_container_port_number"}},
-			{Key: "regex", Value: ep.TargetPort.String()},
-		})
+	} else if ep.TargetPort != nil {
+		if ep.TargetPort.StrVal != "" {
+			relabelings = append(relabelings, yaml.MapSlice{
+				{Key: "action", Value: "keep"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_container_port_name"}},
+				{Key: "regex", Value: ep.TargetPort.String()},
+			})
+		} else if ep.TargetPort.IntVal != 0 {
+			relabelings = append(relabelings, yaml.MapSlice{
+				{Key: "action", Value: "keep"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_container_port_number"}},
+				{Key: "regex", Value: ep.TargetPort.String()},
+			})
+		}
 	}
 
 	// Relabel namespace and pod and service labels into proper labels.
@@ -470,7 +472,7 @@ func (cg *configGenerator) generateServiceMonitorConfig(version semver.Version, 
 			{Key: "target_label", Value: "endpoint"},
 			{Key: "replacement", Value: ep.Port},
 		})
-	} else if ep.TargetPort.String() != "" {
+	} else if ep.TargetPort != nil && ep.TargetPort.String() != "" {
 		relabelings = append(relabelings, yaml.MapSlice{
 			{Key: "target_label", Value: "endpoint"},
 			{Key: "replacement", Value: ep.TargetPort.String()},


### PR DESCRIPTION
This commit guards against a nil pointer dereference caused when an
Endpoint's port is 0 and the targetPort is nil.

Fixes: https://github.com/coreos/prometheus-operator/issues/2156

cc @brancz @metalmatze 