### PR TITLE
pkg/alertmanager: Update to Alertmanager v0.17.0

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -36,7 +36,7 @@ const (
 	governingServiceName = "alertmanager-operated"
 	// DefaultVersion specifies which version of Alertmanager the Prometheus
 	// Operator uses by default.
-	DefaultVersion         = "v0.16.2"
+	DefaultVersion         = "v0.17.0"
 	defaultRetention       = "120h"
 	secretsDir             = "/etc/alertmanager/secrets/"
 	configmapsDir          = "/etc/alertmanager/configmaps/"

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -96,19 +96,19 @@ func testAMVersionMigration(t *testing.T) {
 	name := "test"
 
 	am := framework.MakeBasicAlertmanager(name, 1)
-	am.Spec.Version = "v0.15.3"
+	am.Spec.Version = "v0.16.2"
 	am, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	am.Spec.Version = "v0.16.2"
+	am.Spec.Version = "v0.17.0"
 	am, err = framework.UpdateAlertmanagerAndWaitUntilReady(ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	am.Spec.Version = "v0.15.3"
+	am.Spec.Version = "v0.16.2"
 	am, err = framework.UpdateAlertmanagerAndWaitUntilReady(ns, am)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
See https://github.com/prometheus/alertmanager/releases/tag/v0.17.0 for
release docs.