### PR TITLE
Prometheus selector CLI switch

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -137,6 +137,7 @@ func init() {
 	flagset.StringVar(&cfg.LogLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(availableLogLevels, ", ")))
 	flagset.StringVar(&cfg.LogFormat, "log-format", logFormatLogfmt, fmt.Sprintf("Log format to use. Possible values: %s", strings.Join(availableLogFormats, ", ")))
 	flagset.BoolVar(&cfg.ManageCRDs, "manage-crds", true, "Manage all CRDs with the Prometheus Operator.")
+	flagset.StringVar(&cfg.PromSelector, "prometheus-instance-selector", "", "Label selector to filter Prometheus CRDs to manage")
 	flagset.Parse(os.Args[1:])
 	cfg.Namespaces = ns.asSlice()
 }

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -182,6 +182,10 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 		return nil, errors.Wrap(err, "instantiating monitoring client failed")
 	}
 
+	if _, err := labels.Parse(conf.PromSelector); err != nil {
+		return nil, errors.Wrap(err, "can not parse prometheus selector value")
+	}
+
 	kubeletObjectName := ""
 	kubeletObjectNamespace := ""
 	kubeletSyncEnabled := false


### PR DESCRIPTION
It is often convenient to limit operator to particular Prometheus objects, comes handy in testing or in some namespace specific situations, where "local" Prometheus runs alongside cluster-wide Prometheus.


This adds `--prometheus-instance-selector` switch with a syntax same as `kubectl get -l`.
