### PR TITLE
pkg/prometheus: watch configmaps having the prometheus-name selector

### DIFF
--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -23,7 +23,7 @@ import (
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -31,6 +31,8 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 )
+
+const labelPrometheusName = "prometheus-name"
 
 // The maximum `Data` size of a ConfigMap seems to differ between
 // environments. This is probably due to different meta data sizes which count
@@ -128,7 +130,7 @@ func (c *Operator) createOrUpdateRuleConfigMaps(p *monitoringv1.Prometheus) ([]s
 }
 
 func prometheusRulesConfigMapSelector(prometheusName string) metav1.ListOptions {
-	return metav1.ListOptions{LabelSelector: fmt.Sprintf("prometheus-name=%v", prometheusName)}
+	return metav1.ListOptions{LabelSelector: fmt.Sprintf("%v=%v", labelPrometheusName, prometheusName)}
 }
 
 func (c *Operator) selectRuleNamespaces(p *monitoringv1.Prometheus) ([]string, error) {
@@ -264,7 +266,7 @@ func bucketSize(bucket map[string]string) int {
 func makeRulesConfigMap(p *monitoringv1.Prometheus, ruleFiles map[string]string) v1.ConfigMap {
 	boolTrue := true
 
-	labels := map[string]string{"prometheus-name": p.Name}
+	labels := map[string]string{labelPrometheusName: p.Name}
 	for k, v := range managedByOperatorLabels {
 		labels[k] = v
 	}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1beta2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"


### PR DESCRIPTION
Currently, we are watching all configmaps amongst all configured tenant namespaces. This is very costly in certain deployment use cases where we have:

a) many namespace tenants
b) kubernetes controllers running in those namespace doing leader election using k8s intrinsics

Here, we can observe quite a high CPU usage of the prometheus operator of up to 15% CPU "idle" usage:
![image](https://user-images.githubusercontent.com/375856/53744258-eb98f100-3e9c-11e9-8db1-66154141e371.png)

A profile revealed most CPU time spent in the reconciliation loop:
```
(pprof) top10 -cum
Showing nodes accounting for 0.03s, 0.32% of 9.33s total
Dropped 359 nodes (cum <= 0.05s)
Showing top 10 nodes out of 271
      flat  flat%   sum%        cum   cum%
         0     0%     0%      6.11s 65.49%  github.com/coreos/prometheus-operator/pkg/prometheus.(*Operator).processNextWorkItem
         0     0%     0%      6.11s 65.49%  github.com/coreos/prometheus-operator/pkg/prometheus.(*Operator).sync
         0     0%     0%      6.11s 65.49%  github.com/coreos/prometheus-operator/pkg/prometheus.(*Operator).worker
         0     0%     0%      3.81s 40.84%  github.com/coreos/prometheus-operator/pkg/prometheus.(*Operator).createOrUpdateConfigurationSecret
```

In the above scenario we have a lot of configmap updates, namely `*-lock` configmaps which are being used inside kubernetes to do leader election. In the environment under test (OpenShift), we have up to 3 configmap updates per second:

![image](https://user-images.githubusercontent.com/375856/53744206-cefcb900-3e9c-11e9-8855-e6722760a976.png)


This fixes the above by watching for configmaps having the prometheus-name label selector only. CPU time is reduced to ~0,7% idle CPU usage:
![image](https://user-images.githubusercontent.com/375856/53744381-3adf2180-3e9d-11e9-95b5-f6bf978f6bbf.png)
