### PR TITLE
custom metrics API quick fix

### DIFF
--- a/contrib/kube-prometheus/experimental/custom-metrics-api/README.md
+++ b/contrib/kube-prometheus/experimental/custom-metrics-api/README.md
@@ -14,7 +14,7 @@ When you're done, you can teardown using the `./teardown.sh` script.
 
 Additionally, this directory contains a sample app that uses the [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to scale the Deployment's replicas of Pods up and down as needed.  
 Deploy this app by running `kubectl apply -f sample-app.yaml`. 
-Make the app accessible on your system, for example by using `kubectl -n monitoring port-forward svc/sample-app 8080`. Next you need to put some load on its http endpoints. 
+Make the app accessible on your system, for example by using `kubectl port-forward svc/sample-app 8080`. Next you need to put some load on its http endpoints. 
 
 A tool like [hey](https://github.com/rakyll/hey) is helpful for doing so: `hey -c 20 -n 100000000 http://localhost:8080/metrics`
 

--- a/contrib/kube-prometheus/experimental/custom-metrics-api/deploy.sh
+++ b/contrib/kube-prometheus/experimental/custom-metrics-api/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-kubectl apply -n monitoring custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
-kubectl apply -n monitoring custom-metrics-apiservice.yaml
-kubectl apply -n monitoring custom-metrics-cluster-role.yaml
-kubectl apply -n monitoring custom-metrics-configmap.yaml
-kubectl apply -n monitoring hpa-custom-metrics-cluster-role-binding.yaml
+kubectl apply -n monitoring -f custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
+kubectl apply -n monitoring -f custom-metrics-apiservice.yaml
+kubectl apply -n monitoring -f custom-metrics-cluster-role.yaml
+kubectl apply -n monitoring -f custom-metrics-configmap.yaml
+kubectl apply -n monitoring -f hpa-custom-metrics-cluster-role-binding.yaml

--- a/contrib/kube-prometheus/experimental/custom-metrics-api/teardown.sh
+++ b/contrib/kube-prometheus/experimental/custom-metrics-api/teardown.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-kubectl delete -n monitoring custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
-kubectl delete -n monitoring custom-metrics-apiservice.yaml
-kubectl delete -n monitoring custom-metrics-cluster-role.yaml
-kubectl delete -n monitoring custom-metrics-configmap.yaml
-kubectl delete -n monitoring hpa-custom-metrics-cluster-role-binding.yaml
+kubectl delete -n monitoring -f custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
+kubectl delete -n monitoring -f custom-metrics-apiservice.yaml
+kubectl delete -n monitoring -f custom-metrics-cluster-role.yaml
+kubectl delete -n monitoring -f custom-metrics-configmap.yaml
+kubectl delete -n monitoring -f hpa-custom-metrics-cluster-role-binding.yaml


### PR DESCRIPTION
- Adding -f flag at the deploy.sh script to fit with new kubectl versions
- removing namespace flag when port-forwarding the sample-app service