### PR TITLE
Fix plural in metadata.name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,8 @@ generate-in-docker:
 
 $(CRD_YAML_FILES): $(CONTROLLER_GEN_BINARY) $(TYPES_V1_TARGET)
 	$(CONTROLLER_GEN_BINARY) crd paths=./pkg/apis/monitoring/v1 output:crd:dir=./example/prometheus-operator-crd
-	cat ./example/prometheus-operator-crd/monitoring.coreos.com_prometheus.yaml | \
-	sed s/plural\:\ prometheus/plural\:\ prometheuses/ \
+	sed s/plural\:\ prometheus/plural\:\ prometheuses/ | \
+	sed s/prometheus.monitoring.coreos.com/prometheuses.monitoring.coreos.com/ \
 	> ./example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
 	rm ./example/prometheus-operator-crd/monitoring.coreos.com_prometheus.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ generate-in-docker:
 
 $(CRD_YAML_FILES): $(CONTROLLER_GEN_BINARY) $(TYPES_V1_TARGET)
 	$(CONTROLLER_GEN_BINARY) crd paths=./pkg/apis/monitoring/v1 output:crd:dir=./example/prometheus-operator-crd
+	cat ./example/prometheus-operator-crd/monitoring.coreos.com_prometheus.yaml | \
 	sed s/plural\:\ prometheus/plural\:\ prometheuses/ | \
 	sed s/prometheus.monitoring.coreos.com/prometheuses.monitoring.coreos.com/ \
 	> ./example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.2
   creationTimestamp: null
-  name: prometheus.monitoring.coreos.com
+  name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
   names:


### PR DESCRIPTION
This fix allowed me to ```kubectl apply -f ``` the resulting file, while I was getting errors without:
```
The CustomResourceDefinition "prometheus.monitoring.coreos.com" is invalid: metadata.name: Invalid value: "prometheus.monitoring.coreos.com": must be spec.names.plural+"."+spec.group
```