### PR TITLE
do not close stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,7 @@ daysUntilStale: 60
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-# daysUntilClose: 7
+daysUntilClose: false
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []


### PR DESCRIPTION
Accidentally  we didn't disable this feature and stale bot closed a lot of issues after default 7 days of inactivity. Issues were manually reopened and this PR prevents such thing from happening again

/cc @LiliC 