### PR TITLE
Fix non container metrics

### DIFF
--- a/Documentation/user-guides/cluster-monitoring.md
+++ b/Documentation/user-guides/cluster-monitoring.md
@@ -513,11 +513,6 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: drop
-      regex: container_([a-z_]+);
-      sourceLabels:
-      - __name__
-      - image
-    - action: drop
       regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
       sourceLabels:
       - __name__

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -283,13 +283,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
               },
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
               metricRelabelings: [
-                // Drop container_* metrics with no image.
-                {
-                  sourceLabels: ['__name__', 'image'],
-                  regex: 'container_([a-z_]+);',
-                  action: 'drop',
-                },
-
                 // Drop a bunch of metrics which are disabled but still sent, see
                 // https://github.com/google/cadvisor/issues/1925.
                 {

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "3bd8b755d11bcf9be1e70b5b7ffe0ad881f300fe"
+            "version": "3ba7822228654f3bc864a7c37139665c7549739a"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/prometheus-serviceMonitorKubelet.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-serviceMonitorKubelet.yaml
@@ -19,11 +19,6 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: drop
-      regex: container_([a-z_]+);
-      sourceLabels:
-      - __name__
-      - image
-    - action: drop
       regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
       sourceLabels:
       - __name__


### PR DESCRIPTION
These metrics can still be valuable to troubleshoot components running in cgroups on the host, outside the scope of Kubernetes pods. Previously we were dropping these (somewhat intentionally), but it turns out that was a bit too aggressive.

https://bugzilla.redhat.com/show_bug.cgi?id=1694766

@metalmatze @squat @s-urbaniak @mxinden @paulfantom 