### PR TITLE
contrib/kube-prometheus: Fix metrics for kops installations using kube-dns

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
@@ -15,7 +15,7 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeDnsPrometheusDiscoveryService:
-      service.new('kube-dns-prometheus-discovery', { 'k8s-app': 'kube-dns' }, [servicePort.newNamed('http-metrics-skydns', 10055, 10055), servicePort.newNamed('http-metrics-dnsmasq', 10054, 10054)]) +
+      service.new('kube-dns-prometheus-discovery', { 'k8s-app': 'kube-dns' }, [servicePort.newNamed('metrics', 10055, 10055), servicePort.newNamed('http-metrics-dnsmasq', 10054, 10054)]) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-dns' }) +
       service.mixin.spec.withClusterIp('None'),


### PR DESCRIPTION
This fixes metrics for kops installations using kube-dns. 

kube-dns-prometheus-discovery was updated to `metrics:10055` from `http-metrics-skydns:10055`. 
The CoreDNS ServiceMonitor for kops expects `metrics:10055`.
