### PR TITLE
pkg/prometheus: add Thanos service port to governing service

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -301,6 +301,15 @@ func makeStatefulSetService(p *monitoringv1.Prometheus, config Config) *v1.Servi
 			},
 		},
 	}
+
+	if p.Spec.Thanos != nil {
+		svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{
+			Name:       "grpc",
+			Port:       10901,
+			TargetPort: intstr.FromString("grpc"),
+		})
+	}
+
 	return svc
 }
 

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1288,11 +1288,6 @@ func testThanos(t *testing.T) {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
-	sidecarSvc := framework.MakeThanosSidecarService(prom.Name)
-	if _, err := framework.KubeClient.CoreV1().Services(ns).Create(sidecarSvc); err != nil {
-		t.Fatal("Creating thanos sidecar service failed: ", err)
-	}
-
 	qryDep, err := testFramework.MakeDeployment("../../example/thanos/query-deployment.yaml")
 	if err != nil {
 		t.Fatal("Making thanos query deployment failed: ", err)
@@ -1306,7 +1301,7 @@ func testThanos(t *testing.T) {
 		"query",
 		"--log.level=debug",
 		"--query.replica-label=prometheus_replica",
-		fmt.Sprintf("--store=dnssrv+_grpc._tcp.%s.%s.svc.cluster.local", sidecarSvc.Name, ns),
+		fmt.Sprintf("--store=dnssrv+_grpc._tcp.prometheus-operated.%s.svc.cluster.local", ns),
 	}
 	t.Log("setting up query with args: ", qryArgs)
 	qryDep.Spec.Template.Spec.Containers[0].Args = qryArgs

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -143,28 +143,6 @@ func (f *Framework) MakeThanosQuerierService(name string) *v1.Service {
 	return service
 }
 
-func (f *Framework) MakeThanosSidecarService(name string) *v1.Service {
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("thanos-sidecar-%s", name),
-		},
-		Spec: v1.ServiceSpec{
-			ClusterIP: "None",
-			Ports: []v1.ServicePort{
-				{
-					Name:       "grpc",
-					Port:       10901,
-					TargetPort: intstr.FromString("grpc"),
-				},
-			},
-			Selector: map[string]string{
-				"prometheus": name,
-			},
-		},
-	}
-	return service
-}
-
 func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *monitoringv1.Prometheus) (*monitoringv1.Prometheus, error) {
 	result, err := f.MonClientV1.Prometheuses(ns).Create(p)
 	if err != nil {


### PR DESCRIPTION
Currently, for service discovery of Prometheus instances a separate headless service must be deployed.

This adds the Thanos grpc port to the existing Prometheus statefulset governing service if a Thanos sidecar is given in the Prometheus custom resource specification.

This way no additional service has to be deployed.

/cc @metalmatze @brancz @bwplotka @paulfantom 