### PR TITLE
fix: config reloader memory and cpu as params

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -123,6 +123,8 @@ func init() {
 	// specified.
 	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", fmt.Sprintf("quay.io/coreos/prometheus-config-reloader:v%v", version.Version), "Prometheus config reloader image")
 	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "quay.io/coreos/configmap-reload:v0.0.1", "Reload Image")
+	flagset.StringVar(&cfg.ConfigReloaderCPU, "config-reloader-cpu", "100m", "Config Reloader CPU")
+	flagset.StringVar(&cfg.ConfigReloaderMemory, "config-reloader-memory", "15Mi", "Config Reloader Memory")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", "quay.io/prometheus/alertmanager", "Alertmanager default base image")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", "quay.io/prometheus/prometheus", "Prometheus default base image")
 	flagset.StringVar(&cfg.ThanosDefaultBaseImage, "thanos-default-base-image", "improbable/thanos", "Thanos default base image")

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -116,6 +116,8 @@ func New(c prometheusoperator.Config, logger log.Logger) (*Operator, error) {
 			Host:                         c.Host,
 			LocalHost:                    c.LocalHost,
 			ConfigReloaderImage:          c.ConfigReloaderImage,
+			ConfigReloaderCPU:            c.ConfigReloaderCPU,
+			ConfigReloaderMemory:         c.ConfigReloaderMemory,
 			AlertmanagerDefaultBaseImage: c.AlertmanagerDefaultBaseImage,
 			Namespaces:                   c.Namespaces,
 			CrdGroup:                     c.CrdGroup,

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -73,6 +73,8 @@ type Config struct {
 	Host                         string
 	LocalHost                    string
 	ConfigReloaderImage          string
+	ConfigReloaderCPU            string
+	ConfigReloaderMemory         string
 	AlertmanagerDefaultBaseImage string
 	Namespaces                   []string
 	Labels                       prometheusoperator.Labels

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -462,8 +462,8 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 						},
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("50m"),
-								v1.ResourceMemory: resource.MustParse("10Mi"),
+								v1.ResourceCPU:    resource.MustParse(config.ConfigReloaderCPU),
+								v1.ResourceMemory: resource.MustParse(config.ConfigReloaderMemory),
 							},
 						},
 					},

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -29,6 +29,8 @@ import (
 var (
 	defaultTestConfig = Config{
 		ConfigReloaderImage:          "quay.io/coreos/configmap-reload:latest",
+		ConfigReloaderCPU:            "100m",
+		ConfigReloaderMemory:         "15Mi",
 		AlertmanagerDefaultBaseImage: "quay.io/prometheus/alertmanager",
 	}
 )
@@ -230,7 +232,7 @@ func TestMakeStatefulSetSpecSingleDoubleDashedArgs(t *testing.T) {
 		replicas := int32(3)
 		a.Spec.Replicas = &replicas
 
-		statefulSet, err := makeStatefulSetSpec(&a, Config{})
+		statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -261,7 +263,7 @@ func TestMakeStatefulSetSpecWebRoutePrefix(t *testing.T) {
 		replicas := int32(1)
 		a.Spec.Replicas = &replicas
 
-		statefulSet, err := makeStatefulSetSpec(&a, Config{})
+		statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -299,7 +301,7 @@ func TestMakeStatefulSetSpecMeshClusterFlags(t *testing.T) {
 		replicas := int32(3)
 		a.Spec.Replicas = &replicas
 
-		statefulSet, err := makeStatefulSetSpec(&a, Config{})
+		statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -335,7 +337,7 @@ func TestMakeStatefulSetSpecPeerFlagPort(t *testing.T) {
 		replicas := int32(3)
 		a.Spec.Replicas = &replicas
 
-		statefulSet, err := makeStatefulSetSpec(&a, Config{})
+		statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -359,7 +361,7 @@ func TestMakeStatefulSetSpecAdditionalPeers(t *testing.T) {
 	a.Spec.Replicas = &replicas
 	a.Spec.AdditionalPeers = []string{"example.com"}
 
-	statefulSet, err := makeStatefulSetSpec(&a, Config{})
+	statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -136,6 +136,8 @@ type Config struct {
 	TLSInsecure                  bool
 	TLSConfig                    rest.TLSClientConfig
 	ConfigReloaderImage          string
+	ConfigReloaderCPU            string
+	ConfigReloaderMemory         string
 	PrometheusConfigReloader     string
 	AlertmanagerDefaultBaseImage string
 	PrometheusDefaultBaseImage   string

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -621,8 +621,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 			VolumeMounts: []v1.VolumeMount{},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("25m"),
-					v1.ResourceMemory: resource.MustParse("10Mi"),
+					v1.ResourceCPU:    resource.MustParse(c.ConfigReloaderCPU),
+					v1.ResourceMemory: resource.MustParse(c.ConfigReloaderMemory),
 				},
 			},
 		}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -32,6 +32,8 @@ import (
 var (
 	defaultTestConfig = &Config{
 		ConfigReloaderImage:        "quay.io/coreos/configmap-reload:latest",
+		ConfigReloaderCPU:          "100m",
+		ConfigReloaderMemory:       "15Mi",
 		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "improbable/thanos",
 	}


### PR DESCRIPTION
Fix: https://github.com/coreos/prometheus-operator/issues/2364

Following the conversation in https://github.com/coreos/prometheus-operator/pull/2371