### PR TITLE
Do not modify the PrometheusRule cache object

### DIFF
--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -176,7 +176,7 @@ func (c *Operator) selectRules(p *monitoringv1.Prometheus, namespaces []string) 
 	for _, ns := range namespaces {
 		var marshalErr error
 		err := cache.ListAllByNamespace(c.ruleInf.GetIndexer(), ns, ruleSelector, func(obj interface{}) {
-			promRule := obj.(*monitoringv1.PrometheusRule)
+			promRule := obj.(*monitoringv1.PrometheusRule).DeepCopy()
 			content, err := generateContent(promRule.Spec, p.Spec.EnforcedNamespaceLabel, promRule.Namespace)
 			if err != nil {
 				marshalErr = err

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -176,7 +176,7 @@ func (o *Operator) selectRules(t *monitoringv1.ThanosRuler, namespaces []string)
 	for _, ns := range namespaces {
 		var marshalErr error
 		err := cache.ListAllByNamespace(o.ruleInf.GetIndexer(), ns, ruleSelector, func(obj interface{}) {
-			promRule := obj.(*monitoringv1.PrometheusRule)
+			promRule := obj.(*monitoringv1.PrometheusRule).DeepCopy()
 			content, err := generateContent(promRule.Spec, t.Spec.EnforcedNamespaceLabel, promRule.Namespace)
 			if err != nil {
 				marshalErr = err


### PR DESCRIPTION
As we modify the PrometheusRule when generating the content, we need to make first a DeepCopy of the PrometheusRule object to be able to modify in-place. Currently we were modifying the cached PrometheusRule object, which caused changes to not propagate to the orginal object.

Side note: we need to refactor the prometheus and thanos ruler common code to avoid not missing fixing these kids of errors in the future!

cc @coreos/team-monitoring 