### PR TITLE
kube-prometheus: Add ability to set nodeExporter tolerations

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -319,6 +319,7 @@ These are the available fields with their respective default values:
 
     nodeExporter+:: {
       port: 9100,
+      tolerations: [],
     },
 	},
 }

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -16,6 +16,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
     nodeExporter+:: {
       port: 9100,
+      tolerations: [],
     },
   },
 
@@ -125,6 +126,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         container.withEnv([ip]);
 
       local c = [nodeExporter, proxy];
+      local tolerations = [masterToleration] + $._config.nodeExporter.tolerations
 
       daemonset.new() +
       daemonset.mixin.metadata.withName('node-exporter') +
@@ -132,7 +134,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       daemonset.mixin.metadata.withLabels(podLabels) +
       daemonset.mixin.spec.selector.withMatchLabels(podLabels) +
       daemonset.mixin.spec.template.metadata.withLabels(podLabels) +
-      daemonset.mixin.spec.template.spec.withTolerations([masterToleration]) +
+      daemonset.mixin.spec.template.spec.withTolerations(tolerations) +
       daemonset.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/os': 'linux' }) +
       daemonset.mixin.spec.template.spec.withContainers(c) +
       daemonset.mixin.spec.template.spec.withVolumes([procVolume, sysVolume, rootVolume]) +


### PR DESCRIPTION
We've got some nodes with taints and want to run nodeExporter on all of them, so need the ability to add tolerations to the node exporter daemonset.

I'm an absolute ksonnet newbie, so apologies in advance if I'd done something silly.