### PR TITLE
contrib/kube-prometheus: Jsonnet snippet for managed kubernetes clusters

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-managed-cluster.jsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-managed-cluster.jsonnet
@@ -1,0 +1,28 @@
+// On managed Kubernetes clusters some of the control plane components are not exposed to customers.
+// Disable scrape jobs and service monitors for these components by overwriting 'kube-prometheus.libsonnet' defaults
+// Note this doesn't disable generation of associated alerting rules but the rules don't trigger
+
+{
+  _config+:: {
+    // This snippet walks the original object (super.jobs, set as temp var j) and creates a replacement jobs object
+    //     excluding any members of the set specified (eg: controller and scheduler).
+    local j = super.jobs,
+    jobs: {
+      [k]: j[k]
+      for k in std.objectFields(j)
+      if !std.setMember(k, ['KubeControllerManager', 'KubeScheduler'])
+    },
+  },
+
+  // Same as above but for ServiceMonitor's
+  local p = super.prometheus,
+  prometheus: {
+    [q]: p[q]
+    for q in std.objectFields(p)
+    if !std.setMember(q, ['serviceMonitorKubeControllerManager', 'serviceMonitorKubeScheduler'])
+  },
+
+  // TODO: disable generationg of alerting rules
+  // manifests/prometheus-rules.yaml:52:  - name: kube-scheduler.rules
+
+}


### PR DESCRIPTION
Per: https://github.com/coreos/prometheus-operator/issues/2437#issuecomment-470027546

Thanks to @brancz for sharing the snippet originally. Any breakages mine :)

A patch/snippet to exclude monitoring of components that are commonly unavailable in managed clusters.

Prometheus targets page does not show Scheduler and Controller targets.
Alerts don't fire for Scheduler or Controller but rules are still generated by kube-prometheus (added todo).

Have been using the jobs snippet in our clusters for some time.

Service Monitor section is new, seems to generate correct json/yaml and be working in an existing Prometheus cluster (applied over top, not from fresh). 