### PR TITLE
[backport] jsonnet/prometheus-operator: restrict api extension RBAC rules …

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -29,7 +29,20 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - '*'
+  - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - alertmanagers.monitoring.coreos.com
+  - podmonitors.monitoring.coreos.com
+  - prometheuses.monitoring.coreos.com
+  - prometheusrules.monitoring.coreos.com
+  - servicemonitors.monitoring.coreos.com
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -47,7 +47,20 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - '*'
+  - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - alertmanagers.monitoring.coreos.com
+  - podmonitors.monitoring.coreos.com
+  - prometheuses.monitoring.coreos.com
+  - prometheusrules.monitoring.coreos.com
+  - servicemonitors.monitoring.coreos.com
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -29,7 +29,20 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - '*'
+  - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - alertmanagers.monitoring.coreos.com
+  - podmonitors.monitoring.coreos.com
+  - prometheuses.monitoring.coreos.com
+  - prometheusrules.monitoring.coreos.com
+  - servicemonitors.monitoring.coreos.com
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -12,7 +12,20 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - '*'
+  - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - alertmanagers.monitoring.coreos.com
+  - podmonitors.monitoring.coreos.com
+  - prometheuses.monitoring.coreos.com
+  - prometheusrules.monitoring.coreos.com
+  - servicemonitors.monitoring.coreos.com
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -10,8 +10,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         'app.kubernetes.io/component': 'controller',
       },
       commonLabels:
-        $._config.prometheusOperator.deploymentSelectorLabels +
-        { 'app.kubernetes.io/version': $._config.versions.prometheusOperator, },
+        $._config.prometheusOperator.deploymentSelectorLabels
+        { 'app.kubernetes.io/version': $._config.versions.prometheusOperator },
     },
 
     versions+:: {
@@ -63,12 +63,26 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local clusterRole = k.rbac.v1.clusterRole;
       local policyRule = clusterRole.rulesType;
 
-      local apiExtensionsRule = policyRule.new() +
+      local crdCreateRule = policyRule.new() +
+                            policyRule.withApiGroups(['apiextensions.k8s.io']) +
+                            policyRule.withResources([
+                              'customresourcedefinitions',
+                            ]) +
+                            policyRule.withVerbs(['create']);
+
+      local crdMonitoringRule = policyRule.new() +
                                 policyRule.withApiGroups(['apiextensions.k8s.io']) +
                                 policyRule.withResources([
                                   'customresourcedefinitions',
                                 ]) +
-                                policyRule.withVerbs(['*']);
+                                policyRule.withResourceNames([
+                                  'alertmanagers.monitoring.coreos.com',
+                                  'podmonitors.monitoring.coreos.com',
+                                  'prometheuses.monitoring.coreos.com',
+                                  'prometheusrules.monitoring.coreos.com',
+                                  'servicemonitors.monitoring.coreos.com',
+                                ]) +
+                                policyRule.withVerbs(['get', 'update']);
 
       local monitoringRule = policyRule.new() +
                              policyRule.withApiGroups(['monitoring.coreos.com']) +
@@ -128,7 +142,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                             ]) +
                             policyRule.withVerbs(['get', 'list', 'watch']);
 
-      local rules = [apiExtensionsRule, monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule];
+      local rules = [crdCreateRule, crdMonitoringRule, monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule];
 
       clusterRole.new() +
       clusterRole.mixin.metadata.withLabels(po.commonLabels) +


### PR DESCRIPTION
This is a backport of https://github.com/coreos/prometheus-operator/pull/2974 into the 0.35 branch.