### PR TITLE
RELEASE.md: improve instructions to tag a release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -61,7 +61,7 @@ You can do the tagging on the commandline:
 
 ```bash
 $ tag=$(< VERSION) && git tag -s "v${tag}" -m "v${tag}"
-$ git push --tags
+$ git push origin "v${tag}"
 ```
 
 Signed tag with a GPG key is appreciated, but in case you can't add a GPG key to your Github account using the following [procedure](https://help.github.com/articles/generating-a-gpg-key/), you can replace the `-s` flag by `-a` flag of the `git tag` command to only annotate the tag without signing.


### PR DESCRIPTION
Taken from the [Prometheus instructions](https://github.com/prometheus/prometheus/blob/master/RELEASE.md#2-draft-the-new-release). It is less error-prone that `git push --tags`.