### PR TITLE
Document components that can't be scraped on EKS

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -95,6 +95,8 @@ Aside from the kubelet and the API server the other Kubernetes components all ru
 
 > Note the `Service` manifests for the scheduler and controller-manager are just examples. They may need to be adapted respective to a cluster.
 
+> If you are using a managed Kubernetes cluster such as Amazon EKS, the kube-scheduler and kube-controller-manager might be hidden inside the managed control plane and not visible to Kubernetes itself.  In this case you cannot scrape them with Prometheus and must depend on your cloud provider for monitoring of these components.
+
 kube-scheduler:
 
 ```yaml


### PR DESCRIPTION
The kube-scheduler and kube-cluster-manager are not visible from a managed EKS cluster.  They are likely run inside the managed control plane as a black box.  This means you cannot use Prometheus to scrape these components and must rely on your cloud provider for metrics.