### PR TITLE
cmd/operator: add [prometheus,alertmanager]-instance-namespaces cmdline parameter

### DIFF
--- a/test/e2e/alertmanager_instance_namespaces_test.go
+++ b/test/e2e/alertmanager_instance_namespaces_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testAlertmanagerInstanceNamespaces_AllNs(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+
+	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
+	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
+	nonInstanceNs := ctx.CreateNamespace(t, framework.KubeClient)
+	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+
+	_, err := framework.CreatePrometheusOperator(operatorNs, *opImage, nil, nil, nil, []string{instanceNs}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	am := framework.MakeBasicAlertmanager("non-instance", 3)
+	am.Namespace = nonInstanceNs
+	_, err = framework.MonClientV1.Alertmanagers(nonInstanceNs).Create(am)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	am = framework.MakeBasicAlertmanager("instance", 3)
+	am.Namespace = instanceNs
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(instanceNs, am); err != nil {
+		t.Fatal(err)
+	}
+
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get("alertmanager-instance", metav1.GetOptions{})
+	if !api_errors.IsNotFound(err) {
+		t.Fatalf("expected not to find an Alertmanager statefulset, but did: %v/%v", sts.Namespace, sts.Name)
+	}
+}
+
+func testAlertmanagerInstanceNamespaces_DenyNs(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+
+	// create two namespaces:
+	//
+	// 1. "operator" ns:
+	//   - hosts the prometheus operator deployment
+	//
+	// 2. "instance" ns:
+	//   - will be configured on prometheus operator as --alertmanager-instance-namespaces="instance"
+	//   - will additionally be configured on prometheus operator as --deny-namespaces="instance"
+	//   - hosts an alertmanager CR which must be reconciled.
+	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
+	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
+	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+
+	_, err := framework.CreatePrometheusOperator(operatorNs, *opImage, nil, []string{instanceNs}, nil, []string{instanceNs}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	am := framework.MakeBasicAlertmanager("instance", 3)
+	am.Namespace = instanceNs
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(instanceNs, am); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -37,7 +37,7 @@ func testDenyPrometheus(t *testing.T) {
 
 	ctx.SetupPrometheusRBAC(t, operatorNamespace, framework.KubeClient)
 
-	_, err := framework.CreatePrometheusOperator(operatorNamespace, *opImage, nil, deniedNamespaces, false)
+	_, err := framework.CreatePrometheusOperator(operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func testDenyServiceMonitor(t *testing.T) {
 
 	ctx.SetupPrometheusRBAC(t, operatorNamespace, framework.KubeClient)
 
-	_, err := framework.CreatePrometheusOperator(operatorNamespace, *opImage, nil, deniedNamespaces, false)
+	_, err := framework.CreatePrometheusOperator(operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -67,7 +67,7 @@ func TestAllNS(t *testing.T) {
 
 	ns := ctx.CreateNamespace(t, framework.KubeClient)
 
-	finalizers, err := framework.CreatePrometheusOperator(ns, *opImage, nil, nil, true)
+	finalizers, err := framework.CreatePrometheusOperator(ns, *opImage, nil, nil, nil, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,6 +175,31 @@ func TestDenylist(t *testing.T) {
 	testFuncs := map[string]func(t *testing.T){
 		"Prometheus":     testDenyPrometheus,
 		"ServiceMonitor": testDenyServiceMonitor,
+	}
+
+	for name, f := range testFuncs {
+		t.Run(name, f)
+	}
+}
+
+// TestPromInstanceNs tests prometheus operator in different scenarios when --prometheus-instance-namespace is given
+func TestPromInstanceNs(t *testing.T) {
+	testFuncs := map[string]func(t *testing.T){
+		"AllNs":     testPrometheusInstanceNamespaces_AllNs,
+		"AllowList": testPrometheusInstanceNamespaces_AllowList,
+		"DenyList":  testPrometheusInstanceNamespaces_DenyList,
+	}
+
+	for name, f := range testFuncs {
+		t.Run(name, f)
+	}
+}
+
+// TestAlertmanagerInstanceNs tests prometheus operator in different scenarios when --alertmanager-instance-namespace is given
+func TestAlertmanagerInstanceNs(t *testing.T) {
+	testFuncs := map[string]func(t *testing.T){
+		"AllNs":  testAlertmanagerInstanceNamespaces_AllNs,
+		"DenyNs": testAlertmanagerInstanceNamespaces_DenyNs,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -1,0 +1,315 @@
+// Copyright 2019 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	testFramework "github.com/coreos/prometheus-operator/test/framework"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testPrometheusInstanceNamespaces_AllNs(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+
+	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
+	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
+	nonInstanceNs := ctx.CreateNamespace(t, framework.KubeClient)
+	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+
+	_, err := framework.CreatePrometheusOperator(operatorNs, *opImage, nil, nil, []string{instanceNs}, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := framework.MakeBasicPrometheus(nonInstanceNs, "non-instance", "non-instance", 1)
+	_, err = framework.MonClientV1.Prometheuses(nonInstanceNs).Create(p)
+	if err != nil {
+		t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
+	}
+
+	p = framework.MakeBasicPrometheus(instanceNs, "instance", "instance", 1)
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(instanceNs, p); err != nil {
+		t.Fatal(err)
+	}
+
+	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
+	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get("prometheus-instance", metav1.GetOptions{})
+	if !api_errors.IsNotFound(err) {
+		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
+	}
+}
+
+func testPrometheusInstanceNamespaces_DenyList(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+
+	// create three namespaces:
+	//
+	// 1. "operator" ns:
+	//   - hosts the prometheus operator deployment
+	//
+	// 2. "instance" ns:
+	//   - will be configured on prometheus operator as --prometheus-instance-namespaces="instance"
+	//   - will additionally be configured on prometheus operator as --deny-namespaces="instance"
+	//   - hosts a service monitor CR which must NOT be reconciled.
+	//   - hosts a prometheus CR which must be reconciled.
+	//     This prometheus instance must pick up targets (service monitors)
+	//     in the "allowed" namespace.
+	//
+	// 3. "denied" ns:
+	//   - will be configured on prometheus operator as --deny-namespaces="denied"
+	//   - hosts a service monitor CR which must NOT be reconciled
+	//   - hosts a prometheus CR which must NOT be reconciled
+	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
+	deniedNs := ctx.CreateNamespace(t, framework.KubeClient)
+	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
+	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+
+	for _, ns := range []string{deniedNs, instanceNs} {
+		err := testFramework.AddLabelsToNamespace(framework.KubeClient, ns, map[string]string{
+			"monitored": "true",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := framework.CreatePrometheusOperator(operatorNs, *opImage, nil, []string{deniedNs, instanceNs}, []string{instanceNs}, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		// create Prometheus custom resources in "denied" namespaces.
+		// This must NOT be reconciled as the prometheus-instance-namespaces option points to somewhere else.
+		p := framework.MakeBasicPrometheus(deniedNs, "denied", "denied", 1)
+		_, err = framework.MonClientV1.Prometheuses(deniedNs).Create(p)
+		if err != nil {
+			t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
+		}
+
+		// create a simple echo server in the "denied" namespace,
+		// expose a service pointing to it,
+		// and create a service monitor pointing to that service.
+		// Wait, until that service appears as a target in the "instance" Prometheus.
+		echo := framework.MakeEchoDeployment("denied")
+
+		if err := testFramework.CreateDeployment(framework.KubeClient, deniedNs, echo); err != nil {
+			t.Fatal(err)
+		}
+
+		svc := framework.MakeEchoService("denied", "monitored", v1.ServiceTypeClusterIP)
+		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, deniedNs, svc); err != nil {
+			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		} else {
+			ctx.AddFinalizerFn(finalizerFn)
+		}
+
+		s := framework.MakeBasicServiceMonitor("monitored")
+		if _, err := framework.MonClientV1.ServiceMonitors(deniedNs).Create(s); err != nil {
+			t.Fatal("Creating ServiceMonitor failed: ", err)
+		}
+	}
+
+	// create Prometheus custom resource in the "instance" namespace.
+	// This one must be reconciled.
+	// Let this Prometheus custom resource match service monitors in namespaces having the label `"monitored": "true"`.
+	// This will match the service monitors created in the "denied" namespace.
+	// Also create a service monitor in this namespace. This one must not be reconciled.
+	// Expose the created Prometheus service.
+	{
+		p := framework.MakeBasicPrometheus(instanceNs, "instance", "instance", 1)
+
+		p.Spec.ServiceMonitorNamespaceSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"monitored": "true",
+			},
+		}
+
+		p.Spec.ServiceMonitorSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"group": "monitored",
+			},
+		}
+
+		s := framework.MakeBasicServiceMonitor("monitored")
+		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(s); err != nil {
+			t.Fatal("Creating ServiceMonitor failed: ", err)
+		}
+
+		// create the prometheus service and wait until it is ready
+		_, err := framework.CreatePrometheusAndWaitUntilReady(instanceNs, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
+		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, instanceNs, svc); err != nil {
+			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		} else {
+			ctx.AddFinalizerFn(finalizerFn)
+		}
+	}
+
+	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
+	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(deniedNs).Get("prometheus-instance", metav1.GetOptions{})
+	if !api_errors.IsNotFound(err) {
+		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
+	}
+
+	if err := framework.WaitForTargets(instanceNs, "prometheus-instance", 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testPrometheusInstanceNamespaces_AllowList(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+
+	// create three namespaces:
+	//
+	// 1. "operator" ns:
+	//   - hosts the prometheus operator deployment
+	//
+	// 2. "instance" ns:
+	//   - will be configured on prometheus operator as --prometheus-instance-namespaces="instance"
+	//   - hosts a service monitor CR which must NOT be reconciled.
+	//   - hosts a prometheus CR which must be reconciled.
+	//     This prometheus instance must pick up targets (service monitors)
+	//     in the "allowed" namespace.
+	//
+	// 3. "allowed" ns:
+	//   - will be configured on prometheus operator as --namespaces="allowed"
+	//   - hosts a service monitor CR which must be reconciled
+	//   - hosts a prometheus CR which must NOT be reconciled
+	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
+	allowedNs := ctx.CreateNamespace(t, framework.KubeClient)
+	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
+	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+
+	for _, ns := range []string{allowedNs, instanceNs} {
+		err := testFramework.AddLabelsToNamespace(framework.KubeClient, ns, map[string]string{
+			"monitored": "true",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := framework.CreatePrometheusOperator(operatorNs, *opImage, []string{allowedNs}, nil, []string{instanceNs}, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create Prometheus custom resources in "allowed" namespaces.
+	// This must NOT be reconciled as the prometheus-instance-namespaces option points to somewhere else.
+	p := framework.MakeBasicPrometheus(allowedNs, "allowed", "allowed", 1)
+	_, err = framework.MonClientV1.Prometheuses(allowedNs).Create(p)
+	if err != nil {
+		t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
+	}
+
+	// create Prometheus custom resource in the "instance" namespace.
+	// This one must be reconciled.
+	// Let this Prometheus custom resource match service monitors in namespaces having the label `"monitored": "true"`.
+	// This will match the service monitors created in the "allowed" namespace.
+	// Also create a service monitor in this namespace. This one must not be reconciled.
+	// Expose the created Prometheus service.
+	{
+		p = framework.MakeBasicPrometheus(instanceNs, "instance", "instance", 1)
+
+		p.Spec.ServiceMonitorNamespaceSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"monitored": "true",
+			},
+		}
+
+		p.Spec.ServiceMonitorSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"group": "monitored",
+			},
+		}
+
+		// create the prometheus service and wait until it is ready
+		_, err := framework.CreatePrometheusAndWaitUntilReady(instanceNs, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
+		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, instanceNs, svc); err != nil {
+			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		} else {
+			ctx.AddFinalizerFn(finalizerFn)
+		}
+
+		s := framework.MakeBasicServiceMonitor("monitored")
+		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(s); err != nil {
+			t.Fatal("Creating ServiceMonitor failed: ", err)
+		}
+	}
+
+	{
+		// create a simple echo server in the "allowed" namespace,
+		// expose a service pointing to it,
+		// and create a service monitor pointing to that service.
+		// Wait, until that service appears as a target in the "instance" Prometheus.
+		echo := framework.MakeEchoDeployment("allowed")
+
+		if err := testFramework.CreateDeployment(framework.KubeClient, allowedNs, echo); err != nil {
+			t.Fatal(err)
+		}
+
+		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
+		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, allowedNs, svc); err != nil {
+			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		} else {
+			ctx.AddFinalizerFn(finalizerFn)
+		}
+
+		s := framework.MakeBasicServiceMonitor("monitored")
+		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(s); err != nil {
+			t.Fatal("Creating ServiceMonitor failed: ", err)
+		}
+
+		if err := framework.WaitForTargets(instanceNs, "prometheus-instance", 1); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
+	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get("prometheus-instance", metav1.GetOptions{})
+	if !api_errors.IsNotFound(err) {
+		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
+	}
+
+	// assert that no prometheus target points to the "instance" namespace
+	targets, err := framework.GetActiveTargets(instanceNs, "prometheus-instance")
+	for _, target := range targets {
+		for k, v := range target.Labels {
+			if k == "namespace" && v == instanceNs {
+				t.Fatalf("expected namespace %s not be to have reconciled a service monitor but it has", instanceNs)
+			}
+		}
+	}
+}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1487,7 +1487,7 @@ func testOperatorNSScope(t *testing.T) {
 		}
 
 		// Prometheus Operator only watches single namespace mainNS, not arbitraryNS.
-		_, err := framework.CreatePrometheusOperator(operatorNS, *opImage, []string{mainNS}, nil, false)
+		_, err := framework.CreatePrometheusOperator(operatorNS, *opImage, []string{mainNS}, nil, nil, nil, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1557,7 +1557,7 @@ func testOperatorNSScope(t *testing.T) {
 		}
 
 		// Prometheus Operator only watches prometheusNS and ruleNS, not arbitraryNS.
-		_, err := framework.CreatePrometheusOperator(operatorNS, *opImage, []string{prometheusNS, ruleNS}, nil, false)
+		_, err := framework.CreatePrometheusOperator(operatorNS, *opImage, []string{prometheusNS, ruleNS}, nil, nil, nil, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -321,7 +321,8 @@ func (f *Framework) WaitForPrometheusFiringAlert(ns, svcName, alertName string) 
 }
 
 type Target struct {
-	ScrapeURL string `json:"scrapeUrl"`
+	ScrapeURL string            `json:"scrapeUrl"`
+	Labels    map[string]string `json:"labels"`
 }
 
 type targetDiscovery struct {


### PR DESCRIPTION
This adds two new command line parameters to prometheus operator:

--prometheus-instance-namespaces: Namespaces where Prometheus custom resources
and corresponding Secrets, Configmaps and StatefulSets are watched/created.
If set this takes precedence over --namespaces or --deny-namespaces
for Prometheus custom resources.

--alertmanager-instance-namespaces: Namespaces where Alertmanager custom resources
and corresponding StatefulSets are watched/created.
If set this takes precedence over --namespaces or --deny-namespaces
for Alertmanager custom resources.

This allows fine grained configuration of reconcilation for prometheus/alertmanager
instances to certain namespaces while allow- or deny-listing other namespaces for less
critical custom resources like ServiceMonitors, PodMonitors, etc.

/cc @brancz @LiliC @paulfantom 