### PR TITLE
contrib/kube-prometheus: fix GKE cAdvisor readme link

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -581,7 +581,7 @@ Should the Prometheus `/targets` page show kubelet targets, but not able to succ
 
 As described in the [Prerequisites](#prerequisites) section, in order to retrieve metrics from the kubelet token authentication and authorization must be enabled. Some Kubernetes setup tools do not enable this by default.
 
-If you are using Google's GKE product, see [docs/GKE-cadvisor-support.md].
+If you are using Google's GKE product, see [cAdvisor support](docs/GKE-cadvisor-support.md).
 
 #### Authentication problem
 


### PR DESCRIPTION
I noticed this when reading the docs: https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus#error-retrieving-kubelet-metrics 