### PR TITLE
pkg/prometheus: add metrics about node endpoints synchronization

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -84,6 +84,8 @@ type Operator struct {
 	// corresponding actions (add, delete, update).
 	triggerByCounter        *prometheus.CounterVec
 	nodeAddressLookupErrors prometheus.Counter
+	nodeEndpointSyncs       prometheus.Counter
+	nodeEndpointSyncErrors  prometheus.Counter
 
 	host                   string
 	kubeletObjectName      string
@@ -352,9 +354,19 @@ func (c *Operator) RegisterMetrics(r prometheus.Registerer, reconcileErrorsCount
 		Name: "prometheus_operator_node_address_lookup_errors_total",
 		Help: "Number of times a node IP address could not be determined",
 	})
+	c.nodeEndpointSyncs = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_node_syncs_total",
+		Help: "Number of times node endpoints have been synchronized",
+	})
+	c.nodeEndpointSyncErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_node_syncs_failed_total",
+		Help: "Number of times node endpoints couldn't be synchronized",
+	})
 
 	r.MustRegister(
 		c.nodeAddressLookupErrors,
+		c.nodeEndpointSyncs,
+		c.nodeEndpointSyncErrors,
 		NewPrometheusCollector(c.promInf.GetStore()),
 	)
 }
@@ -589,8 +601,10 @@ func getNodeAddresses(nodes *v1.NodeList) ([]v1.EndpointAddress, []error) {
 }
 
 func (c *Operator) syncNodeEndpointsWithLogError() {
+	c.nodeEndpointSyncs.Inc()
 	err := c.syncNodeEndpoints()
 	if err != nil {
+		c.nodeEndpointSyncErrors.Inc()
 		level.Error(c.logger).Log("msg", "syncing nodes into Endpoints object failed", "err", err)
 	}
 }

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -356,11 +356,11 @@ func (c *Operator) RegisterMetrics(r prometheus.Registerer, reconcileErrorsCount
 	})
 	c.nodeEndpointSyncs = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_node_syncs_total",
-		Help: "Number of times node endpoints have been synchronized",
+		Help: "Number of node endpoints synchronisations",
 	})
 	c.nodeEndpointSyncErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_node_syncs_failed_total",
-		Help: "Number of times node endpoints couldn't be synchronized",
+		Help: "Number of node endpoints synchronisation failures",
 	})
 
 	r.MustRegister(


### PR DESCRIPTION
We have no way currently to detect that the Prometheus operator can't synchronize the nodes' endpoints.

Ref. https://bugzilla.redhat.com/show_bug.cgi?id=1695910