### PR TITLE
prevent statefulset update loop

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -476,6 +476,7 @@ func (c *Operator) sync(key string) error {
 		if err != nil {
 			return errors.Wrap(err, "making the statefulset, to create, failed")
 		}
+		operator.SanitizeSTS(sset)
 		if _, err := ssetClient.Create(sset); err != nil {
 			return errors.Wrap(err, "creating statefulset failed")
 		}
@@ -487,6 +488,7 @@ func (c *Operator) sync(key string) error {
 		return errors.Wrap(err, "making the statefulset, to update, failed")
 	}
 
+	operator.SanitizeSTS(sset)
 	_, err = ssetClient.Update(sset)
 	sErr, ok := err.(*apierrors.StatusError)
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -144,4 +145,14 @@ func (i *instrumentedListerWatcher) Watch(options metav1.ListOptions) (watch.Int
 		i.watchFailed.Inc()
 	}
 	return ret, err
+}
+
+// SanitizeSTS removes values for APIVersion and Kind from the VolumeClaimTemplates.
+// This prevents update failures due to these fields changing when applied.
+// See https://github.com/kubernetes/kubernetes/issues/87583
+func SanitizeSTS(sts *appsv1.StatefulSet) {
+	for i := range sts.Spec.VolumeClaimTemplates {
+		sts.Spec.VolumeClaimTemplates[i].APIVersion = ""
+		sts.Spec.VolumeClaimTemplates[i].Kind = ""
+	}
 }

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1153,7 +1153,7 @@ func (c *Operator) sync(key string) error {
 	if err != nil {
 		return errors.Wrap(err, "making statefulset failed")
 	}
-	sanitizeSTS(sset)
+	operator.SanitizeSTS(sset)
 
 	if !exists {
 		level.Debug(c.logger).Log("msg", "no current Prometheus statefulset found")
@@ -1190,15 +1190,6 @@ func (c *Operator) sync(key string) error {
 	}
 
 	return nil
-}
-
-// sanitizeSTS removes values for APIVersion and Kind from the VolumeClaimTemplates.
-// This prevents update failures due to these fields changing when applied.
-func sanitizeSTS(sts *appsv1.StatefulSet) {
-	for i := range sts.Spec.VolumeClaimTemplates {
-		sts.Spec.VolumeClaimTemplates[i].APIVersion = ""
-		sts.Spec.VolumeClaimTemplates[i].Kind = ""
-	}
 }
 
 //checkPrometheusSpecDeprecation checks for deprecated fields in the prometheus spec and logs a warning if applicable

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -610,6 +610,7 @@ func (o *Operator) sync(key string) error {
 		if err != nil {
 			return errors.Wrap(err, "making thanos statefulset config failed")
 		}
+		operator.SanitizeSTS(sset)
 		if _, err := ssetClient.Create(sset); err != nil {
 			return errors.Wrap(err, "creating thanos statefulset failed")
 		}
@@ -621,6 +622,7 @@ func (o *Operator) sync(key string) error {
 		return errors.Wrap(err, "making the statefulset, to update, failed")
 	}
 
+	operator.SanitizeSTS(sset)
 	_, err = ssetClient.Update(sset)
 	sErr, ok := err.(*apierrors.StatusError)
 


### PR DESCRIPTION
This prevents the alertmanager and thanos-ruler operators from getting
into a statefulset update loop similar to the fix that was
already applied to the prometheus operator.

Fixes #3048