### PR TITLE
Improve detection of StatefulSet changes

### DIFF
--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -41,11 +41,11 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 	p2.Spec.Version = "v1.7.2"
 	c := Config{}
 
-	p1Hash, err := createSSetInputHash(p1, c, []string{})
+	p1Hash, err := createSSetInputHash(p1, c, []string{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	p2Hash, err := createSSetInputHash(p2, c, []string{})
+	p2Hash, err := createSSetInputHash(p2, c, []string{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
By adding current StatefulSet Spec as a source of computed hash we can
improve detection of manual changes to prometheus SS and force their
rollback.

/cc @brancz @LiliC 