### PR TITLE
scripts/jsonnet: enable path@version notation in go get

### DIFF
--- a/scripts/jsonnet/Dockerfile
+++ b/scripts/jsonnet/Dockerfile
@@ -10,7 +10,9 @@ RUN curl -Lso - https://github.com/google/jsonnet/archive/v${JSONNET_VERSION}.ta
     make && mv jsonnetfmt /usr/local/bin && \
     rm -rf /tmp/jsonnet-${JSONNET_VERSION}
 
+ENV GO111MODULE=on
 RUN go get github.com/google/go-jsonnet/cmd/jsonnet@v${JSONNET_VERSION}
+
 RUN go get github.com/brancz/gojsontoyaml
 RUN go get github.com/campoy/embedmd
 RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb


### PR DESCRIPTION
Enable go modules to allow using path@version notation in `go get ...`

Tested locally as this is not tested in CI.

Follow-up to #2625

/cc @brancz @s-urbaniak 