### PR TITLE
relaxing the memory constraints to initialise config reloaders

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -463,7 +463,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
 								v1.ResourceCPU:    resource.MustParse("50m"),
-								v1.ResourceMemory: resource.MustParse("10Mi"),
+								v1.ResourceMemory: resource.MustParse("20Mi"),
 							},
 						},
 					},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -622,7 +622,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("25m"),
-					v1.ResourceMemory: resource.MustParse("10Mi"),
+					v1.ResourceMemory: resource.MustParse("20Mi"),
 				},
 			},
 		}


### PR DESCRIPTION
This MR aims to fix an error making both prometheus and alertmanager statefulsets to hang into a RunContainerError forever as the config reloader container cannot boot.

The error for alertmanager is:
```
Warning  Failed                 2m (x3 over 2m)  kubelet, ip-10-247-1-189.eu-west-1.compute.internal  Error: failed to start container "config-reloader": Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:402: container init caused \"process_linux.go:367: setting cgroup config for procHooks process caused \\\"failed to write 10485760 to memory.limit_in_bytes: write /sys/fs/cgroup/memory/kubepods/burstable/pod4f044360-3126-11e9-8213-0a5f22fbb2d4/config-reloader/memory.limit_in_bytes: device or resource busy\\\"\"": unknown
```
The pod looks like this:
```
$ kubectl get po -l app=alertmanager
alertmanager-prometheus-operator-alertmanager-0                   1/2       CrashLoopBackOff   7          12m
```

The error for prometheus is:
```
Warning  Failed                 12s (x2 over 16s)  kubelet, ip-10-247-3-156.eu-west-1.compute.internal  Error: failed to start container "rules-configmap-reloader": Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:402: container init caused \"process_linux.go:367: setting cgroup config for procHooks process caused \\\"failed to write 10485760 to memory.limit_in_bytes: write /sys/fs/cgroup/memory/kubepods/burstable/pod49b440d6-3122-11e9-8213-0a5f22fbb2d4/rules-configmap-reloader/memory.limit_in_bytes: device or resource busy\\\"\"": unknown
```

The pod looks like this:
```
$ kubectl get po -l app=prometheus
prometheus-prometheus-operator-prometheus-0   2/3       CrashLoopBackOff   12          23m
```