### PR TITLE
pkg/listwatch: fix listwatch wrapping regression

### DIFF
--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -59,8 +59,8 @@ func NewUnprivilegedNamespaceListWatchFromClient(l log.Logger, c cache.Getter, a
 //
 // The given allowed and denied namespaces are mutually exclusive.
 // If allowed namespaces contain multiple items, the given denied namespaces have no effect.
-// If the allowed namespaces includes one entry with the value v1.NamespaceAll (empty string),
-// the given denied namespaces are being applied.
+// If the allowed namespaces includes exactly one entry with the value v1.NamespaceAll (empty string),
+// the given denied namespaces are applied.
 func NewFilteredUnprivilegedNamespaceListWatchFromClient(l log.Logger, c cache.Getter, allowedNamespaces, deniedNamespaces []string, optionsModifier func(options *metav1.ListOptions)) cache.ListerWatcher {
 	// If the only namespace given is `v1.NamespaceAll`, then this
 	// cache.ListWatch must be privileged. In this case, return a regular
@@ -106,8 +106,8 @@ func NewFilteredUnprivilegedNamespaceListWatchFromClient(l log.Logger, c cache.G
 //
 // Allowed namespaces and denied namespaces are mutually exclusive.
 // If allowed namespaces contain multiple items, the given denied namespaces have no effect.
-// If the allowed namespaces includes one entry with the value v1.NamespaceAll (empty string),
-// the given denied namespaces are being applied.
+// If the allowed namespaces includes exactly one entry with the value v1.NamespaceAll (empty string),
+// the given denied namespaces are applied.
 func MultiNamespaceListerWatcher(l log.Logger, allowedNamespaces, deniedNamespaces []string, f func(string) cache.ListerWatcher) cache.ListerWatcher {
 	// If there is only one namespace then there is no need to create a
 	// multi lister watcher proxy.

--- a/pkg/listwatch/namespace_denylist.go
+++ b/pkg/listwatch/namespace_denylist.go
@@ -40,6 +40,10 @@ type denylistListerWatcher struct {
 // wrapping the given next cache.ListerWatcher
 // filtering lists and watch events by the given namespaces.
 func newDenylistListerWatcher(l log.Logger, namespaces []string, next cache.ListerWatcher) cache.ListerWatcher {
+	if len(namespaces) == 0 {
+		return next
+	}
+
 	denylist := make(map[string]struct{})
 
 	for _, ns := range namespaces {


### PR DESCRIPTION
Whenever a multi-listwatch contains only one listwatch, it
would simply use the underlying listwatch without any wrapper. This
improves performance and eliminates unnecessary go routines. This commit
fixes a regression [0] where a denylist-listwatch would wrap underlying
listwatches even if the denylist was empty.

[0] https://github.com/coreos/prometheus-operator/pull/2710/files#diff-b33bee110e95fb2f22d9da56b1630d89R68-R74

cc @s-urbaniak @brancz @LiliC @metalmatze 