### PR TITLE
kube-prometheus: Remove enableAdminAPI configuration option

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -168,7 +168,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           replicas: $._config.prometheus.replicas,
           version: $._config.versions.prometheus,
           baseImage: $._config.imageRepos.prometheus,
-          enableAdminAPI: $._config.prometheus.enableAdminAPI,
           serviceAccountName: 'prometheus-' + $._config.prometheus.name,
           serviceMonitorSelector: {},
           serviceMonitorNamespaceSelector: {},


### PR DESCRIPTION
Manifest generation fails if this option is not set. Instead, remove the
option and require users to patch the object in case they need it.

See https://github.com/coreos/prometheus-operator/pull/2300#issuecomment-456113717 for more details.