### PR TITLE
fix generated statefulset being pruned by kubectl

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -170,11 +170,19 @@ func makeStatefulSet(
 	}
 
 	boolTrue := true
+	// do not transfer kubectl annotations to the statefulset so it is not
+	// pruned by kubectl
+	annotations := make(map[string]string)
+	for key, value := range p.ObjectMeta.Annotations {
+		if !strings.HasPrefix(key, "kubectl.kubernetes.io/") {
+			annotations[key] = value
+		}
+	}
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        prefixedName(p.Name),
 			Labels:      config.Labels.Merge(p.ObjectMeta.Labels),
-			Annotations: p.ObjectMeta.Annotations,
+			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         p.APIVersion,

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -47,6 +47,14 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	}
 	annotations := map[string]string{
 		"testannotation": "testannotationvalue",
+		"kubectl.kubernetes.io/last-applied-configuration": "something",
+		"kubectl.kubernetes.io/something":                  "something",
+	}
+	// kubectl annotations must not be on the statefulset so kubectl does
+	// not manage the generated object
+	expectedAnnotations := map[string]string{
+		"prometheus-operator-input-hash": "",
+		"testannotation":                 "testannotationvalue",
 	}
 
 	sset, err := makeStatefulSet(monitoringv1.Prometheus{
@@ -61,13 +69,6 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	if !reflect.DeepEqual(labels, sset.Labels) {
 		fmt.Println(pretty.Compare(labels, sset.Labels))
 		t.Fatal("Labels are not properly being propagated to the StatefulSet")
-	}
-
-	expectedAnnotations := map[string]string{
-		"prometheus-operator-input-hash": "",
-	}
-	for k, v := range annotations {
-		expectedAnnotations[k] = v
 	}
 
 	if !reflect.DeepEqual(expectedAnnotations, sset.Annotations) {


### PR DESCRIPTION
When the operator transfers all labels and annotations from the source
prometheus object to the generated statefulset this also kubectl managed
annotations.
These annotations will cause the generated statefulset to be pruned when
the source prometheus is applied with kubectl apply --prune.
Cleanup of the statefulset is managed by the garbage collection via
owner references of the prometheus object (which can be pruned).

To fix this do not transfer any kubectl.kubernetes.io/ annotations to
the generated statefulset.

Closes gh-2642

Signed-off-by: Julian Taylor <juliantaylor108@gmail.com>