### PR TITLE
kube-prometheus - updated grafana release version

### DIFF
--- a/contrib/kube-prometheus/manifests/grafana-deployment.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: grafana/grafana:5.2.4
+      - image: grafana/grafana:5.4.3
         name: grafana
         ports:
         - containerPort: 3000


### PR DESCRIPTION
Updated the Grafana release to latest stable release (5.4.3)

The 5.4 release contains new features, enhancements and a lot of bugfixes. Like
enhanced Google stackdriver support and the MySQL query builder.