### PR TITLE
Allow setting the cluster domain so alertmanager makes fewer DNS calls

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -151,6 +151,7 @@ func init() {
 	flagset.Var(&cfg.CrdKinds, "crd-kinds", " - EXPERIMENTAL (could be removed in future releases) - customize CRD kind names")
 	flagset.BoolVar(&cfg.EnableValidation, "with-validation", true, "Include the validation spec in the CRD")
 	flagset.StringVar(&cfg.LocalHost, "localhost", "localhost", "EXPERIMENTAL (could be removed in future releases) - Host used to communicate between local services on a pod. Fixes issues where localhost resolves incorrectly.")
+	flagset.StringVar(&cfg.ClusterDomain, "cluster-domain", "", "The domain of the cluster. This is used to generate service FQDNs. If this is not specified, DNS search domain expansion is used instead.")
 	flagset.StringVar(&cfg.LogLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(availableLogLevels, ", ")))
 	flagset.StringVar(&cfg.LogFormat, "log-format", logFormatLogfmt, fmt.Sprintf("Log format to use. Possible values: %s", strings.Join(availableLogFormats, ", ")))
 	flagset.BoolVar(&cfg.ManageCRDs, "manage-crds", true, "Manage all CRDs with the Prometheus Operator.")

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -74,6 +74,7 @@ type Operator struct {
 type Config struct {
 	Host                         string
 	LocalHost                    string
+	ClusterDomain                string
 	ConfigReloaderImage          string
 	ConfigReloaderCPU            string
 	ConfigReloaderMemory         string
@@ -118,6 +119,7 @@ func New(c prometheusoperator.Config, logger log.Logger, r prometheus.Registerer
 		config: Config{
 			Host:                         c.Host,
 			LocalHost:                    c.LocalHost,
+			ClusterDomain:                c.ClusterDomain,
 			ConfigReloaderImage:          c.ConfigReloaderImage,
 			ConfigReloaderCPU:            c.ConfigReloaderCPU,
 			ConfigReloaderMemory:         c.ConfigReloaderMemory,

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -327,8 +327,15 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	podLabels["app"] = "alertmanager"
 	podLabels["alertmanager"] = a.Name
 
+	var clusterPeerDomain string
+	if config.ClusterDomain != "" {
+		clusterPeerDomain = fmt.Sprintf("%s.%s.svc.%s.", governingServiceName, a.Namespace, config.ClusterDomain)
+	} else {
+		// The default DNS search path will resolve this to the cluster domain
+		clusterPeerDomain = fmt.Sprintf("%s.%s", governingServiceName, a.Namespace)
+	}
 	for i := int32(0); i < *a.Spec.Replicas; i++ {
-		amArgs = append(amArgs, fmt.Sprintf("--cluster.peer=%s-%d.%s.%s.svc:9094", prefixedName(a.Name), i, governingServiceName, a.Namespace))
+		amArgs = append(amArgs, fmt.Sprintf("--cluster.peer=%s-%d.%s:9094", prefixedName(a.Name), i, clusterPeerDomain))
 	}
 
 	for _, peer := range a.Spec.AdditionalPeers {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -331,8 +331,8 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	if config.ClusterDomain != "" {
 		clusterPeerDomain = fmt.Sprintf("%s.%s.svc.%s.", governingServiceName, a.Namespace, config.ClusterDomain)
 	} else {
-		// The default DNS search path will resolve this to the cluster domain
-		clusterPeerDomain = fmt.Sprintf("%s.%s", governingServiceName, a.Namespace)
+		// The default DNS search path is .svc.<cluster domain>
+		clusterPeerDomain = governingServiceName
 	}
 	for i := int32(0); i < *a.Spec.Replicas; i++ {
 		amArgs = append(amArgs, fmt.Sprintf("--cluster.peer=%s-%d.%s:9094", prefixedName(a.Name), i, clusterPeerDomain))

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -290,6 +290,73 @@ func TestMakeStatefulSetSpecWebRoutePrefix(t *testing.T) {
 	}
 }
 
+func TestMakeStatefulSetSpecPeersWithoutClusterDomain(t *testing.T) {
+	replicas := int32(1)
+	a := monitoringv1.Alertmanager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alertmanager",
+			Namespace: "monitoring",
+		},
+		Spec: monitoringv1.AlertmanagerSpec{
+			Version:  "v0.15.3",
+			Replicas: &replicas,
+		},
+	}
+
+	statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	amArgs := statefulSet.Template.Spec.Containers[0].Args
+	expectedArg := "--cluster.peer=alertmanager-alertmanager-0.alertmanager-operated.monitoring:9094"
+	for _, arg := range amArgs {
+		if arg == expectedArg {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("Cluster peer argument %v was not found in %v.", expectedArg, amArgs)
+	}
+}
+
+func TestMakeStatefulSetSpecPeersWithClusterDomain(t *testing.T) {
+	replicas := int32(1)
+	a := monitoringv1.Alertmanager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alertmanager",
+			Namespace: "monitoring",
+		},
+		Spec: monitoringv1.AlertmanagerSpec{
+			Version:  "v0.15.3",
+			Replicas: &replicas,
+		},
+	}
+
+	configWithClusterDomain := defaultTestConfig
+	configWithClusterDomain.ClusterDomain = "custom.cluster"
+
+	statefulSet, err := makeStatefulSetSpec(&a, configWithClusterDomain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	amArgs := statefulSet.Template.Spec.Containers[0].Args
+	expectedArg := "--cluster.peer=alertmanager-alertmanager-0.alertmanager-operated.monitoring.svc.custom.cluster.:9094"
+	for _, arg := range amArgs {
+		if arg == expectedArg {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("Cluster peer argument %v was not found in %v.", expectedArg, amArgs)
+	}
+}
+
 func TestMakeStatefulSetSpecAdditionalPeers(t *testing.T) {
 	a := monitoringv1.Alertmanager{}
 	a.Spec.Version = "v0.15.3"

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -310,7 +310,7 @@ func TestMakeStatefulSetSpecPeersWithoutClusterDomain(t *testing.T) {
 
 	found := false
 	amArgs := statefulSet.Template.Spec.Containers[0].Args
-	expectedArg := "--cluster.peer=alertmanager-alertmanager-0.alertmanager-operated.monitoring:9094"
+	expectedArg := "--cluster.peer=alertmanager-alertmanager-0.alertmanager-operated:9094"
 	for _, arg := range amArgs {
 		if arg == expectedArg {
 			found = true

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -133,6 +133,7 @@ func (labels *Labels) Set(value string) error {
 // Config defines configuration parameters for the Operator.
 type Config struct {
 	Host                          string
+	ClusterDomain                 string
 	KubeletObject                 string
 	ListenAddress                 string
 	TLSInsecure                   bool


### PR DESCRIPTION
Fixes #2934. This is a more complete version of #2936.

There are two changes in this PR:
 - Allow specifying the cluster domain.
    - This allows using FQDNs for referencing the alertmanager so that the DNS search domain isn't used.
    - This is something that is global to the cluster so I placed it in the operator configuration instead of alertmanager configuration.
 - Remove the `.svc` extension on the alertmanager url when he cluster domain is not specified.
    - The default search domain is `.svc.<cluster-domain>` so this reduces the amount of DNS calls when the cluster domain isn't specified from 6 to 2 (1 for ipv4, 1 for ipv6).

(cc @oded-dd)