### PR TITLE
Bump config reloader resources

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -462,8 +462,8 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 						},
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("50m"),
-								v1.ResourceMemory: resource.MustParse("10Mi"),
+								v1.ResourceCPU:    resource.MustParse("100m"),
+								v1.ResourceMemory: resource.MustParse("15Mi"),
 							},
 						},
 					},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -617,8 +617,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 			VolumeMounts: []v1.VolumeMount{},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("25m"),
-					v1.ResourceMemory: resource.MustParse("10Mi"),
+					v1.ResourceCPU:    resource.MustParse("50m"),
+					v1.ResourceMemory: resource.MustParse("15Mi"),
 				},
 			},
 		}
@@ -856,7 +856,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 						VolumeMounts: configReloadVolumeMounts,
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("50m"),
+								v1.ResourceCPU:    resource.MustParse("100m"),
 								v1.ResourceMemory: resource.MustParse("50Mi"),
 							},
 						},


### PR DESCRIPTION
Hi, 
I still observe that alert manager trigger high CPU through for three configurator pods:
* `config-reloader` - alertmanager
* `prometheus-config-reloader` and `rules-configmap-reloader` - prometheus. 

Maybe instead bum those limits every time we can expose them as argument?
