### PR TITLE
 test/framework: Improve WaitForAlertmanagerInitializedMesh debugging

### DIFF
--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -195,11 +195,24 @@ func (f *Framework) WaitForAlertmanagerInitializedMesh(ns, name string, amountPe
 		if err != nil {
 			return false, err
 		}
-		if amStatus.Data.getAmountPeers() == amountPeers {
+
+		if len(amStatus.Data.MeshStatus.Peers) == amountPeers {
 			return true, nil
 		}
 
-		pollError = fmt.Errorf("failed to get correct amount of peers, expected %d, got %d", amountPeers, amStatus.Data.getAmountPeers())
+		var addresses []string
+		if amStatus.Data.MeshStatus != nil {
+			for _, p := range amStatus.Data.MeshStatus.Peers {
+				addresses = append(addresses, p.Address)
+			}
+		}
+
+		pollError = fmt.Errorf(
+			"failed to get correct amount of peers, expected %d, got %d, addresses %v",
+			amountPeers,
+			amStatus.Data.getAmountPeers(),
+			strings.Join(addresses, ","),
+		)
 
 		return false, nil
 	})
@@ -392,6 +405,11 @@ func (s *amAPIStatusData) getAmountPeers() int {
 	return len(s.ClusterStatus.Peers)
 }
 
+type peer struct {
+	Name    string `json:"name"`
+	Address string `json:"address"`
+}
+
 type clusterStatus struct {
-	Peers []interface{} `json:"peers"`
+	Peers []peer `json:"peers"`
 }

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -196,6 +196,10 @@ func (f *Framework) WaitForAlertmanagerInitializedMesh(ns, name string, amountPe
 			return false, err
 		}
 
+		if amStatus.Data.MeshStatus == nil {
+			return false, fmt.Errorf("do not have a mesh status")
+		}
+
 		if len(amStatus.Data.MeshStatus.Peers) == amountPeers {
 			return true, nil
 		}


### PR DESCRIPTION
For debugging flakes on Travis we want to print the addresses of mesh peers on error:

Example flake:
https://travis-ci.org/coreos/prometheus-operator/jobs/484394692#L1121-L1124

Replacing https://github.com/coreos/prometheus-operator/pull/2341