### PR TITLE
pkg/alertmanager: change podManagementPolicy to parallel to prevent statefulset reconciliation from hanging

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -444,9 +444,12 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 
 	terminationGracePeriod := int64(120)
 	finalLabels := config.Labels.Merge(podLabels)
+	// PodManagementPolicy is set to Parallel to mitigate issues in kuberentes: https://github.com/kubernetes/kubernetes/issues/60164
+	// This is also mentioned as one of limitations of StatefulSets: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations
 	return &appsv1.StatefulSetSpec{
-		ServiceName: governingServiceName,
-		Replicas:    a.Spec.Replicas,
+		ServiceName:         governingServiceName,
+		Replicas:            a.Spec.Replicas,
+		PodManagementPolicy: appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,
 		},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -798,7 +798,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to merge containers spec")
 	}
-
+	// PodManagementPolicy is set to Parallel to mitigate issues in kuberentes: https://github.com/kubernetes/kubernetes/issues/60164
+	// This is also mentioned as one of limitations of StatefulSets: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations
 	return &appsv1.StatefulSetSpec{
 		ServiceName:         governingServiceName,
 		Replicas:            p.Spec.Replicas,


### PR DESCRIPTION
When using default podManagementPolicy (`OrderedReady`) it is possible to create a
situation where alertmanager pod objects won't be reconciled with a
statefulset and thus preventing alertmanager from being deployed.

One of such cases is when alertmanager was deployed and afterwards admin
applied taints to all nodes causing pod eviction. Next tolerations were
applied however due to OrderedReady policy one alertmanager pod was still left in
Pending state preventing reconciliation.

While testing manually with `podManagementPolicy: Parallel` alertmanager pods were scheduled correctly.

We are already using `podManagementPolicy: Parallel` for prometheus statefulset (https://github.com/coreos/prometheus-operator/blob/master/pkg/prometheus/statefulset.go#L805), but this wasn't propagated to alertmanager for reasons unknown to me.


/cc @brancz @s-urbaniak 