### PR TITLE
scripts/jsonnet: use go modules only for go-jsonnet

### DIFF
--- a/scripts/jsonnet/Dockerfile
+++ b/scripts/jsonnet/Dockerfile
@@ -10,9 +10,7 @@ RUN curl -Lso - https://github.com/google/jsonnet/archive/v${JSONNET_VERSION}.ta
     make && mv jsonnetfmt /usr/local/bin && \
     rm -rf /tmp/jsonnet-${JSONNET_VERSION}
 
-ENV GO111MODULE=on
-RUN go get github.com/google/go-jsonnet/cmd/jsonnet@v${JSONNET_VERSION}
-
+RUN GO111MODULE=on go get github.com/google/go-jsonnet/cmd/jsonnet@v${JSONNET_VERSION}
 RUN go get github.com/brancz/gojsontoyaml
 RUN go get github.com/campoy/embedmd
 RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb


### PR DESCRIPTION
Use go modules only when downloading go-jsonnet. Otherwise this will fail when downloading other go binaries.

Follow-up to #2626 

Output when running locally:
```
$ docker build -t jsonnet-ci -f scripts/jsonnet/Dockerfile .
Sending build context to Docker daemon  119.5MB
Step 1/12 : FROM golang:1.12-stretch
 ---> 7ced090ee82e
Step 2/12 : ENV JSONNET_VERSION 0.13.0
 ---> Using cache
 ---> 7fadc5b61b7c
Step 3/12 : RUN apt-get update -y && apt-get install -y g++ make git jq gawk python-yaml &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 1dddbc1ec188
Step 4/12 : RUN curl -Lso - https://github.com/google/jsonnet/archive/v${JSONNET_VERSION}.tar.gz |     tar xfz - -C /tmp &&     cd /tmp/jsonnet-${JSONNET_VERSION} &&     make && mv jsonnetfmt /usr/local/bin &&     rm -rf /tmp/jsonnet-${JSONNET_VERSION}
 ---> Using cache
 ---> 3c197540766e
Step 5/12 : RUN GO111MODULE=on go get github.com/google/go-jsonnet/cmd/jsonnet@v${JSONNET_VERSION}
 ---> Running in ea751247122a
go: finding github.com/google/go-jsonnet/cmd/jsonnet v0.13.0
go: finding github.com/google/go-jsonnet/cmd v0.13.0                                                                                                                                                                                         
go: finding github.com/google/go-jsonnet v0.13.0                                                                                                                                                                                             
go: downloading github.com/google/go-jsonnet v0.13.0                                                                                                                                                                                         
go: extracting github.com/google/go-jsonnet v0.13.0                                                                                                                                                                                          
go: finding github.com/fatih/color v1.7.0                                                                                                                                                                                                    
go: finding github.com/stretchr/testify v1.3.0                                                                                                                                                                                               
go: finding github.com/mattn/go-colorable v0.1.1                                                                                                                                                                                             
go: finding github.com/sergi/go-diff v1.0.0                                                                                                                                                                                                  
go: finding github.com/mattn/go-isatty v0.0.7                                                                                                                                                                                                
go: finding github.com/mattn/go-isatty v0.0.5                                                                                                                                                                                                
go: finding golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223                                                                                                                                                                              
go: finding github.com/pmezard/go-difflib v1.0.0                                                                                                                                                                                             
go: finding github.com/stretchr/objx v0.1.0                                                                                                                                                                                                  
go: finding github.com/davecgh/go-spew v1.1.0                                                                                                                                                                                                
go: downloading github.com/fatih/color v1.7.0                                                                                                                                                                                                
go: extracting github.com/fatih/color v1.7.0                                                                                                                                                                                                 
go: downloading github.com/mattn/go-isatty v0.0.7                                                                                                                                                                                            
go: downloading github.com/mattn/go-colorable v0.1.1                                                                                                                                                                                         
go: extracting github.com/mattn/go-colorable v0.1.1                                                                                                                                                                                          
go: extracting github.com/mattn/go-isatty v0.0.7                                                                                                                                                                                             
go: downloading golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223                                                                                                                                                                          
go: extracting golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223                                                                                                                                                                           
Removing intermediate container ea751247122a
 ---> 0365866fbf4c
Step 6/12 : RUN go get github.com/brancz/gojsontoyaml
 ---> Running in 3a1421ad3c7a
Removing intermediate container 3a1421ad3c7a
 ---> cbe62aba4862
Step 7/12 : RUN go get github.com/campoy/embedmd
 ---> Running in 73523116e373
Removing intermediate container 73523116e373
 ---> 5fe93bbc9601
Step 8/12 : RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 ---> Running in 69a8b8b9e3cb
Removing intermediate container 69a8b8b9e3cb
 ---> 6527453bb651
Step 9/12 : RUN go get -u github.com/jteeuwen/go-bindata/...
 ---> Running in 0b2cbc0ca10d
Removing intermediate container 0b2cbc0ca10d
 ---> 5a8271e83fee
Step 10/12 : RUN mkdir -p /go/src/github.com/coreos/prometheus-operator /.cache
 ---> Running in 45f06521e267
Removing intermediate container 45f06521e267
 ---> 79fd4e013def
Step 11/12 : WORKDIR /go/src/github.com/coreos/prometheus-operator
 ---> Running in 8470a2d20602
Removing intermediate container 8470a2d20602
 ---> 5c9d149a3458
Step 12/12 : RUN chmod -R 777 /go /.cache
 ---> Running in 0035032376c1
Removing intermediate container 0035032376c1
 ---> cabc8af6d6bb
Successfully built cabc8af6d6bb
Successfully tagged jsonnet-ci:latest
```

/cc @brancz 