### PR TITLE
kube-prometheus: ability to configure annotations on prometheus service

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -283,6 +283,9 @@ These are the available fields with their respective default values:
         names: 'k8s',
         replicas: 2,
         rules: {},
+        service: {
+          annotations: null,
+        },
     },
 
     alertmanager+:: {

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -22,6 +22,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       rules: {},
       renderedRules: {},
       namespaces: ['default', 'kube-system', $._config.namespace],
+      service: {
+        annotations: null,
+      },
     },
   },
 
@@ -40,7 +43,10 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       service.new('prometheus-' + $._config.prometheus.name, { app: 'prometheus', prometheus: $._config.prometheus.name }, prometheusPort) +
       service.mixin.spec.withSessionAffinity('ClientIP') +
       service.mixin.metadata.withNamespace($._config.namespace) +
-      service.mixin.metadata.withLabels({ prometheus: $._config.prometheus.name }),
+      service.mixin.metadata.withLabels({ prometheus: $._config.prometheus.name }) +
+      if $._config.prometheus.service.annotations != null 
+        then service.mixin.metadata.withAnnotations($._config.prometheus.service.annotations) 
+        else {},
     [if $._config.prometheus.rules != null && $._config.prometheus.rules != {} then 'rules']:
       {
         apiVersion: 'monitoring.coreos.com/v1',


### PR DESCRIPTION
We're configuring an ingress in GCP, and to do some advanced things we need to add annotations to the backing services.

I'm an absolute ksonnet newbie, so apologies in advance if I'd done something silly.