### PR TITLE
test: Return pollError when waiting for Alertmanager mesh

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -150,7 +150,7 @@ func testAMStorageUpdate(t *testing.T) {
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.Core().Pods(ns).List(alertmanager.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(alertmanager.ListOptions(name))
 		if err != nil {
 			return false, err
 		}
@@ -580,7 +580,7 @@ inhibit_rules:
 			"app": "alertmanager-webhook",
 		})).String(),
 	}
-	pl, err := framework.KubeClient.Core().Pods(ns).List(opts)
+	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -84,7 +84,7 @@ func TestAllNS(t *testing.T) {
 		"k8s-app": "prometheus-operator",
 	})).String()}
 
-	pl, err := framework.KubeClient.Core().Pods(ns).List(opts)
+	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -164,7 +164,7 @@ func testPromResourceUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pods, err := framework.KubeClient.Core().Pods(ns).List(prometheus.ListOptions(name))
+	pods, err := framework.KubeClient.CoreV1().Pods(ns).List(prometheus.ListOptions(name))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +185,7 @@ func testPromResourceUpdate(t *testing.T) {
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.Core().Pods(ns).List(prometheus.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(prometheus.ListOptions(name))
 		if err != nil {
 			return false, err
 		}
@@ -245,7 +245,7 @@ func testPromStorageUpdate(t *testing.T) {
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.Core().Pods(ns).List(prometheus.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(prometheus.ListOptions(name))
 		if err != nil {
 			return false, err
 		}

--- a/test/framework/helpers.go
+++ b/test/framework/helpers.go
@@ -49,7 +49,7 @@ func PathToOSFile(relativPath string) (*os.File, error) {
 // container to pass its readiness check.
 func WaitForPodsReady(kubeClient kubernetes.Interface, namespace string, timeout time.Duration, expectedReplicas int, opts metav1.ListOptions) error {
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
-		pl, err := kubeClient.Core().Pods(namespace).List(opts)
+		pl, err := kubeClient.CoreV1().Pods(namespace).List(opts)
 		if err != nil {
 			return false, err
 		}
@@ -75,7 +75,7 @@ func WaitForPodsReady(kubeClient kubernetes.Interface, namespace string, timeout
 
 func WaitForPodsRunImage(kubeClient kubernetes.Interface, namespace string, expectedReplicas int, image string, opts metav1.ListOptions) error {
 	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
-		pl, err := kubeClient.Core().Pods(namespace).List(opts)
+		pl, err := kubeClient.CoreV1().Pods(namespace).List(opts)
 		if err != nil {
 			return false, err
 		}
@@ -123,7 +123,7 @@ func podRunsImage(p v1.Pod, image string) bool {
 }
 
 func GetLogs(kubeClient kubernetes.Interface, namespace string, podName, containerName string) (string, error) {
-	logs, err := kubeClient.Core().RESTClient().Get().
+	logs, err := kubeClient.CoreV1().RESTClient().Get().
 		Resource("pods").
 		Namespace(namespace).
 		Name(podName).SubResource("log").

--- a/test/framework/namespace.go
+++ b/test/framework/namespace.go
@@ -25,7 +25,7 @@ import (
 )
 
 func CreateNamespace(kubeClient kubernetes.Interface, name string) (*v1.Namespace, error) {
-	namespace, err := kubeClient.Core().Namespaces().Create(&v1.Namespace{
+	namespace, err := kubeClient.CoreV1().Namespaces().Create(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -52,7 +52,7 @@ func (ctx *TestCtx) CreateNamespace(t *testing.T, kubeClient kubernetes.Interfac
 }
 
 func DeleteNamespace(kubeClient kubernetes.Interface, name string) error {
-	return kubeClient.Core().Namespaces().Delete(name, nil)
+	return kubeClient.CoreV1().Namespaces().Delete(name, nil)
 }
 
 func AddLabelsToNamespace(kubeClient kubernetes.Interface, name string, additionalLabels map[string]string) error {


### PR DESCRIPTION
We want to know a bit more about the internal error that occurred while waiting for the Alertmanager mesh to get ready.

While working on this change, I also saw several calls to `Core()` which is deprecated and updated these.

/cc @mxinden 