### PR TITLE
consolidate logic for determining image urls and versions

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -182,6 +182,16 @@ func init() {
 	if len(cfg.Namespaces.ThanosRulerAllowList) == 0 {
 		cfg.Namespaces.ThanosRulerAllowList = cfg.Namespaces.AllowList
 	}
+
+	if cfg.AlertmanagerDefaultBaseImage != operator.DefaultAlertmanagerBaseImage {
+		cfg.AlertmanagerDefaultImage = operator.ApplyImageVersion(cfg.AlertmanagerDefaultBaseImage, operator.DefaultAlertmanagerVersion)
+	}
+	if cfg.PrometheusDefaultBaseImage != operator.DefaultPrometheusBaseImage {
+		cfg.PrometheusDefaultImage = operator.ApplyImageVersion(cfg.PrometheusDefaultBaseImage, operator.DefaultPrometheusVersion)
+	}
+	if cfg.ThanosDefaultBaseImage != operator.DefaultThanosBaseImage {
+		cfg.ThanosDefaultImage = operator.ApplyImageVersion(cfg.ThanosDefaultBaseImage, operator.DefaultThanosVersion)
+	}
 }
 
 func Main() int {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -31,6 +31,7 @@ import (
 	alertmanagercontroller "github.com/coreos/prometheus-operator/pkg/alertmanager"
 	"github.com/coreos/prometheus-operator/pkg/api"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	prometheuscontroller "github.com/coreos/prometheus-operator/pkg/prometheus"
 	thanoscontroller "github.com/coreos/prometheus-operator/pkg/thanos"
 	"github.com/coreos/prometheus-operator/pkg/version"
@@ -137,9 +138,12 @@ func init() {
 	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "jimmidyson/configmap-reload:v0.3.0", "Reload Image")
 	flagset.StringVar(&cfg.ConfigReloaderCPU, "config-reloader-cpu", "100m", "Config Reloader CPU. Value \"0\" disables it and causes no limit to be configured.")
 	flagset.StringVar(&cfg.ConfigReloaderMemory, "config-reloader-memory", "25Mi", "Config Reloader Memory. Value \"0\" disables it and causes no limit to be configured.")
-	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", "quay.io/prometheus/alertmanager", "Alertmanager default base image")
-	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", "quay.io/prometheus/prometheus", "Prometheus default base image")
-	flagset.StringVar(&cfg.ThanosDefaultBaseImage, "thanos-default-base-image", "quay.io/thanos/thanos", "Thanos default base image")
+	flagset.StringVar(&cfg.AlertmanagerDefaultImage, "alertmanager-default-image", operator.DefaultAlertmanagerImage, "Alertmanager default container image")
+	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image.  Deprecated: use alertmanager-default-image instead")
+	flagset.StringVar(&cfg.PrometheusDefaultImage, "prometheus-default-image", operator.DefaultPrometheusImage, "Prometheus default container image")
+	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", operator.DefaultPrometheusBaseImage, "Prometheus default base image. Deprecated: use prometheus-default-image instead")
+	flagset.StringVar(&cfg.ThanosDefaultImage, "thanos-default-image", operator.DefaultThanosImage, "Thanos default container image")
+	flagset.StringVar(&cfg.ThanosDefaultBaseImage, "thanos-default-base-image", operator.DefaultThanosBaseImage, "Thanos default base image")
 	flagset.Var(ns, "namespaces", "Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list). This is mutually exclusive with --deny-namespaces.")
 	flagset.Var(deniedNs, "deny-namespaces", "Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with --namespaces.")
 	flagset.Var(prometheusNs, "prometheus-instance-namespaces", "Namespaces where Prometheus custom resources and corresponding Secrets, Configmaps and StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Prometheus custom resources.")

--- a/cmd/po-docgen/compatibility.go
+++ b/cmd/po-docgen/compatibility.go
@@ -17,7 +17,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/coreos/prometheus-operator/pkg/prometheus"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 )
 
 func printCompatMatrixDocs() {
@@ -41,7 +41,7 @@ Due to the use of CustomResourceDefinitions Kubernetes >= v1.7.0 is required.
 The versions of Prometheus compatible to be run with the Prometheus Operator are:`)
 	fmt.Println("")
 
-	for _, v := range prometheus.CompatibilityMatrix {
+	for _, v := range operator.PrometheusCompatibilityMatrix {
 		fmt.Printf("* %s\n", v)
 	}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -78,6 +78,7 @@ type Config struct {
 	ConfigReloaderCPU            string
 	ConfigReloaderMemory         string
 	AlertmanagerDefaultBaseImage string
+	AlertmanagerDefaultImage     string
 	Namespaces                   prometheusoperator.Namespaces
 	Labels                       prometheusoperator.Labels
 	CrdKinds                     monitoringv1.CrdKinds
@@ -122,6 +123,7 @@ func New(c prometheusoperator.Config, logger log.Logger, r prometheus.Registerer
 			ConfigReloaderCPU:            c.ConfigReloaderCPU,
 			ConfigReloaderMemory:         c.ConfigReloaderMemory,
 			AlertmanagerDefaultBaseImage: c.AlertmanagerDefaultBaseImage,
+			AlertmanagerDefaultImage:     c.AlertmanagerDefaultImage,
 			Namespaces:                   c.Namespaces,
 			CrdKinds:                     c.CrdKinds,
 			Labels:                       c.Labels,

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -29,14 +29,12 @@ import (
 	"github.com/blang/semver"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/pkg/errors"
 )
 
 const (
-	governingServiceName = "alertmanager-operated"
-	// DefaultVersion specifies which version of Alertmanager the Prometheus
-	// Operator uses by default.
-	DefaultVersion         = "v0.20.0"
+	governingServiceName   = "alertmanager-operated"
 	defaultRetention       = "120h"
 	secretsDir             = "/etc/alertmanager/secrets/"
 	configmapsDir          = "/etc/alertmanager/configmaps/"
@@ -63,7 +61,7 @@ func makeStatefulSet(am *monitoringv1.Alertmanager, old *appsv1.StatefulSet, con
 		am.Spec.PortName = defaultPortName
 	}
 	if am.Spec.Version == "" {
-		am.Spec.Version = DefaultVersion
+		am.Spec.Version = operator.DefaultAlertmanagerVersion
 	}
 	if am.Spec.Replicas == nil {
 		am.Spec.Replicas = &minReplicas

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -266,7 +267,7 @@ func TestMakeStatefulSetSpecSingleDoubleDashedArgs(t *testing.T) {
 func TestMakeStatefulSetSpecWebRoutePrefix(t *testing.T) {
 	a := monitoringv1.Alertmanager{}
 	replicas := int32(1)
-	a.Spec.Version = DefaultVersion
+	a.Spec.Version = operator.DefaultAlertmanagerVersion
 	a.Spec.Replicas = &replicas
 
 	statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -62,5 +62,5 @@ var (
 	}
 	DefaultPrometheusVersion   = PrometheusCompatibilityMatrix[len(PrometheusCompatibilityMatrix)-1]
 	DefaultPrometheusBaseImage = "quay.io/prometheus/prometheus"
-	DefaultPrometheusImage     = DefaultAlertmanagerBaseImage + ":" + DefaultPrometheusVersion
+	DefaultPrometheusImage     = DefaultPrometheusBaseImage + ":" + DefaultPrometheusVersion
 )

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -1,0 +1,66 @@
+// Copyright 2020 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+const (
+	DefaultAlertmanagerVersion   = "v0.20.0"
+	DefaultAlertmanagerBaseImage = "quay.io/prometheus/alertmanager"
+	DefaultAlertmanagerImage     = DefaultAlertmanagerBaseImage + ":" + DefaultAlertmanagerVersion
+	DefaultThanosVersion         = "v0.10.1"
+	DefaultThanosBaseImage       = "quay.io/thanos/thanos"
+	DefaultThanosImage           = DefaultThanosBaseImage + ":" + DefaultThanosVersion
+)
+
+var (
+	PrometheusCompatibilityMatrix = []string{
+		"v1.4.0",
+		"v1.4.1",
+		"v1.5.0",
+		"v1.5.1",
+		"v1.5.2",
+		"v1.5.3",
+		"v1.6.0",
+		"v1.6.1",
+		"v1.6.2",
+		"v1.6.3",
+		"v1.7.0",
+		"v1.7.1",
+		"v1.7.2",
+		"v1.8.0",
+		"v2.0.0",
+		"v2.2.1",
+		"v2.3.1",
+		"v2.3.2",
+		"v2.4.0",
+		"v2.4.1",
+		"v2.4.2",
+		"v2.4.3",
+		"v2.5.0",
+		"v2.6.0",
+		"v2.6.1",
+		"v2.7.0",
+		"v2.7.1",
+		"v2.7.2",
+		"v2.8.1",
+		"v2.9.2",
+		"v2.10.0",
+		"v2.11.0",
+		"v2.14.0",
+		"v2.15.2",
+	}
+	DefaultPrometheusVersion   = PrometheusCompatibilityMatrix[len(PrometheusCompatibilityMatrix)-1]
+	DefaultPrometheusBaseImage = "quay.io/prometheus/prometheus"
+	DefaultPrometheusImage     = DefaultAlertmanagerBaseImage + ":" + DefaultPrometheusVersion
+)

--- a/pkg/operator/image.go
+++ b/pkg/operator/image.go
@@ -1,0 +1,131 @@
+// Copyright 2020 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/blang/semver"
+)
+
+// ImageConfig contains config for creating a container image URL
+type ImageConfig struct {
+	Image            *string
+	DefaultImage     string
+	BaseImage        string
+	DefaultBaseImage string
+	Version          string
+	DefaultVersion   string
+	Tag              string
+	SHA              string
+}
+
+// ContainerImageURL gets or generates the URL to download a container image.
+// If the `Image` field is not empty, this should override any other setting.
+// If no fields are specified, the default image URL is returned.
+// Otherwise, use a combination of the default base image
+// and the deprecated `Version`, `Tag`, and `SHA`, fields.
+// Returns the image URL and the version of the component.
+func ContainerImageURL(spec *ImageConfig) string {
+	if spec.Image != nil && *spec.Image != "" {
+		return ApplyImageVersion(*spec.Image, spec.Version)
+	}
+	if spec.BaseImage == "" && spec.Version == "" &&
+		spec.Tag == "" && spec.SHA == "" {
+		return spec.DefaultImage
+	}
+
+	// Version is used by default.
+	// If the tag is specified, we use the tag to identify the container image.
+	// If the sha is specified, we use the sha to identify the container image,
+	// as it has even stronger immutable guarantees to identify the image.
+	baseImage := spec.DefaultBaseImage
+	if spec.BaseImage != "" {
+		baseImage = spec.BaseImage
+	}
+	version := spec.DefaultVersion
+	if spec.Version != "" {
+		version = spec.Version
+	}
+	image := fmt.Sprintf("%s:%s", baseImage, version)
+	if spec.Tag != "" {
+		image = fmt.Sprintf("%s:%s", baseImage, spec.Tag)
+	}
+	if spec.SHA != "" {
+		image = fmt.Sprintf("%s@sha256:%s", baseImage, spec.SHA)
+	}
+	return image
+}
+
+// ParseVersion tries to parse the given version.
+// If the version is blank, will try to parse the version
+// in the imageURL.
+// Otherwise will parse the defaultVersion.
+func ParseVersion(version, imageURL, defaultVersion string) (semver.Version, error) {
+	if version != "" {
+		return semver.Parse(strings.TrimLeft(version, "v"))
+	}
+	imageVersion := GetImageVersion(imageURL)
+	if imageVersion != "" {
+		v, err := semver.Parse(strings.TrimLeft(imageVersion, "v"))
+		if err == nil {
+			return v, nil
+		}
+	}
+	return semver.Parse(strings.TrimLeft(defaultVersion, "v"))
+}
+
+var (
+	containerURLRegex = regexp.MustCompile(`^([\w-.:]+/)?([\w-.]+/)?[\w-.]+([:]([\w-.]+))?$`)
+)
+
+// GetImageVersion gets the version/tag portion of a container
+// image URL.  If there is no version specified, or if the url
+// specifies a digest instead of a version or tag, an empty string
+// is returned.
+func GetImageVersion(imageURL string) string {
+	match := containerURLRegex.FindStringSubmatch(imageURL)
+	if len(match) < 5 {
+		return ""
+	}
+	return match[4]
+}
+
+// ApplyImageVersion applies the given version to the imageURL.\
+// If the URL does not contain a version, the given version will
+// be appended.
+// If the URL already includes valid semver version, it will be replaced.
+// If the URL contains an invalid semver version such as a tag or SHA,
+// the original URL will be returned unmodified.
+func ApplyImageVersion(imageURL, version string) string {
+	if strings.TrimSpace(version) == "" {
+		return imageURL
+	}
+	oldVersion := GetImageVersion(imageURL)
+	if oldVersion == "" {
+		if !strings.HasSuffix(imageURL, ":") {
+			imageURL = imageURL + ":"
+		}
+		return imageURL + version
+	}
+	_, err := semver.ParseTolerant(oldVersion)
+	if err == nil {
+		versionIndex := len(imageURL) - len(oldVersion)
+		return imageURL[:versionIndex] + version
+	}
+	return imageURL
+}

--- a/pkg/operator/image.go
+++ b/pkg/operator/image.go
@@ -77,16 +77,16 @@ func ContainerImageURL(spec *ImageConfig) string {
 // Otherwise will parse the defaultVersion.
 func ParseVersion(version, imageURL, defaultVersion string) (semver.Version, error) {
 	if version != "" {
-		return semver.Parse(strings.TrimLeft(version, "v"))
+		return semver.ParseTolerant(version)
 	}
 	imageVersion := GetImageVersion(imageURL)
 	if imageVersion != "" {
-		v, err := semver.Parse(strings.TrimLeft(imageVersion, "v"))
+		v, err := semver.ParseTolerant(imageVersion)
 		if err == nil {
 			return v, nil
 		}
 	}
-	return semver.Parse(strings.TrimLeft(defaultVersion, "v"))
+	return semver.ParseTolerant(defaultVersion)
 }
 
 var (

--- a/pkg/operator/image_test.go
+++ b/pkg/operator/image_test.go
@@ -1,0 +1,217 @@
+// Copyright 2020 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"testing"
+)
+
+func TestContainerImageURL(t *testing.T) {
+	defaultImageSpec := &ImageConfig{
+		DefaultBaseImage: "foo/bar",
+		DefaultImage:     "foo/baz",
+		DefaultVersion:   "0.0.1",
+	}
+	testImage := "myrepo/myimage"
+	testImageWithVersion := "myhost:9090/myrepo/myimage:0.3"
+	cases := []struct {
+		spec     *ImageConfig
+		expected string
+	}{
+		{
+			spec:     &ImageConfig{},
+			expected: "foo/baz",
+		},
+		{
+			spec: &ImageConfig{
+				Image: &testImage,
+			},
+			expected: testImage,
+		},
+		{
+			spec: &ImageConfig{
+				Image: &testImageWithVersion,
+			},
+			expected: testImageWithVersion,
+		},
+		{
+			spec: &ImageConfig{
+				BaseImage: "foo/baseimage",
+			},
+			expected: "foo/baseimage:0.0.1",
+		},
+		{
+			spec: &ImageConfig{
+				Tag: "release-v1",
+			},
+			expected: "foo/bar:release-v1",
+		},
+		{
+			spec: &ImageConfig{
+				SHA: "12345",
+			},
+			expected: "foo/bar@sha256:12345",
+		},
+		{
+			spec: &ImageConfig{
+				Version: "2.0",
+			},
+			expected: "foo/baz",
+		},
+		{
+			spec: &ImageConfig{
+				Image:   &testImageWithVersion,
+				Version: "2.0",
+			},
+			expected: testImageWithVersion,
+		},
+	}
+
+	for i, c := range cases {
+		testSpec := mergeImageSpecs(defaultImageSpec, c.spec)
+		result := ContainerImageURL(testSpec)
+		if c.expected != result {
+			t.Errorf("expected test case %d to be %q but got %q", i, c.expected, result)
+		}
+	}
+}
+
+func mergeImageSpecs(defaults, overrides *ImageConfig) *ImageConfig {
+	spec := *defaults
+	if overrides.DefaultBaseImage != "" {
+		spec.DefaultBaseImage = overrides.DefaultBaseImage
+	}
+	if overrides.BaseImage != "" {
+		spec.BaseImage = overrides.BaseImage
+	}
+	if overrides.DefaultImage != "" {
+		spec.DefaultImage = overrides.DefaultImage
+	}
+	if overrides.Image != nil {
+		spec.Image = overrides.Image
+	}
+	if overrides.DefaultVersion != "" {
+		spec.DefaultVersion = overrides.DefaultVersion
+	}
+	if overrides.Tag != "" {
+		spec.Tag = overrides.Tag
+	}
+	if overrides.SHA != "" {
+		spec.SHA = overrides.SHA
+	}
+	return &spec
+}
+
+func TestGetImageVersion(t *testing.T) {
+	cases := []struct {
+		image    string
+		expected string
+	}{
+		{
+			image:    "myimage",
+			expected: "",
+		},
+		{
+			image:    "myimage:0.2",
+			expected: "0.2",
+		},
+		{
+			image:    "myrepo/myimage:0.3",
+			expected: "0.3",
+		},
+		{
+			image:    "myhost.com/myrepo/myimage:0.4",
+			expected: "0.4",
+		},
+		{
+			image:    "myhost.com:8080/myrepo/myimage",
+			expected: "",
+		},
+		{
+			image:    "myhost.com:8080/myrepo/myimage:0.6-beta1",
+			expected: "0.6-beta1",
+		},
+		{
+			image:    "myimage@sha256:45b23dee",
+			expected: "",
+		},
+		{
+			image:    "myhost.com:8080/myrepo/myimage@sha256:45b23dee0",
+			expected: "",
+		},
+		{
+			image:    "#$&*#&56garbage#($@&($&(#(@(^%)",
+			expected: "",
+		},
+	}
+
+	for i, c := range cases {
+		result := GetImageVersion(c.image)
+		if c.expected != result {
+			t.Errorf("expected test case %d to be %q but got %q", i, c.expected, result)
+		}
+	}
+}
+
+func TestApplyImageVersion(t *testing.T) {
+	cases := []struct {
+		image    string
+		version  string
+		expected string
+	}{
+		{
+			image:    "myimage",
+			version:  "0.1",
+			expected: "myimage:0.1",
+		},
+		{
+			image:    "myrepo/myimage",
+			version:  "0.2",
+			expected: "myrepo/myimage:0.2",
+		},
+		{
+			image:    "myrepo/myimage:v1.0",
+			version:  "0.3",
+			expected: "myrepo/myimage:0.3",
+		},
+		{
+			image:    "myrepo/myimage:0.4",
+			version:  "",
+			expected: "myrepo/myimage:0.4",
+		},
+		{
+			image:    "myhost.com/myrepo/myimage:2.0.1",
+			version:  "v0.5.1",
+			expected: "myhost.com/myrepo/myimage:v0.5.1",
+		},
+		{
+			image:    "myhost.com:8080/myrepo/myimage",
+			version:  "",
+			expected: "myhost.com:8080/myrepo/myimage",
+		},
+		{
+			image:    "myhost.com:8080/myrepo/myimage",
+			version:  "0.6",
+			expected: "myhost.com:8080/myrepo/myimage:0.6",
+		},
+	}
+
+	for i, c := range cases {
+		result := ApplyImageVersion(c.image, c.version)
+		if c.expected != result {
+			t.Errorf("expected test case %d to be %q but got %q", i, c.expected, result)
+		}
+	}
+}

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -140,8 +140,11 @@ type Config struct {
 	ConfigReloaderCPU             string
 	ConfigReloaderMemory          string
 	PrometheusConfigReloaderImage string
+	AlertmanagerDefaultImage      string
 	AlertmanagerDefaultBaseImage  string
+	PrometheusDefaultImage        string
 	PrometheusDefaultBaseImage    string
+	ThanosDefaultImage            string
 	ThanosDefaultBaseImage        string
 	Namespaces                    Namespaces
 	Labels                        Labels

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 )
 
 const (
@@ -161,7 +162,7 @@ func (cg *configGenerator) generateConfig(
 ) ([]byte, error) {
 	versionStr := p.Spec.Version
 	if versionStr == "" {
-		versionStr = DefaultPrometheusVersion
+		versionStr = operator.DefaultPrometheusVersion
 	}
 
 	version, err := semver.Parse(strings.TrimLeft(versionStr, "v"))

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -27,12 +27,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 
 	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestConfigGeneration(t *testing.T) {
-	for _, v := range CompatibilityMatrix {
+	for _, v := range operator.PrometheusCompatibilityMatrix {
 		cfg, err := generateTestConfig(v)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -29,12 +29,12 @@ import (
 	"github.com/blang/semver"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/pkg/errors"
 )
 
 const (
 	governingServiceName            = "prometheus-operated"
-	DefaultThanosVersion            = "v0.10.1"
 	defaultRetention                = "24h"
 	defaultReplicaExternalLabelName = "prometheus_replica"
 	storageDir                      = "/prometheus"
@@ -59,44 +59,6 @@ var (
 		managedByOperatorLabel: managedByOperatorLabelValue,
 	}
 	probeTimeoutSeconds int32 = 3
-
-	CompatibilityMatrix = []string{
-		"v1.4.0",
-		"v1.4.1",
-		"v1.5.0",
-		"v1.5.1",
-		"v1.5.2",
-		"v1.5.3",
-		"v1.6.0",
-		"v1.6.1",
-		"v1.6.2",
-		"v1.6.3",
-		"v1.7.0",
-		"v1.7.1",
-		"v1.7.2",
-		"v1.8.0",
-		"v2.0.0",
-		"v2.2.1",
-		"v2.3.1",
-		"v2.3.2",
-		"v2.4.0",
-		"v2.4.1",
-		"v2.4.2",
-		"v2.4.3",
-		"v2.5.0",
-		"v2.6.0",
-		"v2.6.1",
-		"v2.7.0",
-		"v2.7.1",
-		"v2.7.2",
-		"v2.8.1",
-		"v2.9.2",
-		"v2.10.0",
-		"v2.11.0",
-		"v2.14.0",
-		"v2.15.2",
-	}
-	DefaultPrometheusVersion = CompatibilityMatrix[len(CompatibilityMatrix)-1]
 )
 
 func makeStatefulSet(
@@ -119,10 +81,10 @@ func makeStatefulSet(
 		p.Spec.BaseImage = config.PrometheusDefaultBaseImage
 	}
 	if p.Spec.Version == "" {
-		p.Spec.Version = DefaultPrometheusVersion
+		p.Spec.Version = operator.DefaultPrometheusVersion
 	}
 	if p.Spec.Thanos != nil && p.Spec.Thanos.Version == nil {
-		v := DefaultThanosVersion
+		v := operator.DefaultThanosVersion
 		p.Spec.Thanos.Version = &v
 	}
 

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -78,22 +78,22 @@ type Operator struct {
 
 // Config defines configuration parameters for the Operator.
 type Config struct {
-	Host                   string
-	TLSInsecure            bool
-	TLSConfig              rest.TLSClientConfig
-	ConfigReloaderImage    string
-	ConfigReloaderCPU      string
-	ConfigReloaderMemory   string
-	ThanosDefaultBaseImage string
-	Namespaces             prometheusoperator.Namespaces
-	Labels                 prometheusoperator.Labels
-	CrdKinds               monitoringv1.CrdKinds
-	EnableValidation       bool
-	LocalHost              string
-	LogLevel               string
-	LogFormat              string
-	ManageCRDs             bool
-	ThanosRulerSelector    string
+	Host                 string
+	TLSInsecure          bool
+	TLSConfig            rest.TLSClientConfig
+	ConfigReloaderImage  string
+	ConfigReloaderCPU    string
+	ConfigReloaderMemory string
+	ThanosDefaultImage   string
+	Namespaces           prometheusoperator.Namespaces
+	Labels               prometheusoperator.Labels
+	CrdKinds             monitoringv1.CrdKinds
+	EnableValidation     bool
+	LocalHost            string
+	LogLevel             string
+	LogFormat            string
+	ManageCRDs           bool
+	ThanosRulerSelector  string
 }
 
 // New creates a new controller.
@@ -130,22 +130,22 @@ func New(conf prometheusoperator.Config, logger log.Logger, r prometheus.Registe
 		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "thanos"),
 		metrics:   operator.NewMetrics("thanos", r),
 		config: Config{
-			Host:                   conf.Host,
-			TLSInsecure:            conf.TLSInsecure,
-			TLSConfig:              conf.TLSConfig,
-			ConfigReloaderImage:    conf.ConfigReloaderImage,
-			ConfigReloaderCPU:      conf.ConfigReloaderCPU,
-			ConfigReloaderMemory:   conf.ConfigReloaderMemory,
-			ThanosDefaultBaseImage: conf.ThanosDefaultBaseImage,
-			Namespaces:             conf.Namespaces,
-			Labels:                 conf.Labels,
-			CrdKinds:               conf.CrdKinds,
-			EnableValidation:       conf.EnableValidation,
-			LocalHost:              conf.LocalHost,
-			LogLevel:               conf.LogLevel,
-			LogFormat:              conf.LogFormat,
-			ManageCRDs:             conf.ManageCRDs,
-			ThanosRulerSelector:    conf.ThanosRulerSelector,
+			Host:                 conf.Host,
+			TLSInsecure:          conf.TLSInsecure,
+			TLSConfig:            conf.TLSConfig,
+			ConfigReloaderImage:  conf.ConfigReloaderImage,
+			ConfigReloaderCPU:    conf.ConfigReloaderCPU,
+			ConfigReloaderMemory: conf.ConfigReloaderMemory,
+			ThanosDefaultImage:   conf.ThanosDefaultImage,
+			Namespaces:           conf.Namespaces,
+			Labels:               conf.Labels,
+			CrdKinds:             conf.CrdKinds,
+			EnableValidation:     conf.EnableValidation,
+			LocalHost:            conf.LocalHost,
+			LogLevel:             conf.LogLevel,
+			LogFormat:            conf.LogFormat,
+			ManageCRDs:           conf.ManageCRDs,
+			ThanosRulerSelector:  conf.ThanosRulerSelector,
 		},
 	}
 

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -22,6 +22,7 @@ import (
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -31,7 +32,6 @@ import (
 )
 
 const (
-	DefaultThanosVersion      = "v0.10.1"
 	rulesDir                  = "/etc/thanos/rules"
 	storageDir                = "/thanos/data"
 	governingServiceName      = "thanos-ruler-operated"
@@ -56,7 +56,7 @@ func makeStatefulSet(tr *monitoringv1.ThanosRuler, old *appsv1.StatefulSet, conf
 		tr.Spec.Image = config.ThanosDefaultBaseImage
 	}
 	if !strings.Contains(tr.Spec.Image, ":") {
-		tr.Spec.Image = tr.Spec.Image + ":" + DefaultThanosVersion
+		tr.Spec.Image = tr.Spec.Image + ":" + operator.DefaultThanosVersion
 	}
 	if tr.Spec.Resources.Requests == nil {
 		tr.Spec.Resources.Requests = v1.ResourceList{}

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -32,10 +32,10 @@ import (
 
 var (
 	defaultTestConfig = Config{
-		ConfigReloaderImage:    "jimmidyson/configmap-reload:latest",
-		ConfigReloaderCPU:      "100m",
-		ConfigReloaderMemory:   "25Mi",
-		ThanosDefaultBaseImage: "quay.io/thanos/thanos",
+		ConfigReloaderImage:  "jimmidyson/configmap-reload:latest",
+		ConfigReloaderCPU:    "100m",
+		ConfigReloaderMemory: "25Mi",
+		ThanosDefaultImage:   "quay.io/thanos/thanos",
 	}
 	emptyQueryEndpoints = []string{""}
 )

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/coreos/prometheus-operator/pkg/alertmanager"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/coreos/prometheus-operator/pkg/prometheus"
 	testFramework "github.com/coreos/prometheus-operator/test/framework"
 
@@ -121,8 +122,8 @@ func testPromVersionMigration(t *testing.T) {
 	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
 
 	name := "test"
-	startVersion := prometheus.CompatibilityMatrix[0]
-	compatibilityMatrix := prometheus.CompatibilityMatrix[1:]
+	startVersion := operator.PrometheusCompatibilityMatrix[0]
+	compatibilityMatrix := operator.PrometheusCompatibilityMatrix[1:]
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 	p.Spec.Version = startVersion
@@ -1279,7 +1280,7 @@ func testThanos(t *testing.T) {
 	ns := ctx.CreateNamespace(t, framework.KubeClient)
 	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
 
-	version := prometheus.DefaultThanosVersion
+	version := operator.DefaultThanosVersion
 
 	prom := framework.MakeBasicPrometheus(ns, "basic-prometheus", "test-group", 1)
 	prom.Spec.Replicas = proto.Int32(2)

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/coreos/prometheus-operator/pkg/prometheus"
 	"github.com/pkg/errors"
 )
@@ -43,7 +44,7 @@ func (f *Framework) MakeBasicPrometheus(ns, name, group string, replicas int32) 
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			Replicas: &replicas,
-			Version:  prometheus.DefaultPrometheusVersion,
+			Version:  operator.DefaultPrometheusVersion,
 			ServiceMonitorSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"group": group,


### PR DESCRIPTION
This change introduces three new CLI flags for specifying default image URLs (`alertmanager-default-image`, `prometheus-default-image`, and `thanos-default-image`) and deprecates the similar `-base-image` CLI args.  This follows along with the previous changes (#2914) which deprecated the use of baseImage, tag, and sha fields.

This also moves the all the default image versions into the `operator` package.  This helps maintain the Thanos image version for example, which currently has a two defaults, one in the thanos operator package and one in the prometheus operator package (for the sidecar).

This also moves the logic for figuring out the container image URLs into the `operator` package to ensure consistency in how the image URL and version is determined using a combination of the various config parameters (image, baseimage, version, tag, etc).  If we remove the deprecated fields at some point in the future, then it should be possible to simplify this quite a bit.

I tried to maintain consistent behaviour with the previous versions and added some new tests to verify output, but it's possible that I missed some edge cases where a user sets an unusual combination of CLI baseImage, custom resource base image, version, tag etc.  But I think it shouldn't be difficult to either fix or provide a workaround if those cases come up.