### PR TITLE
Upgrade prometheus-adapter APIService to v1

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -50,7 +50,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
   prometheusAdapter+:: {
     apiService:
       {
-        apiVersion: 'apiregistration.k8s.io/v1beta1',
+        apiVersion: 'apiregistration.k8s.io/v1',
         kind: 'APIService',
         metadata: {
           name: 'v1beta1.metrics.k8s.io',
@@ -147,7 +147,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
       clusterRoleBinding.new() +
       clusterRoleBinding.mixin.metadata.withName($._config.prometheusAdapter.name) +
-      clusterRoleBinding.mixin.metadata.withNamespace($._config.namespace) +
       clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
       clusterRoleBinding.mixin.roleRef.withName($.prometheusAdapter.clusterRole.metadata.name) +
       clusterRoleBinding.mixin.roleRef.mixinInstance({ kind: 'ClusterRole' }) +

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "94b30526f43d589912a38193b69dce19b4fa1893"
+            "version": "a4cd74c5906273ea2c38a2b728641cdef017c76c"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": ""
                 }
             },
-            "version": "5525c8cc8a4a52d272bdaf481dd77b53a0c0f051"
+            "version": "ccb787a44f2ebdecbb346d57490fa7e49981b323"
         },
         {
             "name": "grafonnet",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "403b7d0120d2903d21854eae217b4e4863c454d1"
+            "version": "bbf03a7971ebac7011ef9320fcc23cc01e0a54d3"
         },
         {
             "name": "grafana",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "4cd0bf8ea846a0d158761d55899f631eb2a423cf"
+            "version": "8c228d692bfa516e1c0977922f061b9a0fb1ae0f"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
@@ -2831,7 +2831,7 @@ items:
                           },
                           "yaxes": [
                               {
-                                  "format": "decbytes",
+                                  "format": "bytes",
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
@@ -2919,7 +2919,7 @@ items:
 
                                   ],
                                   "type": "number",
-                                  "unit": "decbytes"
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Memory Requests",
@@ -2937,7 +2937,7 @@ items:
 
                                   ],
                                   "type": "number",
-                                  "unit": "decbytes"
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Memory Requests %",
@@ -2973,7 +2973,7 @@ items:
 
                                   ],
                                   "type": "number",
-                                  "unit": "decbytes"
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Memory Limits %",
@@ -3625,7 +3625,7 @@ items:
                           ],
                           "timeFrom": null,
                           "timeShift": null,
-                          "title": "Memory Usage",
+                          "title": "Memory Usage (w/o cache)",
                           "tooltip": {
                               "shared": true,
                               "sort": 0,
@@ -3643,7 +3643,7 @@ items:
                           },
                           "yaxes": [
                               {
-                                  "format": "decbytes",
+                                  "format": "bytes",
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
@@ -3731,7 +3731,7 @@ items:
 
                                   ],
                                   "type": "number",
-                                  "unit": "decbytes"
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Memory Requests",
@@ -3749,7 +3749,7 @@ items:
 
                                   ],
                                   "type": "number",
-                                  "unit": "decbytes"
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Memory Requests %",
@@ -3785,7 +3785,7 @@ items:
 
                                   ],
                                   "type": "number",
-                                  "unit": "decbytes"
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Memory Limits %",
@@ -3804,6 +3804,60 @@ items:
                                   ],
                                   "type": "number",
                                   "unit": "percentunit"
+                              },
+                              {
+                                  "alias": "Memory Usage (RSS)",
+                                  "colorMode": null,
+                                  "colors": [
+
+                                  ],
+                                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                  "decimals": 2,
+                                  "link": false,
+                                  "linkTooltip": "Drill down",
+                                  "linkUrl": "",
+                                  "pattern": "Value #F",
+                                  "thresholds": [
+
+                                  ],
+                                  "type": "number",
+                                  "unit": "bytes"
+                              },
+                              {
+                                  "alias": "Memory Usage (Cache)",
+                                  "colorMode": null,
+                                  "colors": [
+
+                                  ],
+                                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                  "decimals": 2,
+                                  "link": false,
+                                  "linkTooltip": "Drill down",
+                                  "linkUrl": "",
+                                  "pattern": "Value #G",
+                                  "thresholds": [
+
+                                  ],
+                                  "type": "number",
+                                  "unit": "bytes"
+                              },
+                              {
+                                  "alias": "Memory Usage (Swap",
+                                  "colorMode": null,
+                                  "colors": [
+
+                                  ],
+                                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                  "decimals": 2,
+                                  "link": false,
+                                  "linkTooltip": "Drill down",
+                                  "linkUrl": "",
+                                  "pattern": "Value #H",
+                                  "thresholds": [
+
+                                  ],
+                                  "type": "number",
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Pod",
@@ -3883,6 +3937,33 @@ items:
                                   "intervalFactor": 2,
                                   "legendFormat": "",
                                   "refId": "E",
+                                  "step": 10
+                              },
+                              {
+                                  "expr": "sum(label_replace(container_memory_rss{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+                                  "format": "table",
+                                  "instant": true,
+                                  "intervalFactor": 2,
+                                  "legendFormat": "",
+                                  "refId": "F",
+                                  "step": 10
+                              },
+                              {
+                                  "expr": "sum(label_replace(container_memory_cache{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+                                  "format": "table",
+                                  "instant": true,
+                                  "intervalFactor": 2,
+                                  "legendFormat": "",
+                                  "refId": "G",
+                                  "step": 10
+                              },
+                              {
+                                  "expr": "sum(label_replace(container_memory_swap{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+                                  "format": "table",
+                                  "instant": true,
+                                  "intervalFactor": 2,
+                                  "legendFormat": "",
+                                  "refId": "H",
                                   "step": 10
                               }
                           ],
@@ -4451,10 +4532,26 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
+                                  "expr": "sum(container_memory_rss{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": "{{container_name}}",
+                                  "legendFormat": "{{container_name}} (RSS)",
+                                  "legendLink": null,
+                                  "step": 10
+                              },
+                              {
+                                  "expr": "sum(container_memory_cache{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
+                                  "format": "time_series",
+                                  "intervalFactor": 2,
+                                  "legendFormat": "{{container_name}} (Cache)",
+                                  "legendLink": null,
+                                  "step": 10
+                              },
+                              {
+                                  "expr": "sum(container_memory_swap{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
+                                  "format": "time_series",
+                                  "intervalFactor": 2,
+                                  "legendFormat": "{{container_name}} (Swap)",
                                   "legendLink": null,
                                   "step": 10
                               }
@@ -4482,7 +4579,7 @@ items:
                           },
                           "yaxes": [
                               {
-                                  "format": "short",
+                                  "format": "bytes",
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
@@ -4570,7 +4667,7 @@ items:
 
                                   ],
                                   "type": "number",
-                                  "unit": "decbytes"
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Memory Requests",
@@ -4588,7 +4685,7 @@ items:
 
                                   ],
                                   "type": "number",
-                                  "unit": "decbytes"
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Memory Requests %",
@@ -4624,7 +4721,7 @@ items:
 
                                   ],
                                   "type": "number",
-                                  "unit": "decbytes"
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Memory Limits %",
@@ -4643,6 +4740,60 @@ items:
                                   ],
                                   "type": "number",
                                   "unit": "percentunit"
+                              },
+                              {
+                                  "alias": "Memory Usage (RSS)",
+                                  "colorMode": null,
+                                  "colors": [
+
+                                  ],
+                                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                  "decimals": 2,
+                                  "link": false,
+                                  "linkTooltip": "Drill down",
+                                  "linkUrl": "",
+                                  "pattern": "Value #F",
+                                  "thresholds": [
+
+                                  ],
+                                  "type": "number",
+                                  "unit": "bytes"
+                              },
+                              {
+                                  "alias": "Memory Usage (Cache)",
+                                  "colorMode": null,
+                                  "colors": [
+
+                                  ],
+                                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                  "decimals": 2,
+                                  "link": false,
+                                  "linkTooltip": "Drill down",
+                                  "linkUrl": "",
+                                  "pattern": "Value #G",
+                                  "thresholds": [
+
+                                  ],
+                                  "type": "number",
+                                  "unit": "bytes"
+                              },
+                              {
+                                  "alias": "Memory Usage (Swap",
+                                  "colorMode": null,
+                                  "colors": [
+
+                                  ],
+                                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                  "decimals": 2,
+                                  "link": false,
+                                  "linkTooltip": "Drill down",
+                                  "linkUrl": "",
+                                  "pattern": "Value #H",
+                                  "thresholds": [
+
+                                  ],
+                                  "type": "number",
+                                  "unit": "bytes"
                               },
                               {
                                   "alias": "Container",
@@ -4722,6 +4873,33 @@ items:
                                   "intervalFactor": 2,
                                   "legendFormat": "",
                                   "refId": "E",
+                                  "step": 10
+                              },
+                              {
+                                  "expr": "sum(label_replace(container_memory_rss{namespace=\"$namespace\", pod_name=\"$pod\", container_name != \"\", container_name != \"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+                                  "format": "table",
+                                  "instant": true,
+                                  "intervalFactor": 2,
+                                  "legendFormat": "",
+                                  "refId": "F",
+                                  "step": 10
+                              },
+                              {
+                                  "expr": "sum(label_replace(container_memory_cache{namespace=\"$namespace\", pod_name=\"$pod\", container_name != \"\", container_name != \"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+                                  "format": "table",
+                                  "instant": true,
+                                  "intervalFactor": 2,
+                                  "legendFormat": "",
+                                  "refId": "G",
+                                  "step": 10
+                              },
+                              {
+                                  "expr": "sum(label_replace(container_memory_swap{namespace=\"$namespace\", pod_name=\"$pod\", container_name != \"\", container_name != \"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+                                  "format": "table",
+                                  "instant": true,
+                                  "intervalFactor": 2,
+                                  "legendFormat": "",
+                                  "refId": "H",
                                   "step": 10
                               }
                           ],

--- a/contrib/kube-prometheus/manifests/prometheus-adapter-apiService.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-adapter-apiService.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io

--- a/contrib/kube-prometheus/manifests/prometheus-adapter-clusterRoleBinding.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-adapter-clusterRoleBinding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-adapter
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
`APIRegistration` went v1 in Kubernetes v1.10. Upgrading seems safe.

Also:

- remove unnecessary namespace from prometheus-adapter ClusterRoleBinding
- update Grafana dashboardDefinitions (side effect of `jb update`)

Signed-off-by: Michael Goodness <mike.goodness@ticketmaster.com>