### PR TITLE
*: reference current directory by make built-in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ check-license:
 
 .PHONY: shellcheck
 shellcheck:
-	docker run -v "${PWD}:/mnt" koalaman/shellcheck:stable $(shell find . -type f -name "*.sh" -not -path "*vendor*")
+	docker run -v "$(PWD):/mnt" koalaman/shellcheck:stable $(shell find . -type f -name "*.sh" -not -path "*vendor*")
 
 ###########
 # Testing #


### PR DESCRIPTION
This should prevent issues when PWD env var is not set correctly.

Closes #2701