### PR TITLE
refact check logic in namespaceSelector

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -863,7 +863,7 @@ func (cg *configGenerator) generateK8SSDConfig(namespaces []string, apiserverCon
 		},
 	}
 
-	if namespaces != nil {
+	if len(namespaces) != 0 {
 		k8sSDConfig = append(k8sSDConfig, yaml.MapItem{
 			Key: "namespaces",
 			Value: yaml.MapSlice{


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>
This function will return an empty slice if set namespaceSelector any=true.
``` Go
func getNamespacesFromServiceMonitor(m *v1.ServiceMonitor) []string {
	nsel := m.Spec.NamespaceSelector
	namespaces := []string{}
	if !nsel.Any && len(nsel.MatchNames) == 0 {
		namespaces = append(namespaces, m.Namespace)
	}
	if !nsel.Any && len(nsel.MatchNames) > 0 {
		for i := range nsel.MatchNames {
			namespaces = append(namespaces, nsel.MatchNames[i])
		}
	}
	return namespaces
}
```
Later when generate k8s sd config, it will check if this slice is nil, but empty slice is not nil. I change the nil check to check len() == 0. I think it will be more clear.
``` Go
if namespaces != nil {
		k8sSDConfig = append(k8sSDConfig, yaml.MapItem{
			Key: "namespaces",
			Value: yaml.MapSlice{
				{
					Key:   "names",
					Value: namespaces,
				},
			},
		})
	}
```