### PR TITLE
 pkg/alertmanager: Update to v0.16.2 

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -36,7 +36,7 @@ const (
 	governingServiceName = "alertmanager-operated"
 	// DefaultVersion specifies which version of Alertmanager the Prometheus
 	// Operator uses by default.
-	DefaultVersion         = "v0.16.1"
+	DefaultVersion         = "v0.16.2"
 	defaultRetention       = "120h"
 	secretsDir             = "/etc/alertmanager/secrets/"
 	configmapsDir          = "/etc/alertmanager/configmaps/"

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -102,7 +102,7 @@ func testAMVersionMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	am.Spec.Version = "v0.16.1"
+	am.Spec.Version = "v0.16.2"
 	am, err = framework.UpdateAlertmanagerAndWaitUntilReady(ns, am)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
> ## 0.16.2 / 2019-04-03
> 
> Updating to v0.16.2 is recommended for all users using the Slack, Pagerduty,
> Hipchat, Wechat, VictorOps and Pushover notifier, as connection errors could
> leak secrets embedded in the notifier's URL to stdout.
> 
> * [BUGFIX] Redact notifier URL from logs to not leak secrets embedded in the URL (#1822, #1825)
> * [BUGFIX] Allow sending of unauthenticated SMTP requests when `smtp_auth_username` is not supplied (#1739)


https://github.com/prometheus/alertmanager/releases/tag/v0.16.2