### PR TITLE
Simplify multi-arch building.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM quay.io/prometheus/busybox:latest
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 
 ADD operator /bin/operator
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SHELL=/bin/bash -o pipefail
 
+OS?=linux
+ARCH?=amd64
+
 GO_PKG=github.com/coreos/prometheus-operator
 REPO?=quay.io/coreos/prometheus-operator
 REPO_PROMETHEUS_CONFIG_RELOADER?=quay.io/coreos/prometheus-config-reloader
@@ -39,7 +42,7 @@ K8S_GEN_DEPS:=.header
 K8S_GEN_DEPS+=$(TYPES_V1_TARGET)
 K8S_GEN_DEPS+=$(foreach bin,$(K8S_GEN_BINARIES),$(FIRST_GOPATH)/bin/$(bin))
 
-GO_BUILD_RECIPE=GOOS=linux CGO_ENABLED=0 go build -mod=vendor -ldflags="-s -X $(GO_PKG)/pkg/version.Version=$(VERSION)"
+GO_BUILD_RECIPE=GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -mod=vendor -ldflags="-s -X $(GO_PKG)/pkg/version.Version=$(VERSION)"
 pkgs = $(shell go list ./... | grep -v /vendor/ | grep -v /test/ | grep -v /contrib/)
 
 CONTAINER_CMD:=docker run --rm \
@@ -130,7 +133,7 @@ image: .hack-operator-image .hack-prometheus-config-reloader-image
 # Create empty target file, for the sole purpose of recording when this target
 # was last executed via the last-modification timestamp on the file. See
 # https://www.gnu.org/software/make/manual/make.html#Empty-Targets
-	docker build -t $(REPO):$(TAG) .
+	docker build --build-arg ARCH=$(ARCH) --build-arg OS=$(OS) -t $(REPO):$(TAG) .
 	touch $@
 
 .hack-prometheus-config-reloader-image: cmd/prometheus-config-reloader/Dockerfile prometheus-config-reloader

--- a/cmd/prometheus-config-reloader/Dockerfile
+++ b/cmd/prometheus-config-reloader/Dockerfile
@@ -1,4 +1,6 @@
-FROM quay.io/prometheus/busybox:latest
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 
 ADD prometheus-config-reloader /bin/prometheus-config-reloader
 


### PR DESCRIPTION
I found it hard to build prometheus-operator for arm64 target.
I'm suggesting this little change allowing the use of variables OS and ARCH to specify the target architecture.

Those variables are passed to golang through GOOS and GOARCH variable, and to docker build through build-args.