### PR TITLE
Consistent metrics usage in adapter and dashboards

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -20,7 +20,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         resourceRules:
           cpu:
             containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
-            nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+            nodeQuery: sum(1 - rate(node_cpu_seconds_total{mode="idle"}[1m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>)
             resources:
               overrides:
                 node:
@@ -32,7 +32,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
             containerLabel: container_name
           memory:
             containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
-            nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+            nodeQuery: sum(node:node_memory_bytes_total:sum{<<.LabelMatchers>>} - node:node_memory_bytes_available:sum{<<.LabelMatchers>>}) by (<<.GroupBy>>)
             resources:
               overrides:
                 node:

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "8191e30cccc28c54b2386aab1b685396bf1ed4ba"
+            "version": "df002d09f7b7a50321786c4f19c70d371494410b"
         },
         {
             "name": "ksonnet",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "5effa154b464faa6a9ca88296df831eb7f0b8955"
+            "version": "a7e3bd06b2ef0286e1571836997287a81146c25a"
         }
     ]
 }

--- a/contrib/kube-prometheus/manifests/prometheus-adapter-configMap.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-adapter-configMap.yaml
@@ -4,7 +4,7 @@ data:
     resourceRules:
       cpu:
         containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
-        nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+        nodeQuery: sum(1 - rate(node_cpu_seconds_total{mode="idle"}[1m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>)
         resources:
           overrides:
             node:
@@ -16,7 +16,7 @@ data:
         containerLabel: container_name
       memory:
         containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
-        nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+        nodeQuery: sum(node:node_memory_bytes_total:sum{<<.LabelMatchers>>} - node:node_memory_bytes_available:sum{<<.LabelMatchers>>}) by (<<.GroupBy>>)
         resources:
           overrides:
             node:


### PR DESCRIPTION
This pull request configures the Prometheus adapter for the resource metrics API to be consistent with what is displayed in the "Kubernetes / USE Method / Node" dashboard.

https://bugzilla.redhat.com/show_bug.cgi?id=1656868

@mxinden @s-urbaniak 