### PR TITLE
*: support --deny-namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-kit/kit v0.8.0
 	github.com/go-openapi/spec v0.17.2
+	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.1
 	github.com/googleapis/gnostic v0.1.0 // indirect
 	github.com/hashicorp/go-version v1.1.0

--- a/pkg/listwatch/listwatch_test.go
+++ b/pkg/listwatch/listwatch_test.go
@@ -122,12 +122,13 @@ func TestMultiWatchStop(t *testing.T) {
 }
 
 type mockListerWatcher struct {
-	evCh    chan watch.Event
-	stopped bool
+	listResult runtime.Object
+	evCh       chan watch.Event
+	stopped    bool
 }
 
 func (m *mockListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
-	return nil, nil
+	return m.listResult, nil
 }
 
 func (m *mockListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {

--- a/pkg/listwatch/namespace_denylist.go
+++ b/pkg/listwatch/namespace_denylist.go
@@ -1,0 +1,181 @@
+// Copyright 2019 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package listwatch
+
+import (
+	"fmt"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+// denylistListerWatcher implements cache.ListerWatcher
+// which wraps a cache.ListerWatcher,
+// filtering list results and watch events by denied namespaces.
+type denylistListerWatcher struct {
+	denylist map[string]struct{}
+	next     cache.ListerWatcher
+	logger   log.Logger
+}
+
+// newDenylistListerWatcher creates a cache.ListerWatcher
+// wrapping the given next cache.ListerWatcher
+// filtering lists and watch events by the given namespaces.
+func newDenylistListerWatcher(l log.Logger, namespaces []string, next cache.ListerWatcher) cache.ListerWatcher {
+	denylist := make(map[string]struct{})
+
+	for _, ns := range namespaces {
+		denylist[ns] = struct{}{}
+	}
+
+	return &denylistListerWatcher{
+		denylist: denylist,
+		next:     next,
+		logger:   l,
+	}
+}
+
+// List lists the wrapped next listerwatcher List result,
+// but filtering denied namespaces from the result.
+func (w *denylistListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
+	var (
+		l     = metav1.List{}
+		error = level.Error(w.logger)
+		debug = level.Debug(w.logger)
+	)
+
+	list, err := w.next.List(options)
+	if err != nil {
+		error.Log("msg", "error listing", "err", err)
+		return nil, err
+	}
+
+	objs, err := meta.ExtractList(list)
+	if err != nil {
+		error.Log("msg", "error extracting list", "err", err)
+		return nil, err
+	}
+
+	metaObj, err := meta.ListAccessor(list)
+	if err != nil {
+		error.Log("msg", "error getting list accessor", "err", err)
+		return nil, err
+	}
+
+	for _, obj := range objs {
+		acc, err := meta.Accessor(obj)
+		if err != nil {
+			error.Log("msg", "error getting meta accessor accessor", "obj", fmt.Sprintf("%v", obj), "err", err)
+			return nil, err
+		}
+
+		debugDetailed := log.With(debug, "selflink", acc.GetSelfLink())
+
+		if _, denied := w.denylist[acc.GetNamespace()]; denied {
+			debugDetailed.Log("msg", "denied")
+			continue
+		}
+
+		debugDetailed.Log("msg", "allowed")
+
+		l.Items = append(l.Items, runtime.RawExtension{Object: obj.DeepCopyObject()})
+	}
+
+	l.ListMeta.ResourceVersion = metaObj.GetResourceVersion()
+	return &l, nil
+}
+
+// Watch
+func (w *denylistListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	nextWatch, err := w.next.Watch(options)
+	if err != nil {
+		return nil, err
+	}
+
+	return newDenylistWatch(w.logger, w.denylist, nextWatch), nil
+}
+
+// newDenylistWatch creates a new watch.Interface,
+// wrapping the given next watcher,
+// and filtering watch events by the given namespaces.
+//
+// It starts a new goroutine until either
+// a) the result channel of the wrapped next watcher is closed, or
+// b) Stop() was invoked on the returned watcher.
+func newDenylistWatch(l log.Logger, denylist map[string]struct{}, next watch.Interface) watch.Interface {
+	var (
+		result  = make(chan watch.Event)
+		proxy   = watch.NewProxyWatcher(result)
+		debug   = level.Debug(l)
+		warning = level.Warn(l)
+	)
+
+	go func() {
+		defer func() {
+			debug.Log("msg", "stopped denylist watcher")
+			// According to watch.Interface the result channel is supposed to be called
+			// in case of error or if the listwach is closed, see [1].
+			//
+			// [1] https://github.com/kubernetes/apimachinery/blob/533d101be9a6450773bb2829bef282b6b7c4ff6d/pkg/watch/watch.go#L34-L37
+			close(result)
+		}()
+
+		for {
+			select {
+			case event, ok := <-next.ResultChan():
+				if !ok {
+					debug.Log("msg", "result channel closed")
+					return
+				}
+
+				acc, err := meta.Accessor(event.Object)
+				if err != nil {
+					// ignore this event, it doesn't implement the Object interfaces,
+					// hence we cannot determine its namespace.
+					warning.Log("msg", fmt.Sprintf("unexpected object type in event (%T): %v", event.Object, event.Object))
+					continue
+				}
+
+				debugDetailed := log.With(debug, "selflink", acc.GetSelfLink())
+
+				if _, denied := denylist[acc.GetNamespace()]; denied {
+					debugDetailed.Log("msg", "denied")
+					continue
+				}
+
+				debugDetailed.Log("msg", "allowed")
+
+				select {
+				case result <- event:
+					debugDetailed.Log("msg", "dispatched")
+				case <-proxy.StopChan():
+					next.Stop()
+					return
+				}
+			case <-proxy.StopChan():
+				next.Stop()
+				return
+			}
+		}
+	}()
+
+	return proxy
+}

--- a/pkg/listwatch/namespace_denylist_test.go
+++ b/pkg/listwatch/namespace_denylist_test.go
@@ -1,0 +1,189 @@
+// Copyright 2019 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package listwatch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestDenylistList(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	cases := []struct {
+		name                   string
+		listed, denylist, want []string
+	}{
+		{
+			name:     "one entry",
+			listed:   []string{"monitoring", "default", "kube-system"},
+			denylist: []string{"monitoring"},
+			want:     []string{"default", "kube-system"},
+		},
+		{
+			name:     "multiple entries",
+			listed:   []string{"monitoring", "default", "kube-system"},
+			denylist: []string{"monitoring", "kube-system"},
+			want:     []string{"default"},
+		},
+		{
+			name:   "no entries",
+			listed: []string{"monitoring", "default", "kube-system"},
+			want:   []string{"monitoring", "default", "kube-system"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := metav1.List{}
+			for _, listed := range tc.listed {
+				l.Items = append(l.Items, runtime.RawExtension{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": listed,
+								"name":      "foo",
+							},
+						},
+					},
+				})
+			}
+			mock := &mockListerWatcher{
+				listResult: &l,
+			}
+
+			lw := newDenylistListerWatcher(logger, tc.denylist, mock)
+			result, err := lw.List(metav1.ListOptions{})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			objs, err := meta.ExtractList(result)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			var got []string
+			for _, obj := range objs {
+				acc, err := meta.Accessor(obj)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				got = append(got, acc.GetNamespace())
+			}
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("want listed namespaces to be %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestDenylistWatch(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	cases := []struct {
+		name                    string
+		watched, denylist, want []string
+	}{
+		{
+			name:     "one entry",
+			watched:  []string{"monitoring", "default", "kube-system"},
+			denylist: []string{"monitoring"},
+			want:     []string{"default", "kube-system"},
+		},
+		{
+			name:     "multiple entries",
+			watched:  []string{"monitoring", "kube-system", "default"},
+			denylist: []string{"monitoring", "kube-system"},
+			want:     []string{"default"},
+		},
+		{
+			name:     "denylist contains empty string",
+			watched:  []string{"default", "kube-system"},
+			denylist: []string{""},
+			want:     []string{"default", "kube-system"},
+		},
+		{
+			name:     "empty denylist",
+			watched:  []string{"default", "kube-system"},
+			denylist: []string{},
+			want:     []string{"default", "kube-system"},
+		},
+		{
+			name:    "nil denylist",
+			watched: []string{"default", "kube-system"},
+			want:    []string{"default", "kube-system"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			events := make(chan watch.Event, len(tc.watched))
+			for _, w := range tc.watched {
+				events <- watch.Event{
+					Type: "foo",
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": w,
+								"name":      "foo",
+							},
+						},
+					},
+				}
+			}
+			close(events)
+			mock := &mockListerWatcher{
+				evCh: events,
+			}
+			lw := newDenylistListerWatcher(logger, tc.denylist, mock)
+			w, err := lw.Watch(metav1.ListOptions{})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			for i := 0; i < len(tc.want); i++ {
+				evt := <-w.ResultChan()
+				acc, err := meta.Accessor(evt.Object)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				if got := acc.GetNamespace(); got != tc.want[i] {
+					t.Errorf("want namespace %v, evt %v", tc.want[i], got)
+				}
+			}
+
+			if evt, open := <-events; open {
+				t.Errorf("expected all events to be processed, but they aren't: %v", evt.Object)
+			}
+		})
+	}
+}

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -1,0 +1,178 @@
+// Copyright 2019 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+
+	testFramework "github.com/coreos/prometheus-operator/test/framework"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testDenyPrometheus(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+
+	operatorNamespace := ctx.CreateNamespace(t, framework.KubeClient)
+	allowedNamespaces := []string{ctx.CreateNamespace(t, framework.KubeClient), ctx.CreateNamespace(t, framework.KubeClient)}
+	deniedNamespaces := []string{ctx.CreateNamespace(t, framework.KubeClient), ctx.CreateNamespace(t, framework.KubeClient)}
+
+	ctx.SetupPrometheusRBAC(t, operatorNamespace, framework.KubeClient)
+
+	_, err := framework.CreatePrometheusOperator(operatorNamespace, *opImage, nil, deniedNamespaces, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, denied := range deniedNamespaces {
+		ctx.SetupPrometheusRBAC(t, denied, framework.KubeClient)
+		p := framework.MakeBasicPrometheus(denied, "denied", "denied", 1)
+		_, err = framework.MonClientV1.Prometheuses(denied).Create(p)
+		if err != nil {
+			t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
+		}
+	}
+
+	for _, allowed := range allowedNamespaces {
+		ctx.SetupPrometheusRBAC(t, allowed, framework.KubeClient)
+		p := framework.MakeBasicPrometheus(allowed, "allowed", "allowed", 1)
+		p, err = framework.CreatePrometheusAndWaitUntilReady(allowed, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, denied := range deniedNamespaces {
+		// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
+		// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
+		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get("prometheus-denied", metav1.GetOptions{})
+		if !api_errors.IsNotFound(err) {
+			t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
+		}
+	}
+}
+
+func testDenyServiceMonitor(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+
+	operatorNamespace := ctx.CreateNamespace(t, framework.KubeClient)
+	allowedNamespaces := []string{ctx.CreateNamespace(t, framework.KubeClient), ctx.CreateNamespace(t, framework.KubeClient)}
+	deniedNamespaces := []string{ctx.CreateNamespace(t, framework.KubeClient), ctx.CreateNamespace(t, framework.KubeClient)}
+
+	ctx.SetupPrometheusRBAC(t, operatorNamespace, framework.KubeClient)
+
+	_, err := framework.CreatePrometheusOperator(operatorNamespace, *opImage, nil, deniedNamespaces, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, denied := range deniedNamespaces {
+		echo := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ehoserver",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: proto.Int32(1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"prometheus": "denied",
+					},
+				},
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"prometheus": "denied",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "echoserver",
+								Image: "k8s.gcr.io/echoserver:1.10",
+								Ports: []v1.ContainerPort{
+									{
+										Name:          "web",
+										ContainerPort: 8443,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if err := testFramework.CreateDeployment(framework.KubeClient, denied, echo); err != nil {
+			t.Fatal(err)
+		}
+
+		svc := framework.MakePrometheusService("denied", "denied", v1.ServiceTypeClusterIP)
+		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, denied, svc); err != nil {
+			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		} else {
+			ctx.AddFinalizerFn(finalizerFn)
+		}
+
+		// create the service monitor in a way, that it matches the label selector used in the allowed namespace.
+		s := framework.MakeBasicServiceMonitor("allowed")
+		if _, err := framework.MonClientV1.ServiceMonitors(denied).Create(s); err != nil {
+			t.Fatal("Creating ServiceMonitor failed: ", err)
+		}
+	}
+
+	for _, allowed := range allowedNamespaces {
+		ctx.SetupPrometheusRBAC(t, allowed, framework.KubeClient)
+		p := framework.MakeBasicPrometheus(allowed, "allowed", "allowed", 1)
+		p, err = framework.CreatePrometheusAndWaitUntilReady(allowed, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		svc := framework.MakePrometheusService("allowed", "allowed", v1.ServiceTypeClusterIP)
+		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, allowed, svc); err != nil {
+			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		} else {
+			ctx.AddFinalizerFn(finalizerFn)
+		}
+
+		s := framework.MakeBasicServiceMonitor("allowed")
+		if _, err := framework.MonClientV1.ServiceMonitors(allowed).Create(s); err != nil {
+			t.Fatal("Creating ServiceMonitor failed: ", err)
+		}
+
+		if err := framework.WaitForTargets(allowed, svc.Name, 1); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// just iterate again, so we have a chance to catch a faulty reconciliation of denied namespaces.
+	for _, allowed := range allowedNamespaces {
+		targets, err := framework.GetActiveTargets(allowed, "prometheus-allowed")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got := len(targets); got > 1 {
+			t.Fatalf("expected to have 1 target, got %d", got)
+		}
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -67,7 +67,7 @@ func TestAllNS(t *testing.T) {
 
 	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
-	finalizers, err := framework.CreatePrometheusOperator(ns, *opImage, nil, true)
+	finalizers, err := framework.CreatePrometheusOperator(ns, *opImage, nil, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,6 +163,18 @@ func testAllNS(t *testing.T) {
 func TestMultiNS(t *testing.T) {
 	testFuncs := map[string]func(t *testing.T){
 		"OperatorNSScope": testOperatorNSScope,
+	}
+
+	for name, f := range testFuncs {
+		t.Run(name, f)
+	}
+}
+
+// TestDenylist tests the Prometheus Operator configured not to watch specific namespaces.
+func TestDenylist(t *testing.T) {
+	testFuncs := map[string]func(t *testing.T){
+		"Prometheus":     testDenyPrometheus,
+		"ServiceMonitor": testDenyServiceMonitor,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1492,7 +1492,7 @@ func testOperatorNSScope(t *testing.T) {
 		}
 
 		// Prometheus Operator only watches single namespace mainNS, not arbitraryNS.
-		_, err := framework.CreatePrometheusOperator(operatorNS, *opImage, []string{mainNS}, false)
+		_, err := framework.CreatePrometheusOperator(operatorNS, *opImage, []string{mainNS}, nil, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1562,7 +1562,7 @@ func testOperatorNSScope(t *testing.T) {
 		}
 
 		// Prometheus Operator only watches prometheusNS and ruleNS, not arbitraryNS.
-		_, err := framework.CreatePrometheusOperator(operatorNS, *opImage, []string{prometheusNS, ruleNS}, false)
+		_, err := framework.CreatePrometheusOperator(operatorNS, *opImage, []string{prometheusNS, ruleNS}, nil, false)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Currently, it is possible to explicitly watch for namespaces with the --namespaces option.
If unset, all namespaces are being watched.

The reverse is not possible today, namely exclude (deny) namespaces from being watched.
This fixes it by introducing the --deny-namespaces option.
It is mutually exclusive with --namespaces.

cc @brancz @metalmatze @LiliC @paulfantom @squat