### PR TITLE
Make resource limit and request of Prometheus configurable.

### DIFF
--- a/contrib/kube-prometheus/README.md
+++ b/contrib/kube-prometheus/README.md
@@ -290,6 +290,10 @@ These are the available fields with their respective default values:
         names: 'k8s',
         replicas: 2,
         rules: {},
+        resourceRequests: {
+          memory: '400Mi',
+        },
+        resourceLimits: {},
     },
 
     alertmanager+:: {

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -22,6 +22,10 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       rules: {},
       renderedRules: {},
       namespaces: ['default', 'kube-system', $._config.namespace],
+      resourceRequests: {
+        memory: '400Mi',
+      },
+      resourceLimits: {},
     },
   },
 
@@ -151,7 +155,8 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
       local resources =
         resourceRequirements.new() +
-        resourceRequirements.withRequests({ memory: '400Mi' });
+        resourceRequirements.withRequests($._config.prometheus.resourceRequests) +
+        resourceRequirements.withLimits($._config.prometheus.resourceLimits);
 
       {
         apiVersion: 'monitoring.coreos.com/v1',


### PR DESCRIPTION
This PR introduces `_config.prometheus.resourceRequests` and `_config.prometheus.resourceLimits` to configure resources of Prometheus Pods.