### PR TITLE
node-exporter tolerate any taint

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -221,8 +221,10 @@ spec:
         runAsUser: 65534
       serviceAccountName: node-exporter
       tolerations:
+      - effect: NoExecute
+        operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        operator: Exists
       volumes:
       - hostPath:
           path: /proc

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -66,9 +66,13 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
       local podLabels = { app: 'node-exporter' };
 
-      local masterToleration = toleration.new() +
-                               toleration.withEffect('NoSchedule') +
-                               toleration.withKey('node-role.kubernetes.io/master');
+      local noExecuteToleration = toleration.new() +
+                                  toleration.withOperator('Exists') +
+                                  toleration.withEffect('NoExecute');
+
+      local noScheduleToleration = toleration.new() +
+                                   toleration.withOperator('Exists') +
+                                   toleration.withEffect('NoSchedule');
 
       local procVolumeName = 'proc';
       local procVolume = volume.fromHostPath(procVolumeName, '/proc');
@@ -132,7 +136,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       daemonset.mixin.metadata.withLabels(podLabels) +
       daemonset.mixin.spec.selector.withMatchLabels(podLabels) +
       daemonset.mixin.spec.template.metadata.withLabels(podLabels) +
-      daemonset.mixin.spec.template.spec.withTolerations([masterToleration]) +
+      daemonset.mixin.spec.template.spec.withTolerations([noExecuteToleration, noScheduleToleration]) +
       daemonset.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/os': 'linux' }) +
       daemonset.mixin.spec.template.spec.withContainers(c) +
       daemonset.mixin.spec.template.spec.withVolumes([procVolume, sysVolume, rootVolume]) +

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "a4cd74c5906273ea2c38a2b728641cdef017c76c"
+            "version": "8191e30cccc28c54b2386aab1b685396bf1ed4ba"
         },
         {
             "name": "ksonnet",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "bbf03a7971ebac7011ef9320fcc23cc01e0a54d3"
+            "version": "5d7e5391010c768a6ddd39163c35662f379e20ca"
         },
         {
             "name": "grafana",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "8c228d692bfa516e1c0977922f061b9a0fb1ae0f"
+            "version": "5effa154b464faa6a9ca88296df831eb7f0b8955"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
+++ b/contrib/kube-prometheus/manifests/node-exporter-daemonset.yaml
@@ -74,8 +74,10 @@ spec:
         runAsUser: 65534
       serviceAccountName: node-exporter
       tolerations:
+      - effect: NoExecute
+        operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        operator: Exists
       volumes:
       - hostPath:
           path: /proc


### PR DESCRIPTION
Node-exporter should be running on any linux node, no exception.

@mxinden @s-urbaniak 

cc @sichvoge 