### PR TITLE
Fix unmarshalling crd yaml

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	yaml "github.com/ghodss/yaml"
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	extensionsobj "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -205,7 +205,7 @@ func NewCustomResourceDefinition(crdKind monitoringv1.CrdKind, group string, lab
 	if err != nil {
 		panic("unable to unmarshal crd asset for " + assetPath + ": " + err.Error())
 	}
-	crd.ObjectMeta.Name = crd.Spec.Names.Plural + "." + crd.Spec.Group
+	crd.ObjectMeta.Name = crd.Spec.Names.Plural + "." + group
 	crd.ObjectMeta.Labels = labels
 	crd.Spec.Group = group
 	return crd

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -88,6 +88,8 @@ func TestAllNS(t *testing.T) {
 		ctx.AddFinalizerFn(f)
 	}
 
+	t.Run("TestCRDs", testCRDs)
+
 	// t.Run blocks until the function passed as the second argument (f) returns or
 	// calls t.Parallel to become a parallel test. Run reports whether f succeeded
 	// (or at least did not fail before calling t.Parallel). As all tests in
@@ -123,6 +125,27 @@ func TestAllNS(t *testing.T) {
 				restart,
 			)
 		}
+	}
+}
+
+func testCRDs(t *testing.T) {
+	const (
+		prometheusCRDName = "prometheuses.monitoring.coreos.com"
+	)
+	crds, err := framework.ListCRDs()
+	if err != nil {
+		t.Fatalf("unable to list CRDs: %v", err)
+	}
+	if len(crds.Items) < 5 {
+		t.Fatalf("incorrect number of CRDs, want at least: %v, got %v", 5, len(crds.Items))
+	}
+	crd, err := framework.GetCRD(prometheusCRDName)
+	if err != nil {
+		t.Fatalf("unable to get prometheus custom resource definition: %v", err)
+	}
+	// This field might be nil in older versions of kube (<1.15)
+	if crd.Spec.PreserveUnknownFields != nil && *crd.Spec.PreserveUnknownFields {
+		t.Fatalf("incorrect setting for preserveUnknownFields, want: %v, got: %v", false, *crd.Spec.PreserveUnknownFields)
 	}
 }
 

--- a/test/framework/crd.go
+++ b/test/framework/crd.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	prometheusCRDName = "prometheus"
+)
+
+// GetCRD gets a custom resource definition from the apiserver
+func (f *Framework) GetCRD(name string) (*v1beta1.CustomResourceDefinition, error) {
+	crd, err := f.APIServerClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to get CRD with name %v", name))
+	}
+	return crd, nil
+}
+
+// ListCRDs gets a list of custom resource definitions from the apiserver
+func (f *Framework) ListCRDs() (*v1beta1.CustomResourceDefinitionList, error) {
+	crds, err := f.APIServerClient.ApiextensionsV1beta1().CustomResourceDefinitions().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to list CRDs"))
+	}
+	return crds, nil
+}


### PR DESCRIPTION
Some fields were being left out of the created CRDs due to missing information during yaml unmarshalling.