### PR TITLE
 contrib/kube-prometheus: remove node role

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -129,7 +129,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local coreRule = policyRule.new() +
                        policyRule.withApiGroups(['']) +
                        policyRule.withResources([
-                         'nodes',
                          'services',
                          'endpoints',
                          'pods',

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "9c0d2e34fa0a8bc22049e50bae46f4bb87ec2045"
+            "version": "d5f758dc5d07b214cd5cdf639847ab0197f42f76"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/prometheus-roleSpecificNamespaces.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-roleSpecificNamespaces.yaml
@@ -9,7 +9,6 @@ items:
   - apiGroups:
     - ""
     resources:
-    - nodes
     - services
     - endpoints
     - pods
@@ -26,7 +25,6 @@ items:
   - apiGroups:
     - ""
     resources:
-    - nodes
     - services
     - endpoints
     - pods
@@ -43,7 +41,6 @@ items:
   - apiGroups:
     - ""
     resources:
-    - nodes
     - services
     - endpoints
     - pods


### PR DESCRIPTION
This commit removes get/list/watch on nodes for the Prometheus-k8s
instance, as Prometheus pods do not need that privilege for anything.

cc @brancz @metalmatze @mxinden 