### PR TITLE
Add metric for statefulset re-create and increase logging

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -67,6 +67,7 @@ type Operator struct {
 
 	reconcileErrorsCounter *prometheus.CounterVec
 	triggerByCounter       *prometheus.CounterVec
+	stsDeleteCreateCounter *prometheus.CounterVec
 
 	config Config
 }
@@ -155,9 +156,10 @@ func New(c prometheusoperator.Config, logger log.Logger) (*Operator, error) {
 	return o, nil
 }
 
-func (c *Operator) RegisterMetrics(r prometheus.Registerer, reconcileErrorsCounter *prometheus.CounterVec, triggerByCounter *prometheus.CounterVec) {
+func (c *Operator) RegisterMetrics(r prometheus.Registerer, reconcileErrorsCounter *prometheus.CounterVec, triggerByCounter *prometheus.CounterVec, stsDeleteCreateCounter *prometheus.CounterVec) {
 	c.reconcileErrorsCounter = reconcileErrorsCounter
 	c.triggerByCounter = triggerByCounter
+	c.stsDeleteCreateCounter = stsDeleteCreateCounter
 
 	c.reconcileErrorsCounter.With(prometheus.Labels{}).Add(0)
 
@@ -494,6 +496,7 @@ func (c *Operator) sync(key string) error {
 	sErr, ok := err.(*apierrors.StatusError)
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
+		c.stsDeleteCreateCounter.With(prometheus.Labels{}).Inc()
 		level.Debug(c.logger).Log("msg", "resolving illegal update of Alertmanager StatefulSet")
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(sset.GetName(), &metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -497,7 +497,7 @@ func (c *Operator) sync(key string) error {
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 		c.stsDeleteCreateCounter.With(prometheus.Labels{}).Inc()
-		level.Debug(c.logger).Log("msg", "resolving illegal update of Alertmanager StatefulSet")
+		level.Info(c.logger).Log("msg", "resolving illegal update of Alertmanager StatefulSet", "details", sErr.ErrStatus.Details)
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(sset.GetName(), &metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 			return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -76,6 +76,7 @@ type Operator struct {
 	queue workqueue.RateLimitingInterface
 
 	reconcileErrorsCounter *prometheus.CounterVec
+	stsDeleteCreateCounter *prometheus.CounterVec
 
 	// triggerByCounter is a set of counters keeping track of the amount
 	// of times Prometheus Operator was triggered to reconcile its created
@@ -340,9 +341,10 @@ func New(conf Config, logger log.Logger) (*Operator, error) {
 
 // RegisterMetrics registers Prometheus metrics on the given Prometheus
 // registerer.
-func (c *Operator) RegisterMetrics(r prometheus.Registerer, reconcileErrorsCounter *prometheus.CounterVec, triggerByCounter *prometheus.CounterVec) {
+func (c *Operator) RegisterMetrics(r prometheus.Registerer, reconcileErrorsCounter *prometheus.CounterVec, triggerByCounter *prometheus.CounterVec, stsDeleteCreateCounter *prometheus.CounterVec) {
 	c.reconcileErrorsCounter = reconcileErrorsCounter
 	c.triggerByCounter = triggerByCounter
+	c.stsDeleteCreateCounter = stsDeleteCreateCounter
 
 	c.reconcileErrorsCounter.With(prometheus.Labels{}).Add(0)
 
@@ -1154,6 +1156,7 @@ func (c *Operator) sync(key string) error {
 	sErr, ok := err.(*apierrors.StatusError)
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
+		c.stsDeleteCreateCounter.With(prometheus.Labels{}).Inc()
 		level.Debug(c.logger).Log("msg", "resolving illegal update of Prometheus StatefulSet")
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(sset.GetName(), &metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1157,7 +1157,7 @@ func (c *Operator) sync(key string) error {
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 		c.stsDeleteCreateCounter.With(prometheus.Labels{}).Inc()
-		level.Debug(c.logger).Log("msg", "resolving illegal update of Prometheus StatefulSet")
+		level.Info(c.logger).Log("msg", "resolving illegal update of Prometheus StatefulSet", "details", sErr.ErrStatus.Details)
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(sset.GetName(), &metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 			return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")


### PR DESCRIPTION
We ran into this by surprise a couple of times, which affects our SLA, so we'd like to have more info on when it happens. The logging appears like 
```
level=info 
ts=2019-11-15T15:47:11.035387855Z 
caller=operator.go:1135 
component=prometheusoperator 
msg="resolving illegal update of Prometheus StatefulSet"
details="&StatusDetails{Name:prometheus-prometheus,Group:apps,Kind:StatefulSet,Causes:[{FieldValueForbidden Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden spec}],RetryAfterSeconds:0,UID:,}"
```

An even more extreme version of this might be to have an optional switch that would stop reconciliation if this happens to let someone review what's going to happen.