### PR TITLE
docs: add prometheusrules CRD to cleanup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ done
 kubectl delete --ignore-not-found customresourcedefinitions \
   prometheuses.monitoring.coreos.com \
   servicemonitors.monitoring.coreos.com \
-  alertmanagers.monitoring.coreos.com
+  alertmanagers.monitoring.coreos.com \
+  prometheusrules.monitoring.coreos.com
 ```
 
 ## Development


### PR DESCRIPTION
Unable to redeploy a clean version without this fix as `prometheusrules.monitoring.coreos.com` still exists.