### PR TITLE
Fix operator selector

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -121,7 +121,6 @@ spec:
     matchLabels:
       apps.kubernetes.io/component: controller
       apps.kubernetes.io/name: prometheus-operator
-      apps.kubernetes.io/version: v0.29.0
   template:
     metadata:
       labels:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -103,7 +103,6 @@ spec:
     matchLabels:
       apps.kubernetes.io/component: controller
       apps.kubernetes.io/name: prometheus-operator
-      apps.kubernetes.io/version: v0.29.0
   template:
     metadata:
       labels:

--- a/example/non-rbac/prometheus-operator.yaml
+++ b/example/non-rbac/prometheus-operator.yaml
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       apps.kubernetes.io/component: controller
       apps.kubernetes.io/name: prometheus-operator
-      apps.kubernetes.io/version: v0.29.0
   template:
     metadata:
       labels:

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       apps.kubernetes.io/component: controller
       apps.kubernetes.io/name: prometheus-operator
-      apps.kubernetes.io/version: v0.29.0
   template:
     metadata:
       labels:


### PR DESCRIPTION
#2427 introduced a bug to the prometheus-operator Deployment. Including the version in the selector will result in an orphaned ReplicaSet when the version is changed. This separates labels into two objects, leaving `apps.kubernetes.io/version` out of the one used by the selector.