### PR TITLE
use the latest version of prometheus in compatibility matrix as default

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	governingServiceName            = "prometheus-operated"
-	DefaultPrometheusVersion        = "v2.7.1"
 	DefaultThanosVersion            = "v0.8.1"
 	defaultRetention                = "24h"
 	defaultReplicaExternalLabelName = "prometheus_replica"
@@ -61,7 +60,8 @@ var (
 	}
 	probeTimeoutSeconds int32 = 3
 
-	CompatibilityMatrix = []string{
+	DefaultPrometheusVersion = CompatibilityMatrix[len(CompatibilityMatrix)-1]
+	CompatibilityMatrix      = []string{
 		"v1.4.0",
 		"v1.4.1",
 		"v1.5.0",


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Use the latest version of Prometheus in compatibility matrix instead of v2.7.1