### PR TITLE
Add prometheus-operator Service and Servicemonitor to Bundle

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -147,3 +147,41 @@ metadata:
     apps.kubernetes.io/version: v0.29.0
   name: prometheus-operator
   namespace: default
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
+  name: prometheus-operator
+  namespace: default
+spec:
+  endpoints:
+  - honorLabels: true
+    port: http
+  selector:
+    matchLabels:
+      apps.kubernetes.io/component: controller
+      apps.kubernetes.io/name: prometheus-operator
+      apps.kubernetes.io/version: v0.29.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
+  name: prometheus-operator
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+  selector:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator

--- a/example/rbac/prometheus-operator/prometheus-operator-service-monitor.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-service-monitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
+  name: prometheus-operator
+  namespace: default
+spec:
+  endpoints:
+  - honorLabels: true
+    port: http
+  selector:
+    matchLabels:
+      apps.kubernetes.io/component: controller
+      apps.kubernetes.io/name: prometheus-operator
+      apps.kubernetes.io/version: v0.29.0

--- a/example/rbac/prometheus-operator/prometheus-operator-service.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.29.0
+  name: prometheus-operator
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+  selector:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator

--- a/hack/generate/prometheus-operator-rbac.jsonnet
+++ b/hack/generate/prometheus-operator-rbac.jsonnet
@@ -5,4 +5,6 @@ local po = (import 'prometheus-operator/prometheus-operator.libsonnet').promethe
   'prometheus-operator-cluster-role.yaml': po.clusterRole,
   'prometheus-operator-service-account.yaml': po.serviceAccount,
   'prometheus-operator-deployment.yaml': po.deployment,
+  'prometheus-operator-service.yaml': po.service,
+  'prometheus-operator-service-monitor.yaml': po.serviceMonitor,
 }


### PR DESCRIPTION
Background:

Currently, the Service and ServiceMonitor for the Prometheus Operator are not added to the generated bundle.yaml. 

The issue with the Service and ServiceMonitor not being bundled is seen when a cluster has multiple namespaces with the prometheus-operator pods running, and you'd have to manually create a Service in front of each of the operator pods.

Changes in this PR:
- Add the Service and ServiceMonitor object already present in the jsonnet to the bundle