### PR TITLE
Aggregate prometheus-crd-view role to admin

### DIFF
--- a/Documentation/rbac-crd.md
+++ b/Documentation/rbac-crd.md
@@ -23,6 +23,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: prometheus-crd-view
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["monitoring.coreos.com"]

--- a/example/rbac/prometheus-operator-crd/prometheus-operator-crd-cluster-roles.yaml
+++ b/example/rbac/prometheus-operator-crd/prometheus-operator-crd-cluster-roles.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prometheus-crd-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups: ["monitoring.coreos.com"]
   resources: ["alertmanagers", "prometheuses", "prometheusrules", "servicemonitors"]

--- a/example/rbac/prometheus-operator-crd/prometheus-operator-crd-cluster-roles.yaml
+++ b/example/rbac/prometheus-operator-crd/prometheus-operator-crd-cluster-roles.yaml
@@ -3,8 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: prometheus-crd-view
   labels:
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["monitoring.coreos.com"]
   resources: ["alertmanagers", "prometheuses", "prometheusrules", "servicemonitors"]


### PR DESCRIPTION
In case the `view` is not aggregated to `admin`, you would need to grant a user both `admin` and `view` roles on the same namespace to be able to edit and get the resources respectively. This means that an `admin` on the namespace would be able to `create` the resource object, but not `get` it. 

This change aggregates the view to the admin role, so that the admin can now `get` on the resource as well.