### PR TITLE
lint: add operator lint command as separate container image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /operator
-prometheus-config-reloader
+/lint
+/prometheus-config-reloader
 .build/
 *~
 *.tgz

--- a/Documentation/user-guides/linting.md
+++ b/Documentation/user-guides/linting.md
@@ -1,0 +1,51 @@
+# Linting
+
+This document describes how to use the standalone linting tool to validate your Prometheus Operator [CRD-based](../design.md) configuration files.
+
+## Getting linter
+
+To use the linter either get it with `go get -u github.com/coreos/prometheus-operator/cmd/lint` and executable is `$GOPATH/bin/lint`, or use the container image from `quay.io/coreos/prometheus-operator-lint` and executable is `/bin/lint`.
+
+## Using linter
+
+The `lint` executable takes a list of yaml files to check as command arguments. It will output any errors to stderr and returns with exit code `1` on errors, `0` otherwise.
+
+## Example
+
+Here is an example script to lint a `src` sub-directory full of Prometheus Operator CRD files with ether local `lint` or Dockerized version:
+
+```sh
+#!/bin/sh
+
+LINTER="quay.io/coreos/prometheus-operator-lint"
+SCRIPT=$(basename "$0")
+
+lint_files() {
+  if [ -x "$(command -v lint)" ]; then
+    echo "Linting '${2}' files in directory '${1}'..."
+    had_errors=0
+    for file in $(find "${1}" -name "${2}"); do
+      echo "${file}"
+      lint "${file}"
+      retval=$?
+      if [ $retval -ne 0 ]; then
+        had_errors=1
+      fi
+    done
+    exit ${had_errors}
+  elif [ -x "$(command -v docker)" ]; then
+    echo "Using Dockerized linter."
+    docker run \
+           --rm \
+           --volume "$(pwd):/data:ro" \
+           --entrypoint "/data/${SCRIPT}" \
+           --workdir /data \
+           "${LINTER}" "${1}" "${2}"
+  else
+    echo "Linter executable not found."
+    exit 1
+  fi
+}
+
+lint_files "src" "*.yaml"
+```

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ $(CLIENT_TARGET): $(K8S_GEN_DEPS)
 	--output-package "$(GO_PKG)/pkg/client"
 
 LISTER_TARGET := pkg/client/listers/monitoring/v1/prometheus.go
-$(LISTER_TARGET): $(K8S_GEN_DEPS	)
+$(LISTER_TARGET): $(K8S_GEN_DEPS)
 	$(LISTER_GEN_BINARY) \
 	$(K8S_GEN_ARGS) \
 	--input-dirs     "$(GO_PKG)/pkg/apis/monitoring/v1" \

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The Operator acts on the following [custom resource definitions (CRDs)](https://
 To learn more about the CRDs introduced by the Prometheus Operator have a look
 at the [design doc](Documentation/design.md).
 
+To automate validation of your CRD configuration files see about [linting](Documentation/user-guides/linting.md).
+
 ## Quickstart
 
 Note that this quickstart does not provision an entire monitoring stack; if that is what you are looking for see the [kube-prometheus](https://github.com/coreos/kube-prometheus) project. If you want the whole stack, but have already applied the `bundle.yaml`, delete the bundle first (`kubectl delete -f bundle.yaml`).

--- a/cmd/lint/Dockerfile
+++ b/cmd/lint/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/prometheus/busybox:latest
+
+ADD lint /bin/lint
+
+USER nobody
+
+ENTRYPOINT ["/bin/lint"]

--- a/scripts/travis-push-docker-image.sh
+++ b/scripts/travis-push-docker-image.sh
@@ -14,9 +14,11 @@ trap defer EXIT
 # Push to Quay '-dev' repo if it's not a git tag or master branch build.
 export REPO="quay.io/coreos/prometheus-operator"
 export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/coreos/prometheus-config-reloader"
+export REPO_PROMETHEUS_OPERATOR_LINT="quay.io/coreos/prometheus-operator-lint"
 if [[ "${TRAVIS_TAG}" == "" ]] && [[ "${TRAVIS_BRANCH}" != master ]]; then
 	export REPO="quay.io/coreos/prometheus-operator-dev"
 	export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/coreos/prometheus-config-reloader-dev"
+  export REPO_PROMETHEUS_OPERATOR_LINT="quay.io/coreos/prometheus-operator-lint-dev"
 fi
 
 # For both git tags and git branches 'TRAVIS_BRANCH' contains the name.
@@ -27,3 +29,4 @@ make image
 echo "${QUAY_PASSWORD}" | docker login -u "${QUAY_USERNAME}" --password-stdin quay.io
 docker push "${REPO}:${TAG}"
 docker push "${REPO_PROMETHEUS_CONFIG_RELOADER}:${TAG}"
+docker push "${REPO_PROMETHEUS_OPERATOR_LINT}:${TAG}"


### PR DESCRIPTION
Build and publish the lint executable as separate image, useful to have in CI pipelines to validate the CRD yaml files.