### PR TITLE
prevent prometheus sts update loop

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1145,6 +1145,7 @@ func (c *Operator) sync(key string) error {
 	if err != nil {
 		return errors.Wrap(err, "making statefulset failed")
 	}
+	sanitizeSTS(sset)
 
 	if !exists {
 		level.Debug(c.logger).Log("msg", "no current Prometheus statefulset found")
@@ -1181,6 +1182,15 @@ func (c *Operator) sync(key string) error {
 	}
 
 	return nil
+}
+
+// sanitizeSTS removes values for APIVersion and Kind from the VolumeClaimTemplates.
+// This prevents update failures due to these fields changing when applied.
+func sanitizeSTS(sts *appsv1.StatefulSet) {
+	for i := range sts.Spec.VolumeClaimTemplates {
+		sts.Spec.VolumeClaimTemplates[i].APIVersion = ""
+		sts.Spec.VolumeClaimTemplates[i].Kind = ""
+	}
 }
 
 //checkPrometheusSpecDeprecation checks for deprecated fields in the prometheus spec and logs a warning if applicable


### PR DESCRIPTION
Changes in kubernetes v1.17 cause an update loop due to validation
errors cause by setting the 'apiVersion' and 'kind' fields in the
StatefulSet spec.  These two fields are set to empty strings by
the Kube API server, and v1.17 added validation that does not
allow these fields to be modified.

Fixes #2950