### PR TITLE
Fix `make generate-in-docker` on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ generate: $(DEEPCOPY_TARGET) $(CRD_JSONNET_FILES) bundle.yaml $(shell find Docum
 
 .PHONY: generate-in-docker
 generate-in-docker:
-	$(CONTAINER_CMD) $(MAKE) $(MFLAGS) --always-make generate
+	$(CONTAINER_CMD) make --always-make generate
 
 $(CRD_YAML_FILES): $(CONTROLLER_GEN_BINARY) $(TYPES_V1_TARGET)
 	$(CONTROLLER_GEN_BINARY) $(CRD_OPTIONS) paths=./pkg/apis/monitoring/v1 output:crd:dir=./example/prometheus-operator-crd


### PR DESCRIPTION
The `$(MAKE)` variable is intended for running the same make again,
recursively, propagating the outer make's settings. This is not what is
intended here: the Docker layer is there to insulate the generation
process from the host. Use plain `make` in the container.

Fixes

```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/Applications/Xcode.app/Contents/Developer/usr/bin/make\": stat /Applications/Xcode.app/Contents/Developer/usr/bin/make: no such file or directory": unknown.
```

Signed-off-by: Matthias Rampke <mr@soundcloud.com>