### PR TITLE
Changed kubectl apply -f to kubectl create -f. kubectl apply command …

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -71,7 +71,7 @@ This project is intended to be used as a library (i.e. the intent is not for you
 Though for a quickstart a compiled version of the Kubernetes [manifests](manifests) generated with this library (specifically with `example.jsonnet`) is checked into this repository in order to try the content out quickly. To try out the stack un-customized run:
  * Simply create the stack:
 ```
-$ kubectl apply -f manifests/
+$ kubectl create -f manifests/
 
 # It can take a few seconds for the above 'create manifests' command to fully create the following resources, so verify the resources are ready before proceeding.
 $ until kubectl get customresourcedefinitions servicemonitors.monitoring.coreos.com ; do date; sleep 1; echo ""; done


### PR DESCRIPTION
scripts: correct the kubeclt command for creating the kube-prometheus deployment

kubectl apply -f doesn't seem to work correctly and has to be run again for kube-prometheus to be deployed correctly. I believe the appropriate command to be run is kubectl create -f. It seems to work the first time it is run.

Documentation correction.