### PR TITLE
Multi-arch images (adding ARMv7 & ARM64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 SHELL=/bin/bash -o pipefail
 
-OS?=$(shell go env GOOS)
-ARCH?=$(shell go env GOARCH)
+GOOS?=$(shell go env GOOS)
+GOARCH?=$(shell go env GOARCH)
+ifeq ($(GOARCH),arm)
+	ARCH=armv7
+else
+	ARCH=$(GOARCH)
+endif
 
 GO_PKG=github.com/coreos/prometheus-operator
 REPO?=quay.io/coreos/prometheus-operator
@@ -39,7 +44,7 @@ K8S_GEN_DEPS:=.header
 K8S_GEN_DEPS+=$(TYPES_V1_TARGET)
 K8S_GEN_DEPS+=$(foreach bin,$(K8S_GEN_BINARIES),$(FIRST_GOPATH)/bin/$(bin))
 
-GO_BUILD_RECIPE=GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -mod=vendor -ldflags="-s -X $(GO_PKG)/pkg/version.Version=$(VERSION)"
+GO_BUILD_RECIPE=GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -mod=vendor -ldflags="-s -X $(GO_PKG)/pkg/version.Version=$(VERSION)"
 pkgs = $(shell go list ./... | grep -v /vendor/ | grep -v /test/ | grep -v /contrib/)
 
 CONTAINER_CMD:=docker run --rm \
@@ -123,15 +128,16 @@ image: .hack-operator-image .hack-prometheus-config-reloader-image
 # Create empty target file, for the sole purpose of recording when this target
 # was last executed via the last-modification timestamp on the file. See
 # https://www.gnu.org/software/make/manual/make.html#Empty-Targets
-	docker build --build-arg ARCH=$(ARCH) --build-arg OS=$(OS) -t $(REPO):$(TAG) .
+	docker build --build-arg ARCH=$(ARCH) --build-arg OS=$(GOOS) -t $(REPO):$(TAG) .
 	touch $@
 
 .hack-prometheus-config-reloader-image: cmd/prometheus-config-reloader/Dockerfile prometheus-config-reloader
 # Create empty target file, for the sole purpose of recording when this target
 # was last executed via the last-modification timestamp on the file. See
 # https://www.gnu.org/software/make/manual/make.html#Empty-Targets
-	docker build -t $(REPO_PROMETHEUS_CONFIG_RELOADER):$(TAG) -f cmd/prometheus-config-reloader/Dockerfile .
+	docker build --build-arg ARCH=$(ARCH) --build-arg OS=$(GOOS) -t $(REPO_PROMETHEUS_CONFIG_RELOADER):$(TAG) -f cmd/prometheus-config-reloader/Dockerfile .
 	touch $@
+
 
 ##############
 # Generating #

--- a/scripts/travis-push-docker-image.sh
+++ b/scripts/travis-push-docker-image.sh
@@ -11,9 +11,12 @@ function defer {
 }
 trap defer EXIT
 
+CPU_ARCHS="amd64 arm64 arm"
+
 # Push to Quay '-dev' repo if it's not a git tag or master branch build.
 export REPO="quay.io/coreos/prometheus-operator"
 export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/coreos/prometheus-config-reloader"
+
 if [[ "${TRAVIS_TAG}" == "" ]] && [[ "${TRAVIS_BRANCH}" != master ]]; then
 	export REPO="quay.io/coreos/prometheus-operator-dev"
 	export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/coreos/prometheus-config-reloader-dev"
@@ -22,8 +25,27 @@ fi
 # For both git tags and git branches 'TRAVIS_BRANCH' contains the name.
 export TAG="${TRAVIS_BRANCH}"
 
-make image
+for arch in ${CPU_ARCHS}; do
+	make --always-make image GOARCH="$arch" TAG="${TAG}-$arch"
+done
 
 echo "${QUAY_PASSWORD}" | docker login -u "${QUAY_USERNAME}" --password-stdin quay.io
-docker push "${REPO}:${TAG}"
-docker push "${REPO_PROMETHEUS_CONFIG_RELOADER}:${TAG}"
+export DOCKER_CLI_EXPERIMENTAL=enabled
+for r in ${REPO} ${REPO_PROMETHEUS_CONFIG_RELOADER}; do
+	# Images need to be on remote registry before creating manifests
+	for arch in $CPU_ARCHS; do
+		docker push "${r}:${TAG}-$arch"
+	done
+
+	# Create manifest to join all images under one virtual tag
+	docker manifest create -a "${r}:${TAG}" \
+				  "${r}:${TAG}-amd64" \
+				  "${r}:${TAG}-arm64" \
+				  "${r}:${TAG}-arm"
+
+	# Annotate to set which image is build for which CPU architecture
+	for arch in $CPU_ARCHS; do
+		docker manifest annotate --arch "$arch" "${r}:${TAG}" "${r}:${TAG}-$arch"
+	done
+	docker manifest push "${r}:${TAG}"
+done


### PR DESCRIPTION
- conditionally set ARCH when building for ARM (ARMv7)
- allow building prometheus-config-reloader image for different cpu architectures
- adjust script responsible for pushing images to quay to push cross-architecture images and build image manifest

Following command allows building image for ARM devices
```
make image GOARCH=armv7
```

Manifest creation was tested on https://quay.io/repository/paulfantom/prometheus-config-reloader?tab=tags and https://quay.io/repository/paulfantom/prometheus-operator?tab=tags

Fixes #3162
Fixes #2946 