### PR TITLE
Switch tooling image

### DIFF
--- a/Documentation/user-guides/linting.md
+++ b/Documentation/user-guides/linting.md
@@ -4,7 +4,7 @@ This document describes how to use the standalone linting tool to validate your 
 
 ## Getting linter
 
-To use the linter either get it with `go get -u github.com/coreos/prometheus-operator/cmd/po-lint` and executable is `$GOPATH/bin/po-lint`, or use the container image from `quay.io/coreos/prometheus-operator-lint` and executable is `/bin/po-lint`.
+To use the linter either get it with `go get -u github.com/coreos/prometheus-operator/cmd/po-lint` and executable is `$GOPATH/bin/po-lint`, or use the container image from `quay.io/coreos/po-tooling` and executable is `/go/bin/po-lint`.
 
 ## Using linter
 

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ k8s-gen: \
 	$(OPENAPI_TARGET)
 
 .PHONY: image
-image: .hack-operator-image .hack-prometheus-config-reloader-image .hack-lint-image
+image: .hack-operator-image .hack-prometheus-config-reloader-image
 
 .hack-operator-image: Dockerfile operator
 # Create empty target file, for the sole purpose of recording when this target
@@ -138,13 +138,6 @@ image: .hack-operator-image .hack-prometheus-config-reloader-image .hack-lint-im
 # was last executed via the last-modification timestamp on the file. See
 # https://www.gnu.org/software/make/manual/make.html#Empty-Targets
 	docker build -t $(REPO_PROMETHEUS_CONFIG_RELOADER):$(TAG) -f cmd/prometheus-config-reloader/Dockerfile .
-	touch $@
-
-.hack-lint-image: cmd/po-lint/Dockerfile po-lint
-# Create empty target file, for the sole purpose of recording when this target
-# was last executed via the last-modification timestamp on the file. See
-# https://www.gnu.org/software/make/manual/make.html#Empty-Targets
-	docker build -t $(REPO_PROMETHEUS_OPERATOR_LINT):$(TAG) -f cmd/po-lint/Dockerfile .
 	touch $@
 
 ##############

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ CONTAINER_CMD:=docker run --rm \
 		-w "/go/src/$(GO_PKG)" \
 		-e GO111MODULE=on \
 		-e USER=deadbeef \
-		quay.io/coreos/jsonnet-ci
+		quay.io/coreos/po-tooling
 
 .PHONY: all
 all: format generate build test

--- a/cmd/po-lint/Dockerfile
+++ b/cmd/po-lint/Dockerfile
@@ -1,7 +1,0 @@
-FROM quay.io/prometheus/busybox:latest
-
-ADD po-lint /bin/po-lint
-
-USER nobody
-
-ENTRYPOINT ["/bin/po-lint"]

--- a/scripts/travis-push-docker-image.sh
+++ b/scripts/travis-push-docker-image.sh
@@ -14,11 +14,9 @@ trap defer EXIT
 # Push to Quay '-dev' repo if it's not a git tag or master branch build.
 export REPO="quay.io/coreos/prometheus-operator"
 export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/coreos/prometheus-config-reloader"
-export REPO_PROMETHEUS_OPERATOR_LINT="quay.io/coreos/prometheus-operator-lint"
 if [[ "${TRAVIS_TAG}" == "" ]] && [[ "${TRAVIS_BRANCH}" != master ]]; then
 	export REPO="quay.io/coreos/prometheus-operator-dev"
 	export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/coreos/prometheus-config-reloader-dev"
-  export REPO_PROMETHEUS_OPERATOR_LINT="quay.io/coreos/prometheus-operator-lint-dev"
 fi
 
 # For both git tags and git branches 'TRAVIS_BRANCH' contains the name.
@@ -29,4 +27,3 @@ make image
 echo "${QUAY_PASSWORD}" | docker login -u "${QUAY_USERNAME}" --password-stdin quay.io
 docker push "${REPO}:${TAG}"
 docker push "${REPO_PROMETHEUS_CONFIG_RELOADER}:${TAG}"
-docker push "${REPO_PROMETHEUS_OPERATOR_LINT}:${TAG}"


### PR DESCRIPTION
* use [`quay.io/coreos/po-tooling`](https://quay.io/coreos/po-tooling) instead of [`quay.io/coreos/jsonnet-ci`](https://quay.io/coreos/jsonnet-ci)
* use `po-lint` from [`quay.io/coreos/po-tooling`](https://quay.io/coreos/po-tooling) image instead of building another image.

I believe this closes #2954