### PR TITLE
pkg/thanos: fix thanos statefulset sync updates

### DIFF
--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -607,7 +607,7 @@ func (o *Operator) sync(key string) error {
 	}
 
 	if !exists {
-		sset, err := makeStatefulSet(tr, nil, o.config, ruleConfigMapNames, "")
+		sset, err := makeStatefulSet(tr, o.config, ruleConfigMapNames, "")
 		if err != nil {
 			return errors.Wrap(err, "making thanos statefulset config failed")
 		}
@@ -629,7 +629,7 @@ func (o *Operator) sync(key string) error {
 		return err
 	}
 
-	sset, err := makeStatefulSet(tr, obj.(*appsv1.StatefulSet), o.config, ruleConfigMapNames, newSSetInputHash)
+	sset, err := makeStatefulSet(tr, o.config, ruleConfigMapNames, newSSetInputHash)
 	if err != nil {
 		return errors.Wrap(err, "making the statefulset, to update, failed")
 	}

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -51,7 +51,7 @@ var (
 	}
 )
 
-func makeStatefulSet(tr *monitoringv1.ThanosRuler, old *appsv1.StatefulSet, config Config, ruleConfigMapNames []string, inputHash string) (*appsv1.StatefulSet, error) {
+func makeStatefulSet(tr *monitoringv1.ThanosRuler, config Config, ruleConfigMapNames []string, inputHash string) (*appsv1.StatefulSet, error) {
 
 	if tr.Spec.Image == "" {
 		tr.Spec.Image = config.ThanosDefaultBaseImage
@@ -101,10 +101,6 @@ func makeStatefulSet(tr *monitoringv1.ThanosRuler, old *appsv1.StatefulSet, conf
 
 	if tr.Spec.ImagePullSecrets != nil && len(tr.Spec.ImagePullSecrets) > 0 {
 		statefulset.Spec.Template.Spec.ImagePullSecrets = tr.Spec.ImagePullSecrets
-	}
-
-	if old != nil {
-		statefulset.Annotations = old.Annotations
 	}
 
 	if statefulset.ObjectMeta.Annotations == nil {

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -64,7 +64,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
 		},
-	}, nil, defaultTestConfig, nil, "")
+	}, defaultTestConfig, nil, "")
 
 	require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestPodLabelsAnnotations(t *testing.T) {
 				Labels:      labels,
 			},
 		},
-	}, nil, defaultTestConfig, nil, "")
+	}, defaultTestConfig, nil, "")
 	require.NoError(t, err)
 	if _, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok {
 		t.Fatal("Pod labes are not properly propagated")
@@ -159,7 +159,7 @@ func TestStatefulSetVolumes(t *testing.T) {
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
 		},
-	}, nil, defaultTestConfig, []string{"rules-configmap-one"}, "")
+	}, defaultTestConfig, []string{"rules-configmap-one"}, "")
 	require.NoError(t, err)
 	if !reflect.DeepEqual(expected.Spec.Template.Spec.Volumes, sset.Spec.Template.Spec.Volumes) {
 		fmt.Println(pretty.Compare(expected.Spec.Template.Spec.Volumes, sset.Spec.Template.Spec.Volumes))
@@ -183,7 +183,7 @@ func TestTracing(t *testing.T) {
 				Key: testKey,
 			},
 		},
-	}, nil, defaultTestConfig, nil, "")
+	}, defaultTestConfig, nil, "")
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestObjectStorage(t *testing.T) {
 				Key: testKey,
 			},
 		},
-	}, nil, defaultTestConfig, nil, "")
+	}, defaultTestConfig, nil, "")
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -326,7 +326,7 @@ func TestLabelsAndAlertDropLabels(t *testing.T) {
 				Labels:          tc.Labels,
 				AlertDropLabels: tc.AlertDropLabels,
 			},
-		}, nil, defaultTestConfig, nil, "")
+		}, defaultTestConfig, nil, "")
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -360,7 +360,7 @@ func TestAdditionalContainers(t *testing.T) {
 	// The base to compare everything against
 	baseSet, err := makeStatefulSet(&monitoringv1.ThanosRuler{
 		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
-	}, nil, defaultTestConfig, nil, "")
+	}, defaultTestConfig, nil, "")
 	require.NoError(t, err)
 
 	// Add an extra container
@@ -373,7 +373,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, nil, defaultTestConfig, nil, "")
+	}, defaultTestConfig, nil, "")
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers)+1 != len(addSset.Spec.Template.Spec.Containers) {
@@ -393,7 +393,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, nil, defaultTestConfig, nil, "")
+	}, defaultTestConfig, nil, "")
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers) != len(modSset.Spec.Template.Spec.Containers) {
@@ -423,7 +423,7 @@ func TestRetention(t *testing.T) {
 				Retention:      test.specRetention,
 				QueryEndpoints: emptyQueryEndpoints,
 			},
-		}, nil, defaultTestConfig, nil, "")
+		}, defaultTestConfig, nil, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -487,7 +487,7 @@ func TestPodTemplateConfig(t *testing.T) {
 			PriorityClassName:  priorityClassName,
 			ServiceAccountName: serviceAccountName,
 		},
-	}, nil, defaultTestConfig, nil, "")
+	}, defaultTestConfig, nil, "")
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}


### PR DESCRIPTION
Changes to the ThanosRuler objects were being ignored by the operator.
This was due to copying the hash annotation of the old statefulset
to the new one before doing the comparison, thus they were always
appearing to be equal.

There doesn't seem to be any reason why we are copying the annotations
from the old statefulset to the new one, so this has been removed.

Fixes #3081