### PR TITLE
reduce verbosity of deprecation checks

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -369,6 +369,7 @@ func (c *Operator) handleAlertmanagerAdd(obj interface{}) {
 
 	level.Debug(c.logger).Log("msg", "Alertmanager added", "key", key)
 	c.metrics.TriggerByCounter(monitoringv1.AlertmanagersKind, "add").Inc()
+	checkAlertmanagerSpecDeprecation(key, obj.(*monitoringv1.Alertmanager), c.logger)
 	c.enqueue(key)
 }
 
@@ -391,6 +392,7 @@ func (c *Operator) handleAlertmanagerUpdate(old, cur interface{}) {
 
 	level.Debug(c.logger).Log("msg", "Alertmanager updated", "key", key)
 	c.metrics.TriggerByCounter(monitoringv1.AlertmanagersKind, "update").Inc()
+	checkAlertmanagerSpecDeprecation(key, cur.(*monitoringv1.Alertmanager), c.logger)
 	c.enqueue(key)
 }
 
@@ -455,7 +457,6 @@ func (c *Operator) sync(key string) error {
 	}
 
 	level.Info(c.logger).Log("msg", "sync alertmanager", "key", key)
-	checkAlertmanagerSpecDeprecation(key, am, c.logger)
 
 	// Create governing service if it doesn't exist.
 	svcClient := c.kclient.CoreV1().Services(am.Namespace)

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -510,6 +510,7 @@ func (c *Operator) handlePrometheusAdd(obj interface{}) {
 
 	level.Debug(c.logger).Log("msg", "Prometheus added", "key", key)
 	c.metrics.TriggerByCounter(monitoringv1.PrometheusesKind, "add").Inc()
+	checkPrometheusSpecDeprecation(key, obj.(*monitoringv1.Prometheus), c.logger)
 	c.enqueue(key)
 }
 
@@ -536,6 +537,7 @@ func (c *Operator) handlePrometheusUpdate(old, cur interface{}) {
 
 	level.Debug(c.logger).Log("msg", "Prometheus updated", "key", key)
 	c.metrics.TriggerByCounter(monitoringv1.PrometheusesKind, "update").Inc()
+	checkPrometheusSpecDeprecation(key, cur.(*monitoringv1.Prometheus), c.logger)
 	c.enqueue(key)
 }
 
@@ -1083,7 +1085,6 @@ func (c *Operator) sync(key string) error {
 	}
 
 	level.Info(c.logger).Log("msg", "sync prometheus", "key", key)
-	checkPrometheusSpecDeprecation(key, p, c.logger)
 	ruleConfigMapNames, err := c.createOrUpdateRuleConfigMaps(p)
 	if err != nil {
 		return err


### PR DESCRIPTION
I was getting tired of seeing the deprecation warnings in the logs on every sync.  This changes the prometheus and alertmanager operators to only warn when a Prometheus or Alertmanager resource is added or updated.