### PR TITLE
specify go import path in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 language: go
 go:
 - "1.11.x"
+go_import_path: github.com/coreos/prometheus-operator
 cache:
   directories:
   - $GOCACHE


### PR DESCRIPTION
This doesn't change anything for us. It just eases enabling CI on forked repositories.