### PR TITLE
update jsonnet container to use go-jsonnet and jsonnetfmt

### DIFF
--- a/scripts/jsonnet/Dockerfile
+++ b/scripts/jsonnet/Dockerfile
@@ -1,14 +1,16 @@
 FROM golang:1.12-stretch
 
-ENV JSONNET_VERSION 0.12.1
+ENV JSONNET_VERSION 0.13.0
 
 RUN apt-get update -y && apt-get install -y g++ make git jq gawk python-yaml && \
     rm -rf /var/lib/apt/lists/*
 RUN curl -Lso - https://github.com/google/jsonnet/archive/v${JSONNET_VERSION}.tar.gz | \
     tar xfz - -C /tmp && \
     cd /tmp/jsonnet-${JSONNET_VERSION} && \
-    make && mv jsonnet /usr/local/bin && \
+    make && mv jsonnetfmt /usr/local/bin && \
     rm -rf /tmp/jsonnet-${JSONNET_VERSION}
+
+RUN go get github.com/google/go-jsonnet/cmd/jsonnet@v${JSONNET_VERSION}
 RUN go get github.com/brancz/gojsontoyaml
 RUN go get github.com/campoy/embedmd
 RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb


### PR DESCRIPTION
- Update jsonnet to 0.13.0
- Use only jsonnetfmt from google/jsonnet (C++ version)
- use go version of jsonnet as it is ~3x faster than C++ version.

Speed test for 0.13.0 (generating files in openshift/cluster-monitoring-operator repo):
C++ version:
```
real    0m25.563s
user    0m25.107s
sys     0m0.590s
```

Go version:
```
real    0m7.763s
user    0m9.052s
sys     0m0.558s
```

/cc: @brancz @metalmatze @s-urbaniak @squat 