### PR TITLE
feat: Change governing service port names to match istio standard

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -161,19 +161,19 @@ func makeStatefulSetService(p *monitoringv1.Alertmanager, config Config) *v1.Ser
 			ClusterIP: "None",
 			Ports: []v1.ServicePort{
 				{
-					Name:       "web",
+					Name:       "http",
 					Port:       9093,
 					TargetPort: intstr.FromInt(9093),
 					Protocol:   v1.ProtocolTCP,
 				},
 				{
-					Name:       "mesh-tcp",
+					Name:       "tcp-mesh",
 					Port:       9094,
 					TargetPort: intstr.FromInt(9094),
 					Protocol:   v1.ProtocolTCP,
 				},
 				{
-					Name:       "mesh-udp",
+					Name:       "udp-mesh",
 					Port:       9094,
 					TargetPort: intstr.FromInt(9094),
 					Protocol:   v1.ProtocolUDP,

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -276,7 +276,7 @@ func makeStatefulSetService(p *monitoringv1.Prometheus, config Config) *v1.Servi
 			ClusterIP: "None",
 			Ports: []v1.ServicePort{
 				{
-					Name:       "web",
+					Name:       "http",
 					Port:       9090,
 					TargetPort: intstr.FromString("web"),
 				},

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -198,7 +198,7 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 	}
 
 	proxyGet := framework.KubeClient.CoreV1().Services(ns).ProxyGet
-	request := proxyGet("", alertmanagerService.Name, "web", "/", make(map[string]string))
+	request := proxyGet("", alertmanagerService.Name, "http", "/", make(map[string]string))
 	_, err := request.DoRaw()
 	if err != nil {
 		t.Fatal(err)
@@ -448,7 +448,7 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 							Image: "quay.io/coreos/prometheus-alertmanager-test-webhook",
 							Ports: []v1.ContainerPort{
 								{
-									Name:          "web",
+									Name:          "http",
 									ContainerPort: 5001,
 								},
 							},
@@ -466,9 +466,9 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 			Type: v1.ServiceTypeClusterIP,
 			Ports: []v1.ServicePort{
 				{
-					Name:       "web",
+					Name:       "http",
 					Port:       5001,
-					TargetPort: intstr.FromString("web"),
+					TargetPort: intstr.FromString("http"),
 				},
 			},
 			Selector: map[string]string{

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1137,7 +1137,7 @@ func testPromExposingWithKubernetesAPI(t *testing.T) {
 	}
 
 	ProxyGet := framework.KubeClient.CoreV1().Services(ns).ProxyGet
-	request := ProxyGet("", service.Name, "web", "/metrics", make(map[string]string))
+	request := ProxyGet("", service.Name, "http", "/metrics", make(map[string]string))
 	_, err := request.DoRaw()
 	if err != nil {
 		t.Fatal(err)
@@ -1419,7 +1419,7 @@ func testPromGetBasicAuthSecret(t *testing.T) {
 			Type: v1.ServiceTypeLoadBalancer,
 			Ports: []v1.ServicePort{
 				v1.ServicePort{
-					Name: "web",
+					Name: "http",
 					Port: 8080,
 				},
 			},

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -71,9 +71,9 @@ func (f *Framework) MakeAlertmanagerService(name, group string, serviceType v1.S
 			Type: serviceType,
 			Ports: []v1.ServicePort{
 				{
-					Name:       "web",
+					Name:       "http",
 					Port:       9093,
-					TargetPort: intstr.FromString("web"),
+					TargetPort: intstr.FromString("http"),
 				},
 			},
 			Selector: map[string]string{

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -67,7 +67,7 @@ func (f *Framework) AddAlertingToPrometheus(p *monitoringv1.Prometheus, ns, name
 			{
 				Namespace: ns,
 				Name:      fmt.Sprintf("alertmanager-%s", name),
-				Port:      intstr.FromString("web"),
+				Port:      intstr.FromString("http"),
 			},
 		},
 	}
@@ -89,7 +89,7 @@ func (f *Framework) MakeBasicServiceMonitor(name string) *monitoringv1.ServiceMo
 			},
 			Endpoints: []monitoringv1.Endpoint{
 				{
-					Port:     "web",
+					Port:     "http",
 					Interval: "30s",
 				},
 			},
@@ -109,9 +109,9 @@ func (f *Framework) MakePrometheusService(name, group string, serviceType v1.Ser
 			Type: serviceType,
 			Ports: []v1.ServicePort{
 				{
-					Name:       "web",
+					Name:       "http",
 					Port:       9090,
-					TargetPort: intstr.FromString("web"),
+					TargetPort: intstr.FromString("http"),
 				},
 			},
 			Selector: map[string]string{
@@ -276,7 +276,7 @@ func (f *Framework) WaitForTargets(ns, svcName string, amount int) error {
 
 func (f *Framework) QueryPrometheusSVC(ns, svcName, endpoint string, query map[string]string) ([]byte, error) {
 	ProxyGet := f.KubeClient.CoreV1().Services(ns).ProxyGet
-	request := ProxyGet("", svcName, "web", endpoint, query)
+	request := ProxyGet("", svcName, "http", endpoint, query)
 	return request.DoRaw()
 }
 


### PR DESCRIPTION
Istio requires that service port names follow a convention, and in particular that if two services point at the same pod (e.g. if a user makes a service with a ClusterIP in addition to the governing service) that the name's have the same protocol. By not changing the pod port name this preserves backwards compatibility with existing users services

Fixes https://github.com/coreos/prometheus-operator/issues/2401