### PR TITLE
thanos: expose metrics endpoint

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -710,6 +710,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 				fmt.Sprintf("--prometheus.url=http://%s:9090%s", c.LocalHost, path.Clean(webRoutePrefix)),
 				fmt.Sprintf("--tsdb.path=%s", storageDir),
 				"--grpc-address=[$(POD_IP)]:10901",
+				"--http-address=[$(POD_IP)]:10902",
 			},
 			Env: []v1.EnvVar{
 				{


### PR DESCRIPTION
Whilst the service port is created by default, the metrics endpoint for the sidecar is never started.
