### PR TITLE
Reduce metrics

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -463,6 +463,14 @@ spec:
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__
+    - action: drop
+      regex: apiserver_admission_controller_admission_latencies_seconds_.*
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: apiserver_admission_step_admission_latencies_seconds_.*
+      sourceLabels:
+      - __name__
     port: https
     scheme: https
     tlsConfig:
@@ -499,6 +507,16 @@ spec:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     honorLabels: true
     interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: container_([a-z_]+);
+      sourceLabels:
+      - __name__
+      - image
+    - action: drop
+      regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+      sourceLabels:
+      - __name__
     path: /metrics/cadvisor
     port: https-metrics
     scheme: https

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -282,6 +282,22 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                 insecureSkipVerify: true,
               },
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+              metricRelabelings: [
+                // Drop container_* metrics with no image.
+                {
+                  sourceLabels: ['__name__', 'image'],
+                  regex: 'container_([a-z_]+);',
+                  action: 'drop',
+                },
+
+                // Drop a bunch of metrics which are disabled but still sent, see
+                // https://github.com/google/cadvisor/issues/1925.
+                {
+                  sourceLabels: ['__name__'],
+                  regex: 'container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)',
+                  action: 'drop',
+                },
+              ],
             },
           ],
           selector: {
@@ -372,6 +388,16 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
                 {
                   sourceLabels: ['__name__'],
                   regex: 'etcd_(debugging|disk|request|server).*',
+                  action: 'drop',
+                },
+                {
+                  sourceLabels: ['__name__'],
+                  regex: 'apiserver_admission_controller_admission_latencies_seconds_.*',
+                  action: 'drop',
+                },
+                {
+                  sourceLabels: ['__name__'],
+                  regex: 'apiserver_admission_step_admission_latencies_seconds_.*',
                   action: 'drop',
                 },
               ],

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "6963b7410f28575a90a65c0aee1c79c8ef392fbb"
+            "version": "986d387aaa6c292c248fc9d31c8b564462bd619e"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": ""
                 }
             },
-            "version": "668950e4af13f0153fa1d7b58ebe7023b33f2217"
+            "version": "ae5d0b27229765fc0670c48c09a95cb6da732de3"
         },
         {
             "name": "grafonnet",

--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -241,25 +241,25 @@ spec:
         max by (namespace, pod, device) (node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
       record: 'node:node_filesystem_avail:'
     - expr: |
-        sum(irate(node_network_receive_bytes_total{job="node-exporter",device="eth0"}[1m])) +
-        sum(irate(node_network_transmit_bytes_total{job="node-exporter",device="eth0"}[1m]))
+        sum(irate(node_network_receive_bytes_total{job="node-exporter",device!~"veth.+"}[1m])) +
+        sum(irate(node_network_transmit_bytes_total{job="node-exporter",device!~"veth.+"}[1m]))
       record: :node_net_utilisation:sum_irate
     - expr: |
         sum by (node) (
-          (irate(node_network_receive_bytes_total{job="node-exporter",device="eth0"}[1m]) +
-          irate(node_network_transmit_bytes_total{job="node-exporter",device="eth0"}[1m]))
+          (irate(node_network_receive_bytes_total{job="node-exporter",device!~"veth.+"}[1m]) +
+          irate(node_network_transmit_bytes_total{job="node-exporter",device!~"veth.+"}[1m]))
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )
       record: node:node_net_utilisation:sum_irate
     - expr: |
-        sum(irate(node_network_receive_drop_total{job="node-exporter",device="eth0"}[1m])) +
-        sum(irate(node_network_transmit_drop_total{job="node-exporter",device="eth0"}[1m]))
+        sum(irate(node_network_receive_drop_total{job="node-exporter",device!~"veth.+"}[1m])) +
+        sum(irate(node_network_transmit_drop_total{job="node-exporter",device!~"veth.+"}[1m]))
       record: :node_net_saturation:sum_irate
     - expr: |
         sum by (node) (
-          (irate(node_network_receive_drop_total{job="node-exporter",device="eth0"}[1m]) +
-          irate(node_network_transmit_drop_total{job="node-exporter",device="eth0"}[1m]))
+          (irate(node_network_receive_drop_total{job="node-exporter",device!~"veth.+"}[1m]) +
+          irate(node_network_transmit_drop_total{job="node-exporter",device!~"veth.+"}[1m]))
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )

--- a/contrib/kube-prometheus/manifests/prometheus-serviceMonitorApiserver.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-serviceMonitorApiserver.yaml
@@ -14,6 +14,14 @@ spec:
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__
+    - action: drop
+      regex: apiserver_admission_controller_admission_latencies_seconds_.*
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: apiserver_admission_step_admission_latencies_seconds_.*
+      sourceLabels:
+      - __name__
     port: https
     scheme: https
     tlsConfig:

--- a/contrib/kube-prometheus/manifests/prometheus-serviceMonitorKubelet.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-serviceMonitorKubelet.yaml
@@ -17,6 +17,16 @@ spec:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     honorLabels: true
     interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: container_([a-z_]+);
+      sourceLabels:
+      - __name__
+      - image
+    - action: drop
+      regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+      sourceLabels:
+      - __name__
     path: /metrics/cadvisor
     port: https-metrics
     scheme: https


### PR DESCRIPTION
As described in https://github.com/google/cadvisor/issues/1925, the container network metrics are disabled and therefore cause more confusion than gain as they are always set to 0. This PR removes those at ingestion time, and also drops unnecessary high cardinality metrics from the Kubernetes API.

@metalmatze @mxinden @squat @s-urbaniak 