### PR TITLE
add flag watch interval for prometheus config reloader

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -133,6 +133,7 @@ func init() {
 	// the Prometheus Operator version if no Prometheus config reloader image is
 	// specified.
 	flagset.StringVar(&cfg.PrometheusConfigReloaderImage, "prometheus-config-reloader", fmt.Sprintf("quay.io/coreos/prometheus-config-reloader:v%v", version.Version), "Prometheus config reloader image")
+	flagset.StringVar(&cfg.PrometheusConfigReloaderWatchInterval, "prometheus-config-reloader-interval", "3m", "Prometheus config file watch interval")
 	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "quay.io/coreos/configmap-reload:v0.0.1", "Reload Image")
 	flagset.StringVar(&cfg.ConfigReloaderCPU, "config-reloader-cpu", "100m", "Config Reloader CPU. Value \"0\" disables it and causes no limit to be configured.")
 	flagset.StringVar(&cfg.ConfigReloaderMemory, "config-reloader-memory", "25Mi", "Config Reloader Memory. Value \"0\" disables it and causes no limit to be configured.")

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -51,6 +51,9 @@ func main() {
 	cfgSubstFile := app.Flag("config-envsubst-file", "output file for environment variable substituted config file").
 		String()
 
+	cfgFileWatchInterval := app.Flag("config-file-watch-interval", "time interval for watching config file changes").
+		Default("3m").Duration()
+
 	createStatefulsetOrdinalFrom := app.Flag(
 		"statefulset-ordinal-from-envvar",
 		fmt.Sprintf("parse this environment variable to create %s, containing the statefulset ordinal number", statefulsetOrdinalEnvvar)).
@@ -88,6 +91,7 @@ func main() {
 	{
 		ctx, cancel := context.WithCancel(context.Background())
 		rel := reloader.New(logger, *reloadURL, *cfgFile, *cfgSubstFile, []string{})
+		rel.WithWatchInterval(*cfgFileWatchInterval)
 
 		g.Add(func() error {
 			return rel.Watch(ctx)

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -133,28 +133,29 @@ func (labels *Labels) Set(value string) error {
 
 // Config defines configuration parameters for the Operator.
 type Config struct {
-	Host                          string
-	KubeletObject                 string
-	TLSInsecure                   bool
-	TLSConfig                     rest.TLSClientConfig
-	ConfigReloaderImage           string
-	ConfigReloaderCPU             string
-	ConfigReloaderMemory          string
-	PrometheusConfigReloaderImage string
-	AlertmanagerDefaultBaseImage  string
-	PrometheusDefaultBaseImage    string
-	ThanosDefaultBaseImage        string
-	Namespaces                    []string
-	Labels                        Labels
-	CrdGroup                      string
-	CrdKinds                      monitoringv1.CrdKinds
-	EnableValidation              bool
-	LocalHost                     string
-	LogLevel                      string
-	LogFormat                     string
-	ManageCRDs                    bool
-	PromSelector                  string
-	AlertManagerSelector          string
+	Host                                  string
+	KubeletObject                         string
+	TLSInsecure                           bool
+	TLSConfig                             rest.TLSClientConfig
+	ConfigReloaderImage                   string
+	ConfigReloaderCPU                     string
+	ConfigReloaderMemory                  string
+	PrometheusConfigReloaderImage         string
+	PrometheusConfigReloaderWatchInterval string
+	AlertmanagerDefaultBaseImage          string
+	PrometheusDefaultBaseImage            string
+	ThanosDefaultBaseImage                string
+	Namespaces                            []string
+	Labels                                Labels
+	CrdGroup                              string
+	CrdKinds                              monitoringv1.CrdKinds
+	EnableValidation                      bool
+	LocalHost                             string
+	LogLevel                              string
+	LogFormat                             string
+	ManageCRDs                            bool
+	PromSelector                          string
+	AlertManagerSelector                  string
 }
 
 type BasicAuthCredentials struct {

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -570,6 +570,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 		fmt.Sprintf("--reload-url=%s", localReloadURL),
 		fmt.Sprintf("--config-file=%s", path.Join(confDir, configFilename)),
 		fmt.Sprintf("--config-envsubst-file=%s", path.Join(confOutDir, configEnvsubstFilename)),
+		fmt.Sprintf("--config-file-watch-interval=%s", c.PrometheusConfigReloaderWatchInterval),
 	}
 
 	var livenessProbeHandler v1.Handler


### PR DESCRIPTION
The original logic for watching config file changes is via a regular [ticker and fsnotify watcher](https://github.com/coreos/prometheus-operator/blob/master/vendor/github.com/improbable-eng/thanos/pkg/reloader/reloader.go#L164-L165). I oberseved a long waiting time for reloader being triggered (might up to 2 min)

It would be better if we can customize the time interval of ticker to allow more frequent cfg file re-reading, since now it defaults to [3 min](https://github.com/coreos/prometheus-operator/blob/master/vendor/github.com/improbable-eng/thanos/pkg/reloader/reloader.go#L108).

Signed-off-by: huanggze <loganhuang@yunify.com>