### PR TITLE
Operator labels

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -18,6 +18,10 @@ Here is a ready to use manifest of a `ClusterRole` that can be used to start the
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
 rules:
 - apiGroups:
@@ -148,6 +152,10 @@ Say the Prometheus Operator shall be deployed in the `default` namespace. First 
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
   namespace: default
 ```
@@ -161,6 +169,10 @@ And then a `ClusterRoleBinding`:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -19,6 +19,10 @@ To follow this getting started you will need a Kubernetes cluster you have acces
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -32,6 +36,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
 rules:
 - apiGroups:
@@ -102,18 +110,24 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    k8s-app: prometheus-operator
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: prometheus-operator
+      apps.kubernetes.io/component: controller
+      apps.kubernetes.io/name: prometheus-operator
+      apps.kubernetes.io/version: v0.29.0
   template:
     metadata:
       labels:
-        k8s-app: prometheus-operator
+        apps.kubernetes.io/component: controller
+        apps.kubernetes.io/name: prometheus-operator
+        apps.kubernetes.io/version: v0.29.0
     spec:
       containers:
       - args:
@@ -146,6 +160,10 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
   namespace: default
 ```

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,6 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14,6 +18,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
 rules:
 - apiGroups:
@@ -84,18 +92,24 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    k8s-app: prometheus-operator
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: prometheus-operator
+      apps.kubernetes.io/component: controller
+      apps.kubernetes.io/name: prometheus-operator
+      apps.kubernetes.io/version: v0.29.0
   template:
     metadata:
       labels:
-        k8s-app: prometheus-operator
+        apps.kubernetes.io/component: controller
+        apps.kubernetes.io/name: prometheus-operator
+        apps.kubernetes.io/version: v0.29.0
     spec:
       containers:
       - args:
@@ -128,5 +142,9 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
   namespace: default

--- a/example/non-rbac/prometheus-operator.yaml
+++ b/example/non-rbac/prometheus-operator.yaml
@@ -2,18 +2,24 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    k8s-app: prometheus-operator
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: prometheus-operator
+      apps.kubernetes.io/component: controller
+      apps.kubernetes.io/name: prometheus-operator
+      apps.kubernetes.io/version: v0.29.0
   template:
     metadata:
       labels:
-        k8s-app: prometheus-operator
+        apps.kubernetes.io/component: controller
+        apps.kubernetes.io/name: prometheus-operator
+        apps.kubernetes.io/version: v0.29.0
     spec:
       containers:
       - args:

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
@@ -1,6 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -1,6 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
 rules:
 - apiGroups:

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -2,18 +2,24 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    k8s-app: prometheus-operator
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: prometheus-operator
+      apps.kubernetes.io/component: controller
+      apps.kubernetes.io/name: prometheus-operator
+      apps.kubernetes.io/version: v0.29.0
   template:
     metadata:
       labels:
-        k8s-app: prometheus-operator
+        apps.kubernetes.io/component: controller
+        apps.kubernetes.io/name: prometheus-operator
+        apps.kubernetes.io/version: v0.29.0
     spec:
       containers:
       - args:

--- a/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml
@@ -1,5 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
   namespace: default

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -5,7 +5,11 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
     namespace: 'default',
 
     prometheusOperator+:: {
-      labels: { 'apps.kubernetes.io/name': 'prometheus-operator' },
+      labels: {
+        'apps.kubernetes.io/name': 'prometheus-operator',
+        'apps.kubernetes.io/component': 'controller',
+        'apps.kubernetes.io/version': $._config.versions.prometheusOperator,
+      },
     },
 
     versions+:: {

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -2,8 +2,11 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
 {
   _config+:: {
-    labels: { 'apps.kubernetes.io/name': 'prometheus-operator' },
     namespace: 'default',
+
+    prometheusOperator+:: {
+      labels: { 'apps.kubernetes.io/name': 'prometheus-operator' },
+    },
 
     versions+:: {
       prometheusOperator: 'v0.29.0',
@@ -29,7 +32,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local clusterRoleBinding = k.rbac.v1.clusterRoleBinding;
 
       clusterRoleBinding.new() +
-      clusterRoleBinding.mixin.metadata.withLabels($._config.labels) +
+      clusterRoleBinding.mixin.metadata.withLabels($._config.prometheusOperator.labels) +
       clusterRoleBinding.mixin.metadata.withName('prometheus-operator') +
       clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
       clusterRoleBinding.mixin.roleRef.withName('prometheus-operator') +
@@ -107,7 +110,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local rules = [apiExtensionsRule, monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule];
 
       clusterRole.new() +
-      clusterRole.mixin.metadata.withLabels($._config.labels) +
+      clusterRole.mixin.metadata.withLabels($._config.prometheusOperator.labels) +
       clusterRole.mixin.metadata.withName('prometheus-operator') +
       clusterRole.withRules(rules),
 
@@ -134,10 +137,10 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         container.mixin.resources.withRequests({ cpu: '100m', memory: '100Mi' }) +
         container.mixin.resources.withLimits({ cpu: '200m', memory: '200Mi' });
 
-      deployment.new('prometheus-operator', 1, operatorContainer, $._config.labels) +
+      deployment.new('prometheus-operator', 1, operatorContainer, $._config.prometheusOperator.labels) +
       deployment.mixin.metadata.withNamespace($._config.namespace) +
-      deployment.mixin.metadata.withLabels($._config.labels) +
-      deployment.mixin.spec.selector.withMatchLabels($._config.labels) +
+      deployment.mixin.metadata.withLabels($._config.prometheusOperator.labels) +
+      deployment.mixin.spec.selector.withMatchLabels($._config.prometheusOperator.labels) +
       deployment.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/os': 'linux' }) +
       deployment.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
       deployment.mixin.spec.template.spec.securityContext.withRunAsUser(65534) +
@@ -147,7 +150,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local serviceAccount = k.core.v1.serviceAccount;
 
       serviceAccount.new('prometheus-operator') +
-      serviceAccount.mixin.metadata.withLabels($._config.labels) +
+      serviceAccount.mixin.metadata.withLabels($._config.prometheusOperator.labels) +
       serviceAccount.mixin.metadata.withNamespace($._config.namespace),
 
     service:
@@ -157,7 +160,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local poServicePort = servicePort.newNamed('http', 8080, 'http');
 
       service.new('prometheus-operator', $.prometheusOperator.deployment.spec.selector.matchLabels, [poServicePort]) +
-      service.mixin.metadata.withLabels($._config.labels) +
+      service.mixin.metadata.withLabels($._config.prometheusOperator.labels) +
       service.mixin.metadata.withNamespace($._config.namespace) +
       service.mixin.spec.withClusterIp('None'),
     serviceMonitor:
@@ -167,7 +170,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         metadata: {
           name: 'prometheus-operator',
           namespace: $._config.namespace,
-          labels: $._config.labels,
+          labels: $._config.prometheusOperator.labels,
         },
         spec: {
           endpoints: [
@@ -177,7 +180,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
             },
           ],
           selector: {
-            matchLabels: $._config.labels,
+            matchLabels: $._config.prometheusOperator.labels,
           },
         },
       },

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -81,7 +81,7 @@ func TestAllNS(t *testing.T) {
 
 	// Check if Prometheus Operator ever restarted.
 	opts := metav1.ListOptions{LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-		"k8s-app": "prometheus-operator",
+		"apps.kubernetes.io/name": "prometheus-operator",
 	})).String()}
 
 	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(opts)


### PR DESCRIPTION
This adds a common `app.kubernetes.io/name: prometheus-operator` label to all resources, as [recommended](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) by SIG-Apps.

It also replaces the `k8s-app` label used in the Deployment and Service. That's a potentially disruptive change, since a Deployment's `spec.selector` is immutable. If prometheus-operator is already deployed, it will have to be deleted first.

Not sure how to get new `0prometheus-operator` manifests generated for kube-prometheus.