### PR TITLE
*: remove nil error from logs

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -908,7 +908,6 @@ func (c *Operator) enqueueForNamespace(nsName string) {
 	if !exists {
 		level.Error(c.logger).Log(
 			"msg", fmt.Sprintf("get namespace to enqueue Prometheus instances failed: namespace %q does not exist", nsName),
-			"err", err,
 		)
 		return
 	}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -794,7 +794,6 @@ func (o *Operator) enqueueForNamespace(nsName string) {
 	if !exists {
 		level.Error(o.logger).Log(
 			"msg", fmt.Sprintf("get namespace to enqueue ThanosRuler instances failed: namespace %q does not exist", nsName),
-			"err", err,
 		)
 		return
 	}


### PR DESCRIPTION
When we reach this code path, `err` is always `nil`.