### PR TITLE
Update API groups in examples and Documentation

### DIFF
--- a/Documentation/network-policies.md
+++ b/Documentation/network-policies.md
@@ -53,7 +53,7 @@ networkpolicy "prometheus" configured
  
 [embedmd]:# (../example/networkpolicies/alertmanager.yaml)
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: alertmanager-web
@@ -68,7 +68,7 @@ spec:
       alertmanager: main
       app: alertmanager
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: alertmanager-mesh
@@ -100,7 +100,7 @@ spec:
 
 [embedmd]:# (../example/networkpolicies/grafana.yaml)
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: grafana
@@ -120,7 +120,7 @@ spec:
 
 [embedmd]:# (../example/networkpolicies/prometheus.yaml)
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: prometheus
@@ -141,7 +141,7 @@ spec:
 
 [embedmd]:# (../example/networkpolicies/node-exporter.yaml)
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: node-exporter
@@ -172,7 +172,7 @@ spec:
 
 [embedmd]:# (../example/networkpolicies/kube-state-metrics.yaml)
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: kube-state-metrics

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -187,7 +187,7 @@ First, deploy three instances of a simple example application, which listens and
 
 [embedmd]:# (../../example/user-guides/getting-started/example-app-deployment.yaml)
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-app

--- a/example/networkpolicies/alertmanager.yaml
+++ b/example/networkpolicies/alertmanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: alertmanager-web
@@ -13,7 +13,7 @@ spec:
       alertmanager: main
       app: alertmanager
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: alertmanager-mesh

--- a/example/networkpolicies/grafana.yaml
+++ b/example/networkpolicies/grafana.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: grafana

--- a/example/networkpolicies/kube-state-metrics.yaml
+++ b/example/networkpolicies/kube-state-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: kube-state-metrics

--- a/example/networkpolicies/node-exporter.yaml
+++ b/example/networkpolicies/node-exporter.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: node-exporter

--- a/example/networkpolicies/prometheus.yaml
+++ b/example/networkpolicies/prometheus.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: prometheus

--- a/example/user-guides/getting-started/example-app-deployment.yaml
+++ b/example/user-guides/getting-started/example-app-deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: example-app
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: example-app
   template:
     metadata:
       labels:

--- a/example/user-guides/getting-started/example-app-deployment.yaml
+++ b/example/user-guides/getting-started/example-app-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-app

--- a/test/framework/ressources/basic-auth-app-deployment.yaml
+++ b/test/framework/ressources/basic-auth-app-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: basic-auth-test-app


### PR DESCRIPTION
Next to StatefulSet and Deployment API groups, we should also update all deprecated API groups in the examples and Documentation.

Closes #2592

/cc @s-urbaniak @mxinden @paulfantom @brancz 