### PR TITLE
prometheus-config-reloader: support for watching rules directory

### DIFF
--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -51,6 +51,8 @@ func main() {
 	cfgSubstFile := app.Flag("config-envsubst-file", "output file for environment variable substituted config file").
 		String()
 
+	rulesDir := app.Flag("rules-dir", "Rules directory to watch non-recursively").Strings()
+
 	createStatefulsetOrdinalFrom := app.Flag(
 		"statefulset-ordinal-from-envvar",
 		fmt.Sprintf("parse this environment variable to create %s, containing the statefulset ordinal number", statefulsetOrdinalEnvvar)).
@@ -87,7 +89,7 @@ func main() {
 	var g run.Group
 	{
 		ctx, cancel := context.WithCancel(context.Background())
-		rel := reloader.New(logger, *reloadURL, *cfgFile, *cfgSubstFile, []string{})
+		rel := reloader.New(logger, *reloadURL, *cfgFile, *cfgSubstFile, *rulesDir)
 
 		g.Add(func() error {
 			return rel.Watch(ctx)


### PR DESCRIPTION
Add --rules-dirs to expose the directory watching feature of the reloader library.