### PR TITLE
fix alertmanager statefulset being pruned by kubectl

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -91,11 +91,19 @@ func makeStatefulSet(am *monitoringv1.Alertmanager, old *appsv1.StatefulSet, con
 	}
 
 	boolTrue := true
+	// do not transfer kubectl annotations to the statefulset so it is not
+	// pruned by kubectl
+	annotations := make(map[string]string)
+	for key, value := range am.ObjectMeta.Annotations {
+		if !strings.HasPrefix(key, "kubectl.kubernetes.io/") {
+			annotations[key] = value
+		}
+	}
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        prefixedName(am.Name),
 			Labels:      config.Labels.Merge(am.ObjectMeta.Labels),
-			Annotations: am.ObjectMeta.Annotations,
+			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         am.APIVersion,

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -25,6 +25,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kylelemons/godebug/pretty"
 )
 
 var (
@@ -42,6 +44,13 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	}
 	annotations := map[string]string{
 		"testannotation": "testannotationvalue",
+		"kubectl.kubernetes.io/last-applied-configuration": "something",
+		"kubectl.kubernetes.io/something":                  "something",
+	}
+	// kubectl annotations must not be on the statefulset so kubectl does
+	// not manage the generated object
+	expectedAnnotations := map[string]string{
+		"testannotation": "testannotationvalue",
 	}
 
 	sset, err := makeStatefulSet(&monitoringv1.Alertmanager{
@@ -53,8 +62,14 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 
 	require.NoError(t, err)
 
-	if !reflect.DeepEqual(labels, sset.Labels) || !reflect.DeepEqual(annotations, sset.Annotations) {
-		t.Fatal("Labels or Annotations are not properly being propagated to the StatefulSet")
+	if !reflect.DeepEqual(labels, sset.Labels) {
+		fmt.Println(pretty.Compare(labels, sset.Labels))
+		t.Fatal("Labels are not properly being propagated to the StatefulSet")
+	}
+
+	if !reflect.DeepEqual(expectedAnnotations, sset.Annotations) {
+		fmt.Println(pretty.Compare(expectedAnnotations, sset.Annotations))
+		t.Fatal("Annotations are not properly being propagated to the StatefulSet")
 	}
 }
 

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -63,12 +63,12 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	require.NoError(t, err)
 
 	if !reflect.DeepEqual(labels, sset.Labels) {
-		fmt.Println(pretty.Compare(labels, sset.Labels))
+		t.Log(pretty.Compare(labels, sset.Labels))
 		t.Fatal("Labels are not properly being propagated to the StatefulSet")
 	}
 
 	if !reflect.DeepEqual(expectedAnnotations, sset.Annotations) {
-		fmt.Println(pretty.Compare(expectedAnnotations, sset.Annotations))
+		t.Log(pretty.Compare(expectedAnnotations, sset.Annotations))
 		t.Fatal("Annotations are not properly being propagated to the StatefulSet")
 	}
 }

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -67,12 +67,12 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	require.NoError(t, err)
 
 	if !reflect.DeepEqual(labels, sset.Labels) {
-		fmt.Println(pretty.Compare(labels, sset.Labels))
+		t.Log(pretty.Compare(labels, sset.Labels))
 		t.Fatal("Labels are not properly being propagated to the StatefulSet")
 	}
 
 	if !reflect.DeepEqual(expectedAnnotations, sset.Annotations) {
-		fmt.Println(pretty.Compare(expectedAnnotations, sset.Annotations))
+		t.Log(pretty.Compare(expectedAnnotations, sset.Annotations))
 		t.Fatal("Annotations are not properly being propagated to the StatefulSet")
 	}
 }

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -71,11 +71,19 @@ func makeStatefulSet(tr *monitoringv1.ThanosRuler, old *appsv1.StatefulSet, conf
 	}
 
 	boolTrue := true
+	// do not transfer kubectl annotations to the statefulset so it is not
+	// pruned by kubectl
+	annotations := make(map[string]string)
+	for key, value := range tr.ObjectMeta.Annotations {
+		if !strings.HasPrefix(key, "kubectl.kubernetes.io/") {
+			annotations[key] = value
+		}
+	}
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        prefixedName(tr.Name),
 			Labels:      config.Labels.Merge(tr.ObjectMeta.Labels),
-			Annotations: tr.ObjectMeta.Annotations,
+			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         tr.APIVersion,

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -43,6 +43,13 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	}
 	annotations := map[string]string{
 		"testannotation": "testannotationvalue",
+		"kubectl.kubernetes.io/last-applied-configuration": "something",
+		"kubectl.kubernetes.io/something":                  "something",
+	}
+	// kubectl annotations must not be on the statefulset so kubectl does
+	// not manage the generated object
+	expectedAnnotations := map[string]string{
+		"testannotation": "testannotationvalue",
 	}
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
@@ -57,8 +64,14 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 
 	require.NoError(t, err)
 
-	if !reflect.DeepEqual(labels, sset.Labels) || !reflect.DeepEqual(annotations, sset.Annotations) {
-		t.Fatal("Labels or Annotations are not properly being propagated to the StatefulSet")
+	if !reflect.DeepEqual(labels, sset.Labels) {
+		t.Log(pretty.Compare(labels, sset.Labels))
+		t.Fatal("Labels are not properly being propagated to the StatefulSet")
+	}
+
+	if !reflect.DeepEqual(expectedAnnotations, sset.Annotations) {
+		t.Log(pretty.Compare(expectedAnnotations, sset.Annotations))
+		t.Fatal("Annotations are not properly being propagated to the StatefulSet")
 	}
 }
 


### PR DESCRIPTION
kubectl-managed annotations will cause the generated statefulset to be pruned
when the source alertmanager is applied with kubectl apply --prune.

To fix this do not transfer any kubectl.kubernetes.io/ annotations to
the generated statefulset.

This is the same problem as fixed in #2944 but for alertmanager rather than
prometheus.

Fixes #3029

Signed-off-by: Alex Conlin-Oakley <alexconlin@gmail.com>