### PR TITLE
fix thanos-ruler status reporting

### DIFF
--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -52,7 +52,8 @@ import (
 )
 
 const (
-	resyncPeriod = 5 * time.Minute
+	resyncPeriod     = 5 * time.Minute
+	thanosRulerLabel = "thanos-ruler"
 )
 
 // Operator manages life cycle of Thanos deployments and
@@ -719,8 +720,8 @@ func (o *Operator) createCRDs() error {
 func ListOptions(name string) metav1.ListOptions {
 	return metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-			"app":         "thanosruler",
-			"thanosruler": name,
+			"app":            thanosRulerLabel,
+			thanosRulerLabel: name,
 		})).String(),
 	}
 }

--- a/pkg/thanos/operator_test.go
+++ b/pkg/thanos/operator_test.go
@@ -21,8 +21,8 @@ import (
 func TestListOptions(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		o := ListOptions("test")
-		if o.LabelSelector != "app=thanosruler,thanosruler=test" && o.LabelSelector != "thanosruler=test,app=thanosruler" {
-			t.Fatalf("LabelSelector not computed correctly\n\nExpected: \"app=thanosruler,thanosruler=test\"\n\nGot:      %#+v", o.LabelSelector)
+		if o.LabelSelector != "app=thanos-ruler,thanos-ruler=test" && o.LabelSelector != "thanos-ruler=test,app=thanos-ruler" {
+			t.Fatalf("LabelSelector not computed correctly\n\nExpected: \"app=thanos-ruler,thanos-ruler=test\"\n\nGot:      %#+v", o.LabelSelector)
 		}
 	}
 }

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -298,8 +298,8 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 			}
 		}
 	}
-	podLabels["app"] = "thanos-ruler"
-	podLabels["thanos"] = tr.Name
+	podLabels["app"] = thanosRulerLabel
+	podLabels[thanosRulerLabel] = tr.Name
 	finalLabels := config.Labels.Merge(podLabels)
 
 	storageVolName := volumeName(tr.Name)


### PR DESCRIPTION
Make sure the labels applied to the pods match the labels which
the status function uses for searching.