### PR TITLE
prometheus-config-reloader: Remove unneeded Ownership change

### DIFF
--- a/cmd/prometheus-config-reloader/Dockerfile
+++ b/cmd/prometheus-config-reloader/Dockerfile
@@ -2,8 +2,6 @@ FROM quay.io/prometheus/busybox:latest
 
 ADD prometheus-config-reloader /bin/prometheus-config-reloader
 
-RUN chown nobody:nogroup /bin/prometheus-config-reloader
-
 USER nobody
 
 ENTRYPOINT ["/bin/prometheus-config-reloader"]


### PR DESCRIPTION
As far as I can see, changing the ownership of the p-c-m binary should be unnessecary.
Droping the chown removes a potential attack vector as a non-privileged user
might be able alter content of the binary during runtime.