### PR TITLE
Fix StatefulSet being needlessly re-created

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -132,6 +132,7 @@ func makeStatefulSet(am *monitoringv1.Alertmanager, old *appsv1.StatefulSet, con
 		})
 	} else {
 		pvcTemplate := storageSpec.VolumeClaimTemplate
+		pvcTemplate.CreationTimestamp = metav1.Time{}
 		if pvcTemplate.Name == "" {
 			pvcTemplate.Name = volumeName(am.Name)
 		}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -217,6 +217,7 @@ func makeStatefulSet(
 		})
 	} else {
 		pvcTemplate := storageSpec.VolumeClaimTemplate
+		pvcTemplate.CreationTimestamp = metav1.Time{}
 		if pvcTemplate.Name == "" {
 			pvcTemplate.Name = volumeName(p.Name)
 		}


### PR DESCRIPTION
When using `storage.volumeClaimTemplate` there are some scenarios that require setting `creationTimestamp`

There have been two issues reported around this:
- https://github.com/coreos/prometheus-operator/issues/2824
- https://github.com/coreos/prometheus-operator/issues/2399

An interesting side-effect of this happening is that the timestamp is propagated into the statefulset configuration as well, but this doesn't happen transparently from an operational standpoint - the stateful set is deleted and re-created because updates are forbidden.

Regardless of the implementation of someone's work-around for this (either setting the timestamp to `metav1.Now()` all the time, or only setting it if it is unset) someone moving to an environment where this is required from one where it was not will experience at least one statefulset re-creation per prometheus / alertmanager configuration as the timestamp is changed from `null` to `<something>` on the statefulset.

In environments where a cluster has a lot of Prometheuses on it, and they use PVs this can produce quite a lot of needless pod and cloud-provider storage detach/attach churn.

1. I realize this isn't the optimal solution - we should really just drop the requirement to set this timestamp in the first place - but that fix could take some time, depending on the approach.
2. This probably needs some integration tests, but I'm not sure how to do this comprehensively

---

I also think it's a good idea to provide a metric for the operator's delete-and-recreate behaviour, as it can affect SLAs

cc @s-urbaniak 

Looking for feedback on this so I can proceed in the correct direction