### PR TITLE
*: fix sig-apps recommended labels

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -19,9 +19,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 rules:
 - apiGroups:
@@ -153,9 +153,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 ```
@@ -170,9 +170,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -20,9 +20,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -37,9 +37,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 rules:
 - apiGroups:
@@ -110,23 +110,23 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      apps.kubernetes.io/component: controller
-      apps.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: prometheus-operator
   template:
     metadata:
       labels:
-        apps.kubernetes.io/component: controller
-        apps.kubernetes.io/name: prometheus-operator
-        apps.kubernetes.io/version: v0.29.0
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: prometheus-operator
+        app.kubernetes.io/version: v0.30.0
     spec:
       containers:
       - args:
@@ -160,9 +160,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 ```

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -2,9 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -19,9 +19,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 rules:
 - apiGroups:
@@ -92,23 +92,23 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      apps.kubernetes.io/component: controller
-      apps.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: prometheus-operator
   template:
     metadata:
       labels:
-        apps.kubernetes.io/component: controller
-        apps.kubernetes.io/name: prometheus-operator
-        apps.kubernetes.io/version: v0.30.0
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: prometheus-operator
+        app.kubernetes.io/version: v0.30.0
     spec:
       containers:
       - args:
@@ -142,9 +142,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 ---
@@ -152,9 +152,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 spec:
@@ -164,5 +164,5 @@ spec:
     port: 8080
     targetPort: http
   selector:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator

--- a/example/non-rbac/prometheus-operator.yaml
+++ b/example/non-rbac/prometheus-operator.yaml
@@ -2,23 +2,23 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.29.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      apps.kubernetes.io/component: controller
-      apps.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: prometheus-operator
   template:
     metadata:
       labels:
-        apps.kubernetes.io/component: controller
-        apps.kubernetes.io/name: prometheus-operator
-        apps.kubernetes.io/version: v0.29.0
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: prometheus-operator
+        app.kubernetes.io/version: v0.30.0
     spec:
       containers:
       - args:

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
@@ -2,9 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -2,9 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 rules:
 - apiGroups:

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -2,23 +2,23 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      apps.kubernetes.io/component: controller
-      apps.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: prometheus-operator
   template:
     metadata:
       labels:
-        apps.kubernetes.io/component: controller
-        apps.kubernetes.io/name: prometheus-operator
-        apps.kubernetes.io/version: v0.30.0
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: prometheus-operator
+        app.kubernetes.io/version: v0.30.0
     spec:
       containers:
       - args:

--- a/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default

--- a/example/rbac/prometheus-operator/prometheus-operator-service-monitor.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-service-monitor.yaml
@@ -2,9 +2,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 spec:
@@ -13,6 +13,6 @@ spec:
     port: http
   selector:
     matchLabels:
-      apps.kubernetes.io/component: controller
-      apps.kubernetes.io/name: prometheus-operator
-      apps.kubernetes.io/version: v0.30.0
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/version: v0.30.0

--- a/example/rbac/prometheus-operator/prometheus-operator-service.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-service.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
-    apps.kubernetes.io/version: v0.30.0
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: default
 spec:
@@ -14,5 +14,5 @@ spec:
     port: 8080
     targetPort: http
   selector:
-    apps.kubernetes.io/component: controller
-    apps.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -6,12 +6,12 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
     prometheusOperator+:: {
       deploymentSelectorLabels: {
-        'apps.kubernetes.io/name': 'prometheus-operator',
-        'apps.kubernetes.io/component': 'controller',
+        'app.kubernetes.io/name': 'prometheus-operator',
+        'app.kubernetes.io/component': 'controller',
       },
       commonLabels:
         $._config.prometheusOperator.deploymentSelectorLabels +
-        { 'apps.kubernetes.io/version': $._config.versions.prometheusOperator, },
+        { 'app.kubernetes.io/version': $._config.versions.prometheusOperator, },
     },
 
     versions+:: {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -81,7 +81,7 @@ func TestAllNS(t *testing.T) {
 
 	// Check if Prometheus Operator ever restarted.
 	opts := metav1.ListOptions{LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-		"apps.kubernetes.io/name": "prometheus-operator",
+		"app.kubernetes.io/name": "prometheus-operator",
 	})).String()}
 
 	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(opts)


### PR DESCRIPTION
Per https://github.com/coreos/prometheus-operator/pull/2427#issuecomment-491923629, this fixes the SIG Apps [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) from `apps.kubernetes.io/...` to `app.kubernetes.io/...` (app is singular).

It also updates the `app.kubernetes.io/version` label to `v0.30.0` in the places it was still `v0.29.0`.

It might should be noted that changing selectors requires recreating Deployments.