### PR TITLE
Add README badge for Slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Prometheus Operator
 [![Build Status](https://travis-ci.org/coreos/prometheus-operator.svg?branch=master)](https://travis-ci.org/coreos/prometheus-operator)
 [![Go Report Card](https://goreportcard.com/badge/coreos/prometheus-operator "Go Report Card")](https://goreportcard.com/report/coreos/prometheus-operator)
+[![Slack](https://img.shields.io/badge/join%20slack-%23prometheus--operator-brightgreen.svg)](http://slack.k8s.io/)
 
 **Project status: *beta*** Not all planned features are completed. The API, spec, status and other user facing objects may change, but in a backward compatible way.
 


### PR DESCRIPTION
As we now have a dedicated channel on Kubernetes Slack, why not link to it from the README?