### PR TITLE
jsonnet/prometheus-operator: delete services 

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -61,11 +61,13 @@ rules:
   - ""
   resources:
   - services
+  - services/finalizers
   - endpoints
   verbs:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -75,11 +75,13 @@ rules:
   - ""
   resources:
   - services
+  - services/finalizers
   - endpoints
   verbs:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -57,11 +57,13 @@ rules:
   - ""
   resources:
   - services
+  - services/finalizers
   - endpoints
   verbs:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -44,11 +44,13 @@ rules:
   - ""
   resources:
   - services
+  - services/finalizers
   - endpoints
   verbs:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -83,9 +83,10 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                           policyRule.withApiGroups(['']) +
                           policyRule.withResources([
                             'services',
+                            'services/finalizers',
                             'endpoints',
                           ]) +
-                          policyRule.withVerbs(['get', 'create', 'update']);
+                          policyRule.withVerbs(['get', 'create', 'update', 'delete']);
 
       local nodeRule = policyRule.new() +
                        policyRule.withApiGroups(['']) +


### PR DESCRIPTION
This commit adds the delete verb to the services rule of the prometheus
operator role. It also gives the prometheus operator the power to get,
delete, create, and update the finalizers subresource of services.

fixes: https://github.com/coreos/prometheus-operator/issues/2279

cc @brancz @metalmatze 