### PR TITLE
Fix constant Thanos Ruler Statefulset generation

### DIFF
--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -741,9 +741,9 @@ func (o *Operator) createCRDs() error {
 func createSSetInputHash(tr monitoringv1.ThanosRuler, c Config, ruleConfigMapNames []string, ss interface{}) (string, error) {
 	hash, err := hashstructure.Hash(struct {
 		TR monitoringv1.ThanosRuler
-		C Config
-		S interface{}
-		R []string `hash:"set"`
+		C  Config
+		S  interface{}
+		R  []string `hash:"set"`
 	}{tr, c, ss, ruleConfigMapNames},
 		nil,
 	)

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
 	"github.com/coreos/prometheus-operator/pkg/listwatch"
 	"github.com/coreos/prometheus-operator/pkg/operator"
+	"github.com/mitchellh/hashstructure"
 
 	prometheusoperator "github.com/coreos/prometheus-operator/pkg/prometheus"
 
@@ -606,7 +607,7 @@ func (o *Operator) sync(key string) error {
 	}
 
 	if !exists {
-		sset, err := makeStatefulSet(tr, nil, o.config, ruleConfigMapNames)
+		sset, err := makeStatefulSet(tr, nil, o.config, ruleConfigMapNames, "")
 		if err != nil {
 			return errors.Wrap(err, "making thanos statefulset config failed")
 		}
@@ -617,12 +618,30 @@ func (o *Operator) sync(key string) error {
 		return nil
 	}
 
-	sset, err := makeStatefulSet(tr, obj.(*appsv1.StatefulSet), o.config, ruleConfigMapNames)
+	spec := appsv1.StatefulSetSpec{}
+	if obj != nil {
+		ss := obj.(*appsv1.StatefulSet)
+		spec = ss.Spec
+	}
+
+	newSSetInputHash, err := createSSetInputHash(*tr, o.config, ruleConfigMapNames, spec)
+	if err != nil {
+		return err
+	}
+
+	sset, err := makeStatefulSet(tr, obj.(*appsv1.StatefulSet), o.config, ruleConfigMapNames, newSSetInputHash)
 	if err != nil {
 		return errors.Wrap(err, "making the statefulset, to update, failed")
 	}
 
 	operator.SanitizeSTS(sset)
+
+	oldSSetInputHash := obj.(*appsv1.StatefulSet).ObjectMeta.Annotations[sSetInputHashName]
+	if newSSetInputHash == oldSSetInputHash {
+		level.Debug(o.logger).Log("msg", "new statefulset generation inputs match current, skipping any actions")
+		return nil
+	}
+
 	_, err = ssetClient.Update(sset)
 	sErr, ok := err.(*apierrors.StatusError)
 
@@ -717,6 +736,26 @@ func (o *Operator) createCRDs() error {
 	}
 
 	return nil
+}
+
+func createSSetInputHash(tr monitoringv1.ThanosRuler, c Config, ruleConfigMapNames []string, ss interface{}) (string, error) {
+	hash, err := hashstructure.Hash(struct {
+		TR monitoringv1.ThanosRuler
+		C Config
+		S interface{}
+		R []string `hash:"set"`
+	}{tr, c, ss, ruleConfigMapNames},
+		nil,
+	)
+	if err != nil {
+		return "", errors.Wrap(
+			err,
+			"failed to calculate combined hash of ThanosRuler StatefulSet, ThanosRuler CRD, config and"+
+				" rule ConfigMap names",
+		)
+	}
+
+	return fmt.Sprintf("%d", hash), nil
 }
 
 func ListOptions(name string) metav1.ListOptions {

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -40,7 +40,6 @@ const (
 	defaultEvaluationInterval = "15s"
 	defaultReplicaLabelName   = "thanos_ruler_replica"
 	sSetInputHashName         = "prometheus-operator-input-hash"
-
 )
 
 var (

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -201,10 +201,9 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	for _, endpoint := range tr.Spec.QueryEndpoints {
 		trCLIArgs = append(trCLIArgs, fmt.Sprintf("--query=%s", endpoint))
 	}
-	for _, ruleConfigMapName := range ruleConfigMapNames {
-		rulePath := rulesDir + "/" + ruleConfigMapName + "/*.yaml"
-		trCLIArgs = append(trCLIArgs, fmt.Sprintf("--rule-file=%s", rulePath))
-	}
+
+	rulePath := rulesDir + "/*/*.yaml"
+	trCLIArgs = append(trCLIArgs, fmt.Sprintf("--rule-file=%s", rulePath))
 
 	if tr.Spec.AlertManagersConfig != nil {
 		trCLIArgs = append(trCLIArgs, "--alertmanagers.config=$(ALERTMANAGERS_CONFIG)")

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -39,6 +39,8 @@ const (
 	defaultRetention          = "24h"
 	defaultEvaluationInterval = "15s"
 	defaultReplicaLabelName   = "thanos_ruler_replica"
+	sSetInputHashName         = "prometheus-operator-input-hash"
+
 )
 
 var (
@@ -50,7 +52,7 @@ var (
 	}
 )
 
-func makeStatefulSet(tr *monitoringv1.ThanosRuler, old *appsv1.StatefulSet, config Config, ruleConfigMapNames []string) (*appsv1.StatefulSet, error) {
+func makeStatefulSet(tr *monitoringv1.ThanosRuler, old *appsv1.StatefulSet, config Config, ruleConfigMapNames []string, inputHash string) (*appsv1.StatefulSet, error) {
 
 	if tr.Spec.Image == "" {
 		tr.Spec.Image = config.ThanosDefaultBaseImage
@@ -104,6 +106,14 @@ func makeStatefulSet(tr *monitoringv1.ThanosRuler, old *appsv1.StatefulSet, conf
 
 	if old != nil {
 		statefulset.Annotations = old.Annotations
+	}
+
+	if statefulset.ObjectMeta.Annotations == nil {
+		statefulset.ObjectMeta.Annotations = map[string]string{
+			sSetInputHashName: inputHash,
+		}
+	} else {
+		statefulset.ObjectMeta.Annotations[sSetInputHashName] = inputHash
 	}
 
 	storageSpec := tr.Spec.Storage

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -52,6 +52,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	// kubectl annotations must not be on the statefulset so kubectl does
 	// not manage the generated object
 	expectedAnnotations := map[string]string{
+		"prometheus-operator-input-hash": "",
 		"testannotation": "testannotationvalue",
 	}
 
@@ -63,7 +64,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
 		},
-	}, nil, defaultTestConfig, nil)
+	}, nil, defaultTestConfig, nil, "")
 
 	require.NoError(t, err)
 
@@ -94,7 +95,7 @@ func TestPodLabelsAnnotations(t *testing.T) {
 				Labels:      labels,
 			},
 		},
-	}, nil, defaultTestConfig, nil)
+	}, nil, defaultTestConfig, nil, "")
 	require.NoError(t, err)
 	if _, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok {
 		t.Fatal("Pod labes are not properly propagated")
@@ -158,7 +159,7 @@ func TestStatefulSetVolumes(t *testing.T) {
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
 		},
-	}, nil, defaultTestConfig, []string{"rules-configmap-one"})
+	}, nil, defaultTestConfig, []string{"rules-configmap-one"}, "")
 	require.NoError(t, err)
 	if !reflect.DeepEqual(expected.Spec.Template.Spec.Volumes, sset.Spec.Template.Spec.Volumes) {
 		fmt.Println(pretty.Compare(expected.Spec.Template.Spec.Volumes, sset.Spec.Template.Spec.Volumes))
@@ -182,7 +183,7 @@ func TestTracing(t *testing.T) {
 				Key: testKey,
 			},
 		},
-	}, nil, defaultTestConfig, nil)
+	}, nil, defaultTestConfig, nil, "")
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -230,7 +231,7 @@ func TestObjectStorage(t *testing.T) {
 				Key: testKey,
 			},
 		},
-	}, nil, defaultTestConfig, nil)
+	}, nil, defaultTestConfig, nil, "")
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -325,7 +326,7 @@ func TestLabelsAndAlertDropLabels(t *testing.T) {
 				Labels:          tc.Labels,
 				AlertDropLabels: tc.AlertDropLabels,
 			},
-		}, nil, defaultTestConfig, nil)
+		}, nil, defaultTestConfig, nil, "")
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -359,7 +360,7 @@ func TestAdditionalContainers(t *testing.T) {
 	// The base to compare everything against
 	baseSet, err := makeStatefulSet(&monitoringv1.ThanosRuler{
 		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
-	}, nil, defaultTestConfig, nil)
+	}, nil, defaultTestConfig, nil, "")
 	require.NoError(t, err)
 
 	// Add an extra container
@@ -372,7 +373,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, nil, defaultTestConfig, nil)
+	}, nil, defaultTestConfig, nil, "")
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers)+1 != len(addSset.Spec.Template.Spec.Containers) {
@@ -392,7 +393,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, nil, defaultTestConfig, nil)
+	}, nil, defaultTestConfig, nil, "")
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers) != len(modSset.Spec.Template.Spec.Containers) {
@@ -422,7 +423,7 @@ func TestRetention(t *testing.T) {
 				Retention:      test.specRetention,
 				QueryEndpoints: emptyQueryEndpoints,
 			},
-		}, nil, defaultTestConfig, nil)
+		}, nil, defaultTestConfig, nil, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -486,7 +487,7 @@ func TestPodTemplateConfig(t *testing.T) {
 			PriorityClassName:  priorityClassName,
 			ServiceAccountName: serviceAccountName,
 		},
-	}, nil, defaultTestConfig, nil)
+	}, nil, defaultTestConfig, nil, "")
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -53,7 +53,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	// not manage the generated object
 	expectedAnnotations := map[string]string{
 		"prometheus-operator-input-hash": "",
-		"testannotation": "testannotationvalue",
+		"testannotation":                 "testannotationvalue",
 	}
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{


### PR DESCRIPTION
Fixes #3056

Basically the Thanos Ruler statefulset object is constantly being updated whenever a PrometheusRule object undergoes a CRUD operation. This PR makes it so that:

- We no longer look for the specific name of the ConfigMap created, instead using globs to match zero or more ConfigMaps. The container arguments will now not get updated if one or more configmap names are created.
- We do a check on the StatefulSet that the operator wants to generate for Thanos Ruler. If it does not need to be updated, it won't be.