### PR TITLE
Ignore ServiceMonitor in bundle.yaml

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -148,25 +148,6 @@ metadata:
   name: prometheus-operator
   namespace: default
 ---
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
-  name: prometheus-operator
-  namespace: default
-spec:
-  endpoints:
-  - honorLabels: true
-    port: http
-  selector:
-    matchLabels:
-      apps.kubernetes.io/component: controller
-      apps.kubernetes.io/name: prometheus-operator
-      apps.kubernetes.io/version: v0.30.0
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/hack/generate-bundle.sh
+++ b/hack/generate-bundle.sh
@@ -6,4 +6,5 @@ set -o pipefail
 # error on unset variables
 set -u
 
-hack/concat-kubernetes-manifests.sh example/rbac/prometheus-operator/*.yaml > bundle.yaml
+# shellcheck disable=SC2046
+hack/concat-kubernetes-manifests.sh $(find example/rbac/prometheus-operator -name '*.yaml' | sort | grep -v service-monitor) > bundle.yaml


### PR DESCRIPTION
Users installing the bundle.yaml most likely do not yet have the
ServiceMonitor CRD available in their cluster, therefore having this
object in the bundle.yaml would break them.

/cc @brancz @aditya-konarde 