### PR TITLE
Update travis to latest minikube, k8s, jsonnet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 sudo: required
+dist: xenial
 language: go
 go:
-- "1.11"
+- "1.11.x"
+cache:
+  directories:
+  - $GOCACHE
+  - $GOPATH/pkg/mod
 services:
 - docker
 before_install:

--- a/Makefile
+++ b/Makefile
@@ -214,12 +214,12 @@ test: test-unit test-e2e
 
 .PHONY: test-unit
 test-unit:
-	@go test -race $(TEST_RUN_ARGS) -short $(pkgs)
+	@go test -race $(TEST_RUN_ARGS) -short $(pkgs) -count=1
 
 .PHONY: test-e2e
 test-e2e: KUBECONFIG?=$(HOME)/.kube/config
 test-e2e:
-	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG) --operator-image=$(REPO):$(TAG)
+	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG) --operator-image=$(REPO):$(TAG) -count=1
 
 
 ########

--- a/contrib/kube-prometheus/Makefile
+++ b/contrib/kube-prometheus/Makefile
@@ -18,6 +18,7 @@ generate-in-docker: ../../hack/jsonnet-docker-image
 	--rm \
 	-u=$(shell id -u $(USER)):$(shell id -g $(USER)) \
 	-v $(shell dirname $(dir $(abspath $(dir $$PWD)))):/go/src/github.com/coreos/prometheus-operator/ \
+	-v $(shell go env GOCACHE):/.cache/go-build \
 	--workdir /go/src/github.com/coreos/prometheus-operator/contrib/kube-prometheus \
 	po-jsonnet make generate
 
@@ -43,7 +44,7 @@ test: $(JB_BINARY)
 	./test.sh
 
 test-e2e:
-	go test -timeout 55m -v ./tests/e2e
+	go test -timeout 55m -v ./tests/e2e -count=1
 
 test-in-docker: ../../hack/jsonnet-docker-image
 	@echo ">> Compiling assets and generating Kubernetes manifests"
@@ -51,6 +52,7 @@ test-in-docker: ../../hack/jsonnet-docker-image
 	--rm \
 	-u=$(shell id -u $(USER)):$(shell id -g $(USER)) \
 	-v $(shell dirname $(dir $(abspath $(dir $$PWD)))):/go/src/github.com/coreos/prometheus-operator/ \
+	-v $(shell go env GOCACHE):/.cache/go-build \
 	--workdir /go/src/github.com/coreos/prometheus-operator/contrib/kube-prometheus \
 	po-jsonnet make test
 

--- a/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
+++ b/contrib/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
@@ -796,7 +796,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(max(node_filesystem_size_bytes{fstype=\u007e\"ext[234]|btrfs|xfs|zfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{fstype=\u007e\"ext[234]|btrfs|xfs|zfs\", cluster=\"$cluster\"}) by (device,pod,namespace)) by (pod,namespace)\n/ scalar(sum(max(node_filesystem_size_bytes{fstype=\u007e\"ext[234]|btrfs|xfs|zfs\", cluster=\"$cluster\"}) by (device,pod,namespace)))\n* on (namespace, pod) group_left (node) node_namespace_pod:kube_pod_info:{cluster=\"$cluster\"}\n",
+                                  "expr": "sum(max(node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\", cluster=\"$cluster\"}) by (device,pod,namespace)) by (pod,namespace)\n/ scalar(sum(max(node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\", cluster=\"$cluster\"}) by (device,pod,namespace)))\n* on (namespace, pod) group_left (node) node_namespace_pod:kube_pod_info:{cluster=\"$cluster\"}\n",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
@@ -6100,7 +6100,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "max(rate(node_network_receive_bytes_total{cluster=\"$cluster\", job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m]))",
+                                  "expr": "max(rate(node_network_receive_bytes_total{cluster=\"$cluster\", job=\"node-exporter\", instance=\"$instance\", device!~\"lo\"}[5m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{device}}",
@@ -6191,7 +6191,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "max(rate(node_network_transmit_bytes_total{cluster=\"$cluster\", job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m]))",
+                                  "expr": "max(rate(node_network_transmit_bytes_total{cluster=\"$cluster\", job=\"node-exporter\", instance=\"$instance\", device!~\"lo\"}[5m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{device}}",
@@ -7006,21 +7006,21 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum by(container_name) (container_memory_usage_bytes{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=\"$pod\", container_name=\u007e\"$container\", container_name!=\"POD\"})",
+                                  "expr": "sum by(container_name) (container_memory_usage_bytes{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=\"$pod\", container_name=~\"$container\", container_name!=\"POD\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "Current: {{ container_name }}",
                                   "refId": "A"
                               },
                               {
-                                  "expr": "sum by(container) (kube_pod_container_resource_requests_memory_bytes{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container=\u007e\"$container\"})",
+                                  "expr": "sum by(container) (kube_pod_container_resource_requests_memory_bytes{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "Requested: {{ container }}",
                                   "refId": "B"
                               },
                               {
-                                  "expr": "sum by(container) (kube_pod_container_resource_limits_memory_bytes{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container=\u007e\"$container\"})",
+                                  "expr": "sum by(container) (kube_pod_container_resource_limits_memory_bytes{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "Limit: {{ container }}",
@@ -7374,7 +7374,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info{cluster=\"$cluster\", namespace=\u007e\"$namespace\"}, pod)",
+                      "query": "label_values(kube_pod_info{cluster=\"$cluster\", namespace=~\"$namespace\"}, pod)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 0,
@@ -7541,7 +7541,7 @@ items:
                           "tableColumn": "",
                           "targets": [
                               {
-                                  "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=\u007e\"$statefulset.*\"}[3m]))",
+                                  "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\"}[3m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "",
@@ -7624,7 +7624,7 @@ items:
                           "tableColumn": "",
                           "targets": [
                               {
-                                  "expr": "sum(container_memory_usage_bytes{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=\u007e\"$statefulset.*\"}) / 1024^3",
+                                  "expr": "sum(container_memory_usage_bytes{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\"}) / 1024^3",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "",
@@ -7707,7 +7707,7 @@ items:
                           "tableColumn": "",
                           "targets": [
                               {
-                                  "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=\u007e\"$statefulset.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\",pod_name=\u007e\"$statefulset.*\"}[3m]))",
+                                  "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\",pod_name=~\"$statefulset.*\"}[3m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "",

--- a/contrib/kube-prometheus/tests/e2e/travis-e2e.sh
+++ b/contrib/kube-prometheus/tests/e2e/travis-e2e.sh
@@ -12,9 +12,6 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 "${SCRIPT_DIR}"/../../../../scripts/create-minikube.sh
 
-# waiting for kube-dns to be ready
-JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
-
 (
     cd "${SCRIPT_DIR}"/../.. || exit
     kubectl apply -f manifests

--- a/hack/generate-in-docker.sh
+++ b/hack/generate-in-docker.sh
@@ -22,4 +22,5 @@ docker run \
     --rm \
     -u="$(id -u "$USER")":"$(id -g "$USER")" \
     -v "${SCRIPTDIR}/..:/go/src/github.com/coreos/prometheus-operator${VOLUME_OPTIONS}" \
+    -v "$(go env GOCACHE)":/.cache/go-build \
     po-jsonnet make ${MFLAGS[@]} generate

--- a/scripts/create-minikube.sh
+++ b/scripts/create-minikube.sh
@@ -8,8 +8,8 @@ set -u
 # print each command before executing it
 set -x
 
-export MINIKUBE_VERSION=v0.28.0
-export KUBERNETES_VERSION=v1.10.0
+export MINIKUBE_VERSION=v0.35.0
+export KUBERNETES_VERSION=v1.13.4
 
 sudo mount --make-rshared /
 sudo mount --make-rshared /proc
@@ -22,24 +22,32 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VER
     chmod +x minikube && \
     sudo mv minikube /usr/local/bin/
 
-export MINIKUBE_WANTUPDATENOTIFICATION=false
-export MINIKUBE_WANTREPORTERRORPROMPT=false
 export MINIKUBE_HOME=$HOME
 export CHANGE_MINIKUBE_NONE_USER=true
 mkdir "${HOME}"/.kube || true
 touch "${HOME}"/.kube/config
 
 export KUBECONFIG=$HOME/.kube/config
+
+# minikube config
+minikube config set WantUpdateNotification false
+minikube config set WantReportErrorPrompt false
+minikube config set WantNoneDriverWarning false
+minikube config set vm-driver none
+
 minikube version
-minikube addons enable storage-provisioner
-sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=$KUBERNETES_VERSION --extra-config=apiserver.Authorization.Mode=RBAC --extra-config=apiserver.feature-gates=CustomResourceSubresources=true
+sudo minikube start --kubernetes-version=$KUBERNETES_VERSION --extra-config=apiserver.authorization-mode=RBAC
+sudo chown -R travis: /home/travis/.minikube/
 
 minikube update-context
 
 # waiting for node(s) to be ready
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
-kubectl apply -f scripts/minikube-rbac.yaml
+# waiting for kube-addon-manager to be ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
 
 # waiting for kube-dns to be ready
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
+
+kubectl apply -f scripts/minikube-rbac.yaml

--- a/scripts/jsonnet/Dockerfile
+++ b/scripts/jsonnet/Dockerfile
@@ -1,13 +1,14 @@
 FROM golang:1.11-stretch
 
-ENV JSONNET_VERSION 0.10.0
+ENV JSONNET_VERSION 0.12.1
 
-RUN apt-get update -y && apt-get install -y g++ make git jq
-RUN cd /tmp && wget https://github.com/google/jsonnet/archive/v${JSONNET_VERSION}.tar.gz && \
-    tar xvfz v${JSONNET_VERSION}.tar.gz && \
-    cd jsonnet-${JSONNET_VERSION} && \
+RUN apt-get update -y && apt-get install -y g++ make git jq && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -Lso - https://github.com/google/jsonnet/archive/v${JSONNET_VERSION}.tar.gz | \
+    tar xfz - -C /tmp && \
+    cd /tmp/jsonnet-${JSONNET_VERSION} && \
     make && mv jsonnet /usr/local/bin && \
-    rm -rf /tmp/v${JSONNET_VERSION}.tar.gz /tmp/jsonnet-${JSONNET_VERSION}
+    rm -rf /tmp/jsonnet-${JSONNET_VERSION}
 RUN go get github.com/brancz/gojsontoyaml
 RUN go get github.com/campoy/embedmd
 RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb

--- a/scripts/travis-e2e.sh
+++ b/scripts/travis-e2e.sh
@@ -12,9 +12,6 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 "${SCRIPT_DIR}"/create-minikube.sh
 
-# waiting for kube-dns to be ready
-JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
-
 make build image
 make test-e2e
 


### PR DESCRIPTION
Attempt to update travis scripts to use latest versions of minikube (v0.35.0), kubernetes (v1.13.4) and jsonnet (v0.12.1). 
* `dist: xenial` is required for the default minikube bootstrapper (kubeadm) as it depends on systemd
* bump go to latest `1.11.x`
* enable caching of go build cache to speed up builds
* enable go build cache when running `po-jsonnet` container
* remove redundant `kube-dns` check from e2e scripts
* `create_minikube.sh`: use minikube config to set defaults, add `kube-addon-manager` check
* `Dockerfile`: use latest jsonnet `v0.12.1`, replace wget with curl