### PR TITLE
Allow browsing of downsampled thanos data in Grafana

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-thanos.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-thanos.libsonnet
@@ -83,6 +83,7 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
           'query',
           '--log.level=debug',
           '--query.replica-label=prometheus_replica',
+          '--query.auto-downsampling',
           '--cluster.peers=thanos-peers.' + $._config.namespace + '.svc:10900',
         ]);
       local podLabels = { app: 'thanos-query', 'thanos-peers': 'true' };


### PR DESCRIPTION
As per https://github.com/improbable-eng/thanos/issues/601
We need to enable the `'--query.auto-downsampling'` flag
So that grafana can browse data beyond the Raw Data period of prometheus/sidecar

Dashboard showing 70d data of prometheus and alertmanager config-reloads
<img width="791" alt="screen shot 2019-02-28 at 3 08 01 pm" src="https://user-images.githubusercontent.com/581287/53556833-ae65f380-3b6a-11e9-8206-87ec8f5f5143.png">
