### PR TITLE
extend configuration for Grafana config file

### DIFF
--- a/helm/grafana/templates/grafana-deployment.yaml
+++ b/helm/grafana/templates/grafana-deployment.yaml
@@ -114,12 +114,18 @@ spec:
         - name: grafana-dashboards
           configMap:
             name: {{ template "grafana.server.fullname" . }}
-      {{- if .Values.mountGrafanaConfig }}
+      {{- if .Values.mountGrafanaConfig.enabled }}
         - name: grafana-config
+      {{- if eq .Values.mountGrafanaConfig.type "hostpath" }}
           hostPath:
-            path: /etc/grafana
-            type: Directory
-      {{- end }}
+            {{ toYaml .Values.mountGrafanaConfig.hostPath | indent 2 }}
+      {{- else if eq .Values.mountGrafanaConfig.type "secret" }}
+          secret:
+            {{ toYaml .Values.mountGrafanaConfig.secretName | indent 2 }}
+      {{- else if eq .Values.mountGrafanaConfig.type "configmap" }}
+          configMap:
+            {{ toYaml .Values.mountGrafanaConfig.configmapName | indent 2 }}
+      {{ end }}
       {{- range .Values.serverDashboardConfigmaps }}
         - name: {{ . }}
           configMap:

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -38,8 +38,18 @@ global:
 extraVars:
 
 ## Change to true override Grafana's default config.
+## There are 3 possibilities for config type: hostpath, configmap or secret
 ## Make sure grafana.ini is present on /etc/grafana
-mountGrafanaConfig: false
+mountGrafanaConfig:
+  enabled: false
+  # type: hostpath
+
+  # hostPath:
+  #   path: /etc/grafana
+  #   type: Directory
+
+  # secretName: "configSecretName"
+  # configmapName: "configConfigmapName"
 
 adminUser: "admin"
 adminPassword: "admin"


### PR DESCRIPTION
I have found that current approach with `hostPath` as volume mount for grafana configuration file is not enough so I decided to extend it with more options like `secret` and `configmap`.
Please review my changes as I don't have any experience with writing helm's charts and go templating.