### PR TITLE
Disable KubeClientCertificateExpiration when metric 0

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-rules.yaml
@@ -792,7 +792,7 @@ spec:
           in less than 7 days.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration
       expr: |
-        histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
+        histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800 > 0
       labels:
         severity: warning
     - alert: KubeClientCertificateExpiration
@@ -801,7 +801,7 @@ spec:
           in less than 24 hours.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration
       expr: |
-        histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
+        histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400 > 0
       labels:
         severity: critical
   - name: alertmanager.rules


### PR DESCRIPTION
The alert should not fire if the metric value is exactly 0, i.e. no expiration duration was recorded by the server. This happens for example with aws-iam-authenticator on EKS.