### PR TITLE
only set thanos web.route-prefix if it was set by user

### DIFF
--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -238,16 +238,14 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		})
 	}
 
-	webRoutePrefix := "/"
 	if tr.Spec.RoutePrefix != "" {
-		webRoutePrefix = tr.Spec.RoutePrefix
+		trCLIArgs = append(trCLIArgs, fmt.Sprintf("--web.route-prefix=%s", tr.Spec.RoutePrefix))
 	}
-	trCLIArgs = append(trCLIArgs, fmt.Sprintf("--web.route-prefix=%s", webRoutePrefix))
 
 	localReloadURL := &url.URL{
 		Scheme: "http",
 		Host:   config.LocalHost + ":10902",
-		Path:   path.Clean(webRoutePrefix + "/-/reload"),
+		Path:   path.Clean(tr.Spec.RoutePrefix + "/-/reload"),
 	}
 
 	additionalContainers := []v1.Container{}


### PR DESCRIPTION
Due to a problem in the way thanos handles a web.route-prefix set
to '/' (https://github.com/thanos-io/thanos/issues/2207), the value
 should only set if the user has set a value for it.  If it's set
to empty string, no argument should be passed, so that thanos
uses it's own default value.