### PR TITLE
pkg/listwatch: ensure namespace objects are denied

### DIFF
--- a/pkg/listwatch/namespace_denylist.go
+++ b/pkg/listwatch/namespace_denylist.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -89,7 +90,7 @@ func (w *denylistListerWatcher) List(options metav1.ListOptions) (runtime.Object
 
 		debugDetailed := log.With(debug, "selflink", acc.GetSelfLink())
 
-		if _, denied := w.denylist[acc.GetNamespace()]; denied {
+		if _, denied := w.denylist[getNamespace(acc)]; denied {
 			debugDetailed.Log("msg", "denied")
 			continue
 		}
@@ -148,15 +149,14 @@ func newDenylistWatch(l log.Logger, denylist map[string]struct{}, next watch.Int
 
 				acc, err := meta.Accessor(event.Object)
 				if err != nil {
-					// ignore this event, it doesn't implement the Object interfaces,
+					// ignore this event, it doesn't implement the metav1.Object interface,
 					// hence we cannot determine its namespace.
 					warning.Log("msg", fmt.Sprintf("unexpected object type in event (%T): %v", event.Object, event.Object))
 					continue
 				}
 
 				debugDetailed := log.With(debug, "selflink", acc.GetSelfLink())
-
-				if _, denied := denylist[acc.GetNamespace()]; denied {
+				if _, denied := denylist[getNamespace(acc)]; denied {
 					debugDetailed.Log("msg", "denied")
 					continue
 				}
@@ -178,4 +178,14 @@ func newDenylistWatch(l log.Logger, denylist map[string]struct{}, next watch.Int
 	}()
 
 	return proxy
+}
+
+// getNamespace returns the namespace of the given object.
+// If the object is itself a namespace, it returns the object's
+// name.
+func getNamespace(obj metav1.Object) string {
+	if _, ok := obj.(*v1.Namespace); ok {
+		return obj.GetName()
+	}
+	return obj.GetNamespace()
 }


### PR DESCRIPTION
The original implementation of the denylist-listwatch does not properly
filter out namespace objects as they are not namespaced. Nevertheless,
the denylist-listwatch is applied to the multi-namespace listwatch. This
means that changes to blacklisted namespaces would be handled by
unsuspecting informers.

This commit ensures that namespaces are correctly filtered.

cc @s-urbaniak @brancz @LiliC @metalmatze 