### PR TITLE
consolidate container image defaults

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -31,6 +31,7 @@ import (
 	alertmanagercontroller "github.com/coreos/prometheus-operator/pkg/alertmanager"
 	"github.com/coreos/prometheus-operator/pkg/api"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	prometheuscontroller "github.com/coreos/prometheus-operator/pkg/prometheus"
 	thanoscontroller "github.com/coreos/prometheus-operator/pkg/thanos"
 	"github.com/coreos/prometheus-operator/pkg/version"
@@ -133,13 +134,13 @@ func init() {
 	// Prometheus Operator image, tagged with the same semver version. Default to
 	// the Prometheus Operator version if no Prometheus config reloader image is
 	// specified.
-	flagset.StringVar(&cfg.PrometheusConfigReloaderImage, "prometheus-config-reloader", fmt.Sprintf("quay.io/coreos/prometheus-config-reloader:v%v", version.Version), "Prometheus config reloader image")
-	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", "jimmidyson/configmap-reload:v0.3.0", "Reload Image")
+	flagset.StringVar(&cfg.PrometheusConfigReloaderImage, "prometheus-config-reloader", operator.DefaultPrometheusConfigReloaderImage, "Prometheus config reloader image")
+	flagset.StringVar(&cfg.ConfigReloaderImage, "config-reloader-image", operator.DefaultConfigMapReloaderImage, "Reload Image")
 	flagset.StringVar(&cfg.ConfigReloaderCPU, "config-reloader-cpu", "100m", "Config Reloader CPU. Value \"0\" disables it and causes no limit to be configured.")
 	flagset.StringVar(&cfg.ConfigReloaderMemory, "config-reloader-memory", "25Mi", "Config Reloader Memory. Value \"0\" disables it and causes no limit to be configured.")
-	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", "quay.io/prometheus/alertmanager", "Alertmanager default base image")
-	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", "quay.io/prometheus/prometheus", "Prometheus default base image")
-	flagset.StringVar(&cfg.ThanosDefaultBaseImage, "thanos-default-base-image", "quay.io/thanos/thanos", "Thanos default base image")
+	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image")
+	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", operator.DefaultPrometheusBaseImage, "Prometheus default base image")
+	flagset.StringVar(&cfg.ThanosDefaultBaseImage, "thanos-default-base-image", operator.DefaultThanosBaseImage, "Thanos default base image")
 	flagset.Var(ns, "namespaces", "Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list). This is mutually exclusive with --deny-namespaces.")
 	flagset.Var(deniedNs, "deny-namespaces", "Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with --namespaces.")
 	flagset.Var(prometheusNs, "prometheus-instance-namespaces", "Namespaces where Prometheus custom resources and corresponding Secrets, Configmaps and StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Prometheus custom resources.")

--- a/cmd/po-docgen/compatibility.go
+++ b/cmd/po-docgen/compatibility.go
@@ -17,7 +17,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/coreos/prometheus-operator/pkg/prometheus"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 )
 
 func printCompatMatrixDocs() {
@@ -41,7 +41,7 @@ Due to the use of CustomResourceDefinitions Kubernetes >= v1.7.0 is required.
 The versions of Prometheus compatible to be run with the Prometheus Operator are:`)
 	fmt.Println("")
 
-	for _, v := range prometheus.CompatibilityMatrix {
+	for _, v := range operator.PrometheusCompatibilityMatrix {
 		fmt.Printf("* %s\n", v)
 	}
 

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -29,14 +29,12 @@ import (
 	"github.com/blang/semver"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/pkg/errors"
 )
 
 const (
-	governingServiceName = "alertmanager-operated"
-	// DefaultVersion specifies which version of Alertmanager the Prometheus
-	// Operator uses by default.
-	DefaultVersion         = "v0.20.0"
+	governingServiceName   = "alertmanager-operated"
 	defaultRetention       = "120h"
 	secretsDir             = "/etc/alertmanager/secrets/"
 	configmapsDir          = "/etc/alertmanager/configmaps/"
@@ -63,7 +61,7 @@ func makeStatefulSet(am *monitoringv1.Alertmanager, old *appsv1.StatefulSet, con
 		am.Spec.PortName = defaultPortName
 	}
 	if am.Spec.Version == "" {
-		am.Spec.Version = DefaultVersion
+		am.Spec.Version = operator.DefaultAlertmanagerVersion
 	}
 	if am.Spec.Replicas == nil {
 		am.Spec.Replicas = &minReplicas

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -266,7 +267,7 @@ func TestMakeStatefulSetSpecSingleDoubleDashedArgs(t *testing.T) {
 func TestMakeStatefulSetSpecWebRoutePrefix(t *testing.T) {
 	a := monitoringv1.Alertmanager{}
 	replicas := int32(1)
-	a.Spec.Version = DefaultVersion
+	a.Spec.Version = operator.DefaultAlertmanagerVersion
 	a.Spec.Replicas = &replicas
 
 	statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -1,0 +1,74 @@
+// Copyright 2020 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"github.com/coreos/prometheus-operator/pkg/version"
+)
+
+const (
+	DefaultAlertmanagerVersion    = "v0.20.0"
+	DefaultAlertmanagerBaseImage  = "quay.io/prometheus/alertmanager"
+	DefaultAlertmanagerImage      = DefaultAlertmanagerBaseImage + ":" + DefaultAlertmanagerVersion
+	DefaultThanosVersion          = "v0.11.0"
+	DefaultThanosBaseImage        = "quay.io/thanos/thanos"
+	DefaultThanosImage            = DefaultThanosBaseImage + ":" + DefaultThanosVersion
+	DefaultConfigMapReloaderImage = "jimmidyson/configmap-reload:v0.3.0"
+)
+
+var (
+	DefaultPrometheusConfigReloaderImage = "quay.io/coreos/prometheus-config-reloader:v" + version.Version
+
+	PrometheusCompatibilityMatrix = []string{
+		"v1.4.0",
+		"v1.4.1",
+		"v1.5.0",
+		"v1.5.1",
+		"v1.5.2",
+		"v1.5.3",
+		"v1.6.0",
+		"v1.6.1",
+		"v1.6.2",
+		"v1.6.3",
+		"v1.7.0",
+		"v1.7.1",
+		"v1.7.2",
+		"v1.8.0",
+		"v2.0.0",
+		"v2.2.1",
+		"v2.3.1",
+		"v2.3.2",
+		"v2.4.0",
+		"v2.4.1",
+		"v2.4.2",
+		"v2.4.3",
+		"v2.5.0",
+		"v2.6.0",
+		"v2.6.1",
+		"v2.7.0",
+		"v2.7.1",
+		"v2.7.2",
+		"v2.8.1",
+		"v2.9.2",
+		"v2.10.0",
+		"v2.11.0",
+		"v2.14.0",
+		"v2.15.2",
+		"v2.16.0",
+	}
+	DefaultPrometheusVersion   = PrometheusCompatibilityMatrix[len(PrometheusCompatibilityMatrix)-1]
+	DefaultPrometheusBaseImage = "quay.io/prometheus/prometheus"
+	DefaultPrometheusImage     = DefaultAlertmanagerBaseImage + ":" + DefaultPrometheusVersion
+)

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 )
 
 const (
@@ -161,7 +162,7 @@ func (cg *configGenerator) generateConfig(
 ) ([]byte, error) {
 	versionStr := p.Spec.Version
 	if versionStr == "" {
-		versionStr = DefaultPrometheusVersion
+		versionStr = operator.DefaultPrometheusVersion
 	}
 
 	version, err := semver.Parse(strings.TrimLeft(versionStr, "v"))

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -27,12 +27,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 
 	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestConfigGeneration(t *testing.T) {
-	for _, v := range CompatibilityMatrix {
+	for _, v := range operator.PrometheusCompatibilityMatrix {
 		cfg, err := generateTestConfig(v)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -29,12 +29,12 @@ import (
 	"github.com/blang/semver"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/pkg/errors"
 )
 
 const (
 	governingServiceName            = "prometheus-operated"
-	DefaultThanosVersion            = "v0.11.0"
 	defaultRetention                = "24h"
 	defaultReplicaExternalLabelName = "prometheus_replica"
 	storageDir                      = "/prometheus"
@@ -59,45 +59,6 @@ var (
 		managedByOperatorLabel: managedByOperatorLabelValue,
 	}
 	probeTimeoutSeconds int32 = 3
-
-	CompatibilityMatrix = []string{
-		"v1.4.0",
-		"v1.4.1",
-		"v1.5.0",
-		"v1.5.1",
-		"v1.5.2",
-		"v1.5.3",
-		"v1.6.0",
-		"v1.6.1",
-		"v1.6.2",
-		"v1.6.3",
-		"v1.7.0",
-		"v1.7.1",
-		"v1.7.2",
-		"v1.8.0",
-		"v2.0.0",
-		"v2.2.1",
-		"v2.3.1",
-		"v2.3.2",
-		"v2.4.0",
-		"v2.4.1",
-		"v2.4.2",
-		"v2.4.3",
-		"v2.5.0",
-		"v2.6.0",
-		"v2.6.1",
-		"v2.7.0",
-		"v2.7.1",
-		"v2.7.2",
-		"v2.8.1",
-		"v2.9.2",
-		"v2.10.0",
-		"v2.11.0",
-		"v2.14.0",
-		"v2.15.2",
-		"v2.16.0",
-	}
-	DefaultPrometheusVersion = CompatibilityMatrix[len(CompatibilityMatrix)-1]
 )
 
 func makeStatefulSet(
@@ -120,10 +81,10 @@ func makeStatefulSet(
 		p.Spec.BaseImage = config.PrometheusDefaultBaseImage
 	}
 	if p.Spec.Version == "" {
-		p.Spec.Version = DefaultPrometheusVersion
+		p.Spec.Version = operator.DefaultPrometheusVersion
 	}
 	if p.Spec.Thanos != nil && p.Spec.Thanos.Version == nil {
-		v := DefaultThanosVersion
+		v := operator.DefaultThanosVersion
 		p.Spec.Thanos.Version = &v
 	}
 

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -22,6 +22,7 @@ import (
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/coreos/prometheus-operator/pkg/k8sutil"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -31,7 +32,6 @@ import (
 )
 
 const (
-	DefaultThanosVersion      = "v0.11.0"
 	rulesDir                  = "/etc/thanos/rules"
 	storageDir                = "/thanos/data"
 	governingServiceName      = "thanos-ruler-operated"
@@ -57,7 +57,7 @@ func makeStatefulSet(tr *monitoringv1.ThanosRuler, config Config, ruleConfigMapN
 		tr.Spec.Image = config.ThanosDefaultBaseImage
 	}
 	if !strings.Contains(tr.Spec.Image, ":") {
-		tr.Spec.Image = tr.Spec.Image + ":" + DefaultThanosVersion
+		tr.Spec.Image = tr.Spec.Image + ":" + operator.DefaultThanosVersion
 	}
 	if tr.Spec.Resources.Requests == nil {
 		tr.Spec.Resources.Requests = v1.ResourceList{}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/coreos/prometheus-operator/pkg/alertmanager"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/coreos/prometheus-operator/pkg/prometheus"
 	testFramework "github.com/coreos/prometheus-operator/test/framework"
 
@@ -121,8 +122,8 @@ func testPromVersionMigration(t *testing.T) {
 	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
 
 	name := "test"
-	startVersion := prometheus.CompatibilityMatrix[0]
-	compatibilityMatrix := prometheus.CompatibilityMatrix[1:]
+	startVersion := operator.PrometheusCompatibilityMatrix[0]
+	compatibilityMatrix := operator.PrometheusCompatibilityMatrix[1:]
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 	p.Spec.Version = startVersion
@@ -1279,7 +1280,7 @@ func testThanos(t *testing.T) {
 	ns := ctx.CreateNamespace(t, framework.KubeClient)
 	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
 
-	version := prometheus.DefaultThanosVersion
+	version := operator.DefaultThanosVersion
 
 	prom := framework.MakeBasicPrometheus(ns, "basic-prometheus", "test-group", 1)
 	prom.Spec.Replicas = proto.Int32(2)

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/coreos/prometheus-operator/pkg/operator"
 	"github.com/coreos/prometheus-operator/pkg/prometheus"
 	"github.com/pkg/errors"
 )
@@ -43,7 +44,7 @@ func (f *Framework) MakeBasicPrometheus(ns, name, group string, replicas int32) 
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			Replicas: &replicas,
-			Version:  prometheus.DefaultPrometheusVersion,
+			Version:  operator.DefaultPrometheusVersion,
 			ServiceMonitorSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"group": group,


### PR DESCRIPTION
This moves the default image versions and urls from multiple
packages into a single location in the operator package.
This has the advantage of easier maintenance and ensuring that
the default Thanos sidecar image doesn't become out of
sync with the default image used for Thanos Ruler.

This is a subset of #3003, to try to reduce the complexity of that one.