### PR TITLE
Make the ports on the kubelet Service and Endpoints match.

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -665,6 +665,14 @@ func (c *Operator) syncNodeEndpoints() error {
 					Name: "https-metrics",
 					Port: 10250,
 				},
+				{
+					Name: "http-metrics",
+					Port: 10255,
+				},
+				{
+					Name: "cadvisor",
+					Port: 4194,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Prometheus only actually uses the Endpoints but it helps humans to have them be the same.