### PR TITLE
pkg/alertmanager: increase terminationGracePeriod to 120

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -442,7 +442,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 		resources.Limits[v1.ResourceMemory] = resource.MustParse(config.ConfigReloaderMemory)
 	}
 
-	terminationGracePeriod := int64(0)
+	terminationGracePeriod := int64(120)
 	finalLabels := config.Labels.Merge(podLabels)
 	return &appsv1.StatefulSetSpec{
 		ServiceName: governingServiceName,


### PR DESCRIPTION
Increase terminationGracePeriod to 120 seconds as it cannot be 0. More in statefulSet docs: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#deployment-and-scaling-guarantees

[Bug was discovered in openshift](https://bugzilla.redhat.com/show_bug.cgi?id=1721922) when trying to apply taints and tolerations and alertmanager pods spec weren't updated with config from statefulset spec.

/cc @brancz @s-urbaniak 