### PR TITLE
update default image versions

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -36,7 +36,7 @@ const (
 	governingServiceName = "alertmanager-operated"
 	// DefaultVersion specifies which version of Alertmanager the Prometheus
 	// Operator uses by default.
-	DefaultVersion         = "v0.17.0"
+	DefaultVersion         = "v0.20.0"
 	defaultRetention       = "120h"
 	secretsDir             = "/etc/alertmanager/secrets/"
 	configmapsDir          = "/etc/alertmanager/configmaps/"

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -34,8 +34,7 @@ import (
 
 const (
 	governingServiceName            = "prometheus-operated"
-	DefaultPrometheusVersion        = "v2.7.1"
-	DefaultThanosVersion            = "v0.8.1"
+	DefaultThanosVersion            = "v0.10.1"
 	defaultRetention                = "24h"
 	defaultReplicaExternalLabelName = "prometheus_replica"
 	storageDir                      = "/prometheus"
@@ -97,6 +96,7 @@ var (
 		"v2.14.0",
 		"v2.15.2",
 	}
+	DefaultPrometheusVersion = CompatibilityMatrix[len(CompatibilityMatrix)-1]
 )
 
 func makeStatefulSet(

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	DefaultThanosVersion      = "v0.10.0"
+	DefaultThanosVersion      = "v0.10.1"
 	rulesDir                  = "/etc/thanos/rules"
 	storageDir                = "/thanos/data"
 	governingServiceName      = "thanos-ruler-operated"


### PR DESCRIPTION
Prometheus image should default to latest version in compatibility
matrix.  Also updates Alertmanager and Thanos to latest stable versions.