### PR TITLE
use tolerant parsing of version strings

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -234,9 +234,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 		image = *a.Spec.Image
 	}
 
-	versionStr := strings.TrimLeft(a.Spec.Version, "v")
-
-	version, err := semver.Parse(versionStr)
+	version, err := semver.ParseTolerant(a.Spec.Version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse alertmanager version")
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -165,7 +165,7 @@ func (cg *configGenerator) generateConfig(
 		versionStr = operator.DefaultPrometheusVersion
 	}
 
-	version, err := semver.Parse(strings.TrimLeft(versionStr, "v"))
+	version, err := semver.ParseTolerant(versionStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse version")
 	}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -92,9 +92,7 @@ func makeStatefulSet(
 		p.Spec.PortName = defaultPortName
 	}
 
-	versionStr := strings.TrimLeft(p.Spec.Version, "v")
-
-	version, err := semver.Parse(versionStr)
+	version, err := semver.ParseTolerant(p.Spec.Version)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse version")
 	}
@@ -297,9 +295,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 	// Allow up to 10 minutes for clean termination.
 	terminationGracePeriod := int64(600)
 
-	versionStr := strings.TrimLeft(p.Spec.Version, "v")
-
-	version, err := semver.Parse(versionStr)
+	version, err := semver.ParseTolerant(p.Spec.Version)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse version")
 	}


### PR DESCRIPTION
From the godoc:

ParseTolerant allows for certain version specifications that do not
strictly adhere to semver specs to be parsed by the semver library.
It currently trims spaces, removes a "v" prefix, and adds a
0 patch number to versions with only major and minor components specified.