### PR TITLE
Bump manifest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ generate: $(DEEPCOPY_TARGET) $(OPENAPI_TARGET) $(shell find jsonnet/prometheus-o
 
 .PHONY: generate-in-docker
 generate-in-docker:
-	$(CONTAINER_CMD) $(MAKE) $(MFLAGS) generate
+	$(CONTAINER_CMD) $(MAKE) $(MFLAGS) --always-make generate
 
 example/prometheus-operator-crd/**.crd.yaml: $(OPENAPI_TARGET) $(PO_CRDGEN_BINARY)
 	po-crdgen prometheus > example/prometheus-operator-crd/prometheus.crd.yaml

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -88,7 +88,7 @@ rules:
   - list
   - watch
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -130,7 +130,6 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:

--- a/example/non-rbac/prometheus-operator.yaml
+++ b/example/non-rbac/prometheus-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -25,8 +25,8 @@ spec:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
-        image: quay.io/coreos/prometheus-operator:v0.29.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.30.0
+        image: quay.io/coreos/prometheus-operator:v0.30.0
         name: prometheus-operator
         ports:
         - containerPort: 8080
@@ -40,7 +40,6 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -40,7 +40,6 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
 {
   _config+:: {
@@ -121,15 +121,15 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       clusterRole.withRules(rules),
 
     deployment:
-      local deployment = k.apps.v1beta2.deployment;
-      local container = k.apps.v1beta2.deployment.mixin.spec.template.spec.containersType;
+      local deployment = k.apps.v1.deployment;
+      local container = k.apps.v1.deployment.mixin.spec.template.spec.containersType;
       local containerPort = container.portsType;
 
       local targetPort = 8080;
 
       local operatorContainer =
         container.new('prometheus-operator', $._config.imageRepos.prometheusOperator + ':' + $._config.versions.prometheusOperator) +
-        container.withPorts(containerPort.newNamed('http', targetPort)) +
+        container.withPorts(containerPort.newNamed(targetPort, 'http')) +
         container.withArgs([
           '--kubelet-service=kube-system/kubelet',
           // Prometheus Operator is run with a read-only root file system. By
@@ -139,7 +139,6 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           '--prometheus-config-reloader=' + $._config.imageRepos.prometheusConfigReloader + ':' + $._config.versions.prometheusConfigReloader,
         ]) +
         container.mixin.securityContext.withAllowPrivilegeEscalation(false) +
-        container.mixin.securityContext.withReadOnlyRootFilesystem(true) +
         container.mixin.resources.withRequests({ cpu: '100m', memory: '100Mi' }) +
         container.mixin.resources.withLimits({ cpu: '200m', memory: '200Mi' });
 

--- a/scripts/generate-bundle.sh
+++ b/scripts/generate-bundle.sh
@@ -11,4 +11,4 @@ function concat() {
 }
 
 # shellcheck disable=SC2046
-concat $(find example/rbac/prometheus-operator -name '*.yaml' | sort | grep -v service-monitor) > bundle-new.yaml
+concat $(find example/rbac/prometheus-operator -name '*.yaml' | sort | grep -v service-monitor) > bundle.yaml

--- a/scripts/generate/prometheus-operator-non-rbac.jsonnet
+++ b/scripts/generate/prometheus-operator-non-rbac.jsonnet
@@ -1,6 +1,6 @@
 local po = (import 'prometheus-operator/prometheus-operator.libsonnet').prometheusOperator;
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
-local deployment = k.apps.v1beta2.deployment;
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+local deployment = k.apps.v1.deployment;
 
 po.deployment +
 deployment.mixin.spec.template.spec.withServiceAccountName('')


### PR DESCRIPTION
I'm not exactly sure why, I went down to re-generating ksonnet.4 but for some reason `withReadOnlyRootFilesystem` is not available anymore. In order to move forward I removed it for now.

@paulfantom @squat @metalmatze @s-urbaniak 