### PR TITLE
Fix thanos ruler example

### DIFF
--- a/example/thanos/prometheus-service.yaml
+++ b/example/thanos/prometheus-service.yaml
@@ -5,6 +5,7 @@ metadata:
     app: prometheus
     prometheus: self
   name: prometheus-self
+  namespace: default
 spec:
   ports:
   - name: web

--- a/example/thanos/prometheus-servicemonitor.yaml
+++ b/example/thanos/prometheus-servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: prometheus
+  namespace: default
   labels:
     app: prometheus
 spec:

--- a/example/thanos/prometheus.yaml
+++ b/example/thanos/prometheus.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: self
+  namespace: default
   labels:
     prometheus: self
 spec:
@@ -14,4 +15,4 @@ spec:
       role: prometheus-rulefiles
       prometheus: k8s
   thanos:
-    version: v0.5.0
+    version: v0.10.1

--- a/example/thanos/query-deployment.yaml
+++ b/example/thanos/query-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: thanos-query
+  namespace: default
   labels:
     app: thanos-query
 spec:
@@ -16,7 +17,7 @@ spec:
     spec:
       containers:
       - name: thanos-query
-        image: quay.io/thanos/thanos:v0.7.0
+        image: quay.io/thanos/thanos:v0.10.1
         args:
         - query
         - --log.level=debug

--- a/example/thanos/query-service.yaml
+++ b/example/thanos/query-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: thanos-query
+  namespace: default
   labels:
     app: thanos-query
 spec:

--- a/example/thanos/sidecar-service.yaml
+++ b/example/thanos/sidecar-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: thanos-sidecar
+  namespace: default
   labels:
     app: thanos-sidecar
 spec:

--- a/example/thanos/thanos-ruler-service.yaml
+++ b/example/thanos/thanos-ruler-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: thanos-ruler
+  namespace: default
   labels:
     app: thanos-ruler
 spec:

--- a/example/thanos/thanos-ruler.yaml
+++ b/example/thanos/thanos-ruler.yaml
@@ -3,15 +3,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: ThanosRuler
 metadata:
   name: thanos-ruler
+  namespace: default
   labels:
     app: thanos-ruler
 spec:
-  image: quay.io/thanos/thanos
+  image: quay.io/thanos/thanos:v0.10.1
   ruleSelector:
     matchLabels:
       role: thanos-example
   queryEndpoints:
-  - dnssrv+_http._tcp.thanos-query.monitoring.svc.cluster.local
+  - dnssrv+_http._tcp.thanos-query.default.svc.cluster.local
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -21,7 +22,7 @@ metadata:
     prometheus: example-alert
     role: thanos-example
   name: prometheus-example-alerts
-  namespace: monitoring
+  namespace: default
 spec:
   groups:
   - name: ./example-alert.rules

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -330,5 +330,5 @@ func makeRulesConfigMap(t *monitoringv1.ThanosRuler, ruleFiles map[string]string
 }
 
 func thanosRuleConfigMapName(name string) string {
-	return "thanos-ruler" + name + "-rulefiles"
+	return "thanos-ruler-" + name + "-rulefiles"
 }


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

This PR does:
1. Bump thanos image version to v0.10.1  in example manifests
2. Explicitly add `namespace: default` in the manifests to make sure the query and ruler service discovery work.
3. Add `-` to make thanos ruler configmap name more readable (also consistent to prometheus configmap name)