### PR TITLE
scripts/jsonnet: add go-bindata to satisfy openshift/cmo

### DIFF
--- a/scripts/jsonnet/Dockerfile
+++ b/scripts/jsonnet/Dockerfile
@@ -12,8 +12,10 @@ RUN curl -Lso - https://github.com/google/jsonnet/archive/v${JSONNET_VERSION}.ta
 RUN go get github.com/brancz/gojsontoyaml
 RUN go get github.com/campoy/embedmd
 RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+RUN go get -u github.com/jteeuwen/go-bindata/...
 
-RUN mkdir -p /go/src/github.com/coreos/prometheus-operator
+RUN mkdir -p /go/src/github.com/coreos/prometheus-operator /.cache
 WORKDIR /go/src/github.com/coreos/prometheus-operator
 
-RUN chmod -R 777 /go
+
+RUN chmod -R 777 /go /.cache


### PR DESCRIPTION
- download go-bindata to temporarily satisfy openshift/cmo CI requirements
- add `/.cache` to allow installations with `go get` when `GOPATH` is set to other directory than `/go`.

This unblocks CI in openshift/telemeter and openshift/cluster-monitoring-operator.

/cc: @brancz @s-urbaniak 