### PR TITLE
scripts: Bump minikube version

### DIFF
--- a/scripts/create-minikube.sh
+++ b/scripts/create-minikube.sh
@@ -8,7 +8,7 @@ set -u
 # print each command before executing it
 set -x
 
-export MINIKUBE_VERSION=v0.35.0
+export MINIKUBE_VERSION=v1.2.0
 export KUBERNETES_VERSION=v1.13.4
 
 sudo mount --make-rshared /


### PR DESCRIPTION
All the tests are failing, as suggested in https://github.com/coreos/prometheus-operator/pull/2684#issuecomment-514260866 bumping minikube version should do the trick.