### PR TITLE
contrib/kube-prometheus: simple typo fix in README.md

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -89,7 +89,7 @@ $ kubectl delete -f manifests/
 
 Prometheus, Grafana, and Alertmanager dashboards can be accessed quickly using `kubectl port-forward` after running the quickstart via the commands below. Kubernetes 1.10 or later is required.
 
-> Note: There are instructions on how to route to these pods behdind an ingress controller in the [Exposing Prometheus/Alermanager/Grafana via Ingress](#exposing-prometheusalermanagergrafana-via-ingress) section.
+> Note: There are instructions on how to route to these pods behind an ingress controller in the [Exposing Prometheus/Alermanager/Grafana via Ingress](#exposing-prometheusalermanagergrafana-via-ingress) section.
 
 Prometheus
 
@@ -374,7 +374,7 @@ If your kops cluster is using CoreDNS, there is an additional mixin to import.
 [embedmd]:# (examples/jsonnet-snippets/kops-coredns.jsonnet)
 ```jsonnet
 (import 'kube-prometheus/kube-prometheus.libsonnet') +
-(import 'kube-prometheus/kube-prometheus-kops.libsonnet') + 
+(import 'kube-prometheus/kube-prometheus-kops.libsonnet') +
 (import 'kube-prometheus/kube-prometheus-kops-coredns.libsonnet')
 ```
 


### PR DESCRIPTION
behdind -> behind