### PR TITLE
Increase memory to 25Mi for reloader

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -124,7 +124,7 @@ func init() {
 	flagset.StringVar(&cfg.PrometheusConfigReloader, "prometheus-config-reloader", fmt.Sprintf("quay.io/coreos/prometheus-config-reloader:v%v", version.Version), "Prometheus config reloader image")
 	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "quay.io/coreos/configmap-reload:v0.0.1", "Reload Image")
 	flagset.StringVar(&cfg.ConfigReloaderCPU, "config-reloader-cpu", "100m", "Config Reloader CPU")
-	flagset.StringVar(&cfg.ConfigReloaderMemory, "config-reloader-memory", "15Mi", "Config Reloader Memory")
+	flagset.StringVar(&cfg.ConfigReloaderMemory, "config-reloader-memory", "25Mi", "Config Reloader Memory")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", "quay.io/prometheus/alertmanager", "Alertmanager default base image")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", "quay.io/prometheus/prometheus", "Prometheus default base image")
 	flagset.StringVar(&cfg.ThanosDefaultBaseImage, "thanos-default-base-image", "improbable/thanos", "Thanos default base image")

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -30,7 +30,7 @@ var (
 	defaultTestConfig = Config{
 		ConfigReloaderImage:          "quay.io/coreos/configmap-reload:latest",
 		ConfigReloaderCPU:            "100m",
-		ConfigReloaderMemory:         "15Mi",
+		ConfigReloaderMemory:         "25Mi",
 		AlertmanagerDefaultBaseImage: "quay.io/prometheus/alertmanager",
 	}
 )

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -33,7 +33,7 @@ var (
 	defaultTestConfig = &Config{
 		ConfigReloaderImage:        "quay.io/coreos/configmap-reload:latest",
 		ConfigReloaderCPU:          "100m",
-		ConfigReloaderMemory:       "15Mi",
+		ConfigReloaderMemory:       "25Mi",
 		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "improbable/thanos",
 	}


### PR DESCRIPTION
Running in a test cluster with docker 1.09.2 shows max memory to be about 17Mi, and the container starts ok with a limit of 20Mi. But increase this to 25Mi to be sure

fixes: #2409