### PR TITLE
Adjust thanos-sidecar doc

### DIFF
--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -54,14 +54,10 @@ kubectl -n monitoring create secret generic thanos-objstore-config --from-file=t
 ### Prometheus Custom Resource with Thanos Sidecar
 
 The `Prometheus` CRD has support for adding a Thanos sidecar to the Prometheus
-Pod. To enable the sidecar, reference the following examples. These examples
-assume that the Thanos components have been configured to use the
-`thanos-peers.monitoring.svc:10900` service for querier peers to connect to,
-which is important for getting high availability to work with Thanos.
+Pod. To enable the sidecar, reference the following examples.
 
 This is the simplest configuration change that needs to be made to your
-Prometheus Custom Resource, after creating the secret, and is the only configuration needed to
-provide high availability benefits.
+Prometheus Custom Resource, after creating the secret.
 
 ```
 ...
@@ -70,7 +66,6 @@ spec:
   thanos:
     baseImage: improbable/thanos
     version: v0.2.1
-    peers: thanos-peers.monitoring.svc:10900
     objectStorageConfig:
       key: thanos.yaml
       name: thanos-objstore-config


### PR DESCRIPTION
according to https://github.com/coreos/prometheus-operator/pull/2629 `peers` has been removed due to deprecation.
Documentation needs to be updated accordingly, since other wise when someone specifies `peers` and a value for it, they will get an error similar to 
```ts=2019-07-10T13:09:21.386620549Z caller=main.go:292 msg="Unhandled error received. Exiting..." err="creating CRDs failed: waiting for Prometheus crd failed: timed out waiting for Custom Resource: failed to list CRD: v1.PrometheusList.Items: []*v1.Prometheus: v1.Prometheus.Spec: v1.PrometheusSpec.Thanos: v1.ThanosSpec.Resources: v1.ResourceRequirements.Requests: Limits: unmarshalerDecoder: unable to parse quantity's suffix, error found in #10 byte of ...|y\":\"768mi\"},\"request|..., bigger context ...|sources\":{\"limits\":{\"cpu\":\"1512m\",\"memory\":\"768mi\"},\"requests\":{\"cpu\":\"1024m\",\"memory\":\"512mi\"}},\"ve|..."```