### PR TITLE
prometheus-operator: set config-reloader containers resources

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -725,16 +725,19 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 			Args: []string{
 				fmt.Sprintf("--webhook-url=%s", localReloadURL),
 			},
-			VolumeMounts:             []v1.VolumeMount{},
-			Resources:                v1.ResourceRequirements{Limits: v1.ResourceList{}},
+			VolumeMounts: []v1.VolumeMount{},
+			Resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{}, Requests: v1.ResourceList{}},
 			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 		}
 
 		if c.ConfigReloaderCPU != "0" {
 			container.Resources.Limits[v1.ResourceCPU] = resource.MustParse(c.ConfigReloaderCPU)
+			container.Resources.Requests[v1.ResourceCPU] = resource.MustParse(c.ConfigReloaderCPU)
 		}
 		if c.ConfigReloaderMemory != "0" {
 			container.Resources.Limits[v1.ResourceMemory] = resource.MustParse(c.ConfigReloaderMemory)
+			container.Resources.Requests[v1.ResourceMemory] = resource.MustParse(c.ConfigReloaderMemory)
 		}
 
 		for _, name := range ruleConfigMapNames {
@@ -855,12 +858,15 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 		prometheusImage = *p.Spec.Image
 	}
 
-	prometheusConfigReloaderResources := v1.ResourceRequirements{Limits: v1.ResourceList{}}
+	prometheusConfigReloaderResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{}, Requests: v1.ResourceList{}}
 	if c.ConfigReloaderCPU != "0" {
 		prometheusConfigReloaderResources.Limits[v1.ResourceCPU] = resource.MustParse(c.ConfigReloaderCPU)
+		prometheusConfigReloaderResources.Requests[v1.ResourceCPU] = resource.MustParse(c.ConfigReloaderCPU)
 	}
 	if c.ConfigReloaderMemory != "0" {
 		prometheusConfigReloaderResources.Limits[v1.ResourceMemory] = resource.MustParse(c.ConfigReloaderMemory)
+		prometheusConfigReloaderResources.Requests[v1.ResourceMemory] = resource.MustParse(c.ConfigReloaderMemory)
 	}
 
 	operatorContainers := append([]v1.Container{

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -808,9 +808,14 @@ func TestSidecarsNoCPULimits(t *testing.T) {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
 
-	expectedResources := v1.ResourceRequirements{Limits: v1.ResourceList{
-		v1.ResourceMemory: resource.MustParse("50Mi"),
-	}}
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+	}
 	for _, c := range sset.Spec.Template.Spec.Containers {
 		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
 			t.Fatal("Unexpected resource requests/limits set, when none should be set.")
@@ -834,9 +839,14 @@ func TestSidecarsNoMemoryLimits(t *testing.T) {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
 
-	expectedResources := v1.ResourceRequirements{Limits: v1.ResourceList{
-		v1.ResourceCPU: resource.MustParse("100m"),
-	}}
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("100m"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("100m"),
+		},
+	}
 	for _, c := range sset.Spec.Template.Spec.Containers {
 		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
 			t.Fatal("Unexpected resource requests/limits set, when none should be set.")


### PR DESCRIPTION
Currently when passing `--config-reloader-(cpu|memory)` values those are
used only for limits. This PR sets the same values for requests.
I wasn't sure if the options for the requests should have been passed
with separate options but I thought this was a good compromise in the
meantime.

The initial question was brought up in https://github.com/coreos/kube-prometheus/issues/376