### PR TITLE
*: create separate namespace informers if needed

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -264,17 +263,6 @@ func (c *Operator) enqueue(obj interface{}) {
 	}
 
 	c.queue.Add(key)
-}
-
-// enqueueForNamespace enqueues all Alertmanager object keys that belong to the
-// given namespace.
-func (c *Operator) enqueueForNamespace(ns string) {
-	cache.ListAll(c.alrtInf.GetStore(), labels.Everything(), func(obj interface{}) {
-		am := obj.(*monitoringv1.Alertmanager)
-		if am.Namespace == ns {
-			c.enqueue(am)
-		}
-	})
 }
 
 // worker runs a worker thread that just dequeues items, processes them

--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -267,3 +267,18 @@ func IsAllNamespaces(namespaces map[string]struct{}) bool {
 	_, ok := namespaces[v1.NamespaceAll]
 	return ok && len(namespaces) == 1
 }
+
+// IdenticalNamespaces returns true if a and b are identical.
+func IdenticalNamespaces(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/listwatch/listwatch_test.go
+++ b/pkg/listwatch/listwatch_test.go
@@ -184,3 +184,37 @@ func TestRacyMultiWatch(t *testing.T) {
 	mw.Stop()
 	mw.Stop()
 }
+
+func TestIdenticalNamespaces(t *testing.T) {
+	for _, tc := range []struct {
+		a, b map[string]struct{}
+		ret  bool
+	}{
+		{
+			a: map[string]struct{}{
+				"foo": struct{}{},
+			},
+			b: map[string]struct{}{
+				"foo": struct{}{},
+			},
+			ret: true,
+		},
+		{
+			a: map[string]struct{}{
+				"foo": struct{}{},
+			},
+			b: map[string]struct{}{
+				"bar": struct{}{},
+			},
+			ret: false,
+		},
+	} {
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			ret := IdenticalNamespaces(tc.a, tc.b)
+			if ret != tc.ret {
+				t.Fatalf("expecting IdenticalNamespaces() to return %v, got %v", tc.ret, ret)
+			}
+		})
+	}
+}

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -62,14 +62,15 @@ type Operator struct {
 	mclient monitoringclient.Interface
 	logger  log.Logger
 
-	promInf cache.SharedIndexInformer
-	smonInf cache.SharedIndexInformer
-	pmonInf cache.SharedIndexInformer
-	ruleInf cache.SharedIndexInformer
-	cmapInf cache.SharedIndexInformer
-	secrInf cache.SharedIndexInformer
-	ssetInf cache.SharedIndexInformer
-	nsInf   cache.SharedIndexInformer
+	promInf   cache.SharedIndexInformer
+	smonInf   cache.SharedIndexInformer
+	pmonInf   cache.SharedIndexInformer
+	ruleInf   cache.SharedIndexInformer
+	cmapInf   cache.SharedIndexInformer
+	secrInf   cache.SharedIndexInformer
+	ssetInf   cache.SharedIndexInformer
+	nsPromInf cache.SharedIndexInformer
+	nsMonInf  cache.SharedIndexInformer
 
 	queue workqueue.RateLimitingInterface
 
@@ -344,23 +345,33 @@ func New(conf Config, logger log.Logger, r prometheus.Registerer) (*Operator, er
 		&appsv1.StatefulSet{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 
-	// nsResyncPeriod is used to control how often the namespace informer
-	// should resync. If the unprivileged ListerWatcher is used, then the
-	// informer must resync more often because it cannot watch for
-	// namespace changes.
-	nsResyncPeriod := 15 * time.Second
-	// If the only namespace is v1.NamespaceAll, then the client must be
-	// privileged and a regular cache.ListWatch will be used. In this case
-	// watching works and we do not need to resync so frequently.
-	if listwatch.IsAllNamespaces(c.config.Namespaces.AllowList) {
-		nsResyncPeriod = resyncPeriod
+	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) cache.SharedIndexInformer {
+		// nsResyncPeriod is used to control how often the namespace informer
+		// should resync. If the unprivileged ListerWatcher is used, then the
+		// informer must resync more often because it cannot watch for
+		// namespace changes.
+		nsResyncPeriod := 15 * time.Second
+		// If the only namespace is v1.NamespaceAll, then the client must be
+		// privileged and a regular cache.ListWatch will be used. In this case
+		// watching works and we do not need to resync so frequently.
+		if listwatch.IsAllNamespaces(allowList) {
+			nsResyncPeriod = resyncPeriod
+		}
+		nsInf := cache.NewSharedIndexInformer(
+			o.metrics.NewInstrumentedListerWatcher(
+				listwatch.NewUnprivilegedNamespaceListWatchFromClient(o.logger, o.kclient.CoreV1().RESTClient(), allowList, o.config.Namespaces.DenyList, fields.Everything()),
+			),
+			&v1.Namespace{}, nsResyncPeriod, cache.Indexers{},
+		)
+
+		return nsInf
 	}
-	c.nsInf = cache.NewSharedIndexInformer(
-		c.metrics.NewInstrumentedListerWatcher(
-			listwatch.NewUnprivilegedNamespaceListWatchFromClient(c.logger, c.kclient.CoreV1().RESTClient(), c.config.Namespaces.AllowList, c.config.Namespaces.DenyList, fields.Everything()),
-		),
-		&v1.Namespace{}, nsResyncPeriod, cache.Indexers{},
-	)
+	c.nsMonInf = newNamespaceInformer(c, c.config.Namespaces.AllowList)
+	if listwatch.IdenticalNamespaces(c.config.Namespaces.AllowList, c.config.Namespaces.PrometheusAllowList) {
+		c.nsPromInf = c.nsMonInf
+	} else {
+		c.nsPromInf = newNamespaceInformer(c, c.config.Namespaces.PrometheusAllowList)
+	}
 
 	return c, nil
 }
@@ -379,7 +390,8 @@ func (c *Operator) waitForCacheSync(stopc <-chan struct{}) error {
 		{"ConfigMap", c.cmapInf},
 		{"Secret", c.secrInf},
 		{"StatefulSet", c.ssetInf},
-		{"Namespace", c.nsInf},
+		{"PromNamespace", c.nsPromInf},
+		{"MonNamespace", c.nsMonInf},
 	}
 	for _, inf := range informers {
 		if !cache.WaitForCacheSync(stopc, inf.informer.HasSynced) {
@@ -469,7 +481,10 @@ func (c *Operator) Run(stopc <-chan struct{}) error {
 	go c.cmapInf.Run(stopc)
 	go c.secrInf.Run(stopc)
 	go c.ssetInf.Run(stopc)
-	go c.nsInf.Run(stopc)
+	go c.nsMonInf.Run(stopc)
+	if c.nsPromInf != c.nsMonInf {
+		go c.nsPromInf.Run(stopc)
+	}
 	if err := c.waitForCacheSync(stopc); err != nil {
 		return err
 	}
@@ -687,7 +702,7 @@ func (c *Operator) handleSmonAdd(obj interface{}) {
 		level.Debug(c.logger).Log("msg", "ServiceMonitor added")
 		c.metrics.TriggerByCounter(monitoringv1.ServiceMonitorsKind, "add").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
 
@@ -702,7 +717,7 @@ func (c *Operator) handleSmonUpdate(old, cur interface{}) {
 		level.Debug(c.logger).Log("msg", "ServiceMonitor updated")
 		c.metrics.TriggerByCounter(monitoringv1.ServiceMonitorsKind, "update").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
 
@@ -713,7 +728,7 @@ func (c *Operator) handleSmonDelete(obj interface{}) {
 		level.Debug(c.logger).Log("msg", "ServiceMonitor delete")
 		c.metrics.TriggerByCounter(monitoringv1.ServiceMonitorsKind, "delete").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
 
@@ -723,7 +738,7 @@ func (c *Operator) handlePmonAdd(obj interface{}) {
 	if ok {
 		level.Debug(c.logger).Log("msg", "PodMonitor added")
 		c.metrics.TriggerByCounter(monitoringv1.PodMonitorsKind, "add").Inc()
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
 
@@ -738,7 +753,7 @@ func (c *Operator) handlePmonUpdate(old, cur interface{}) {
 		level.Debug(c.logger).Log("msg", "PodMonitor updated")
 		c.metrics.TriggerByCounter(monitoringv1.PodMonitorsKind, "update").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
 
@@ -749,7 +764,7 @@ func (c *Operator) handlePmonDelete(obj interface{}) {
 		level.Debug(c.logger).Log("msg", "PodMonitor delete")
 		c.metrics.TriggerByCounter(monitoringv1.PodMonitorsKind, "delete").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
 
@@ -760,7 +775,7 @@ func (c *Operator) handleRuleAdd(obj interface{}) {
 		level.Debug(c.logger).Log("msg", "PrometheusRule added")
 		c.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, "add").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
 
@@ -775,7 +790,7 @@ func (c *Operator) handleRuleUpdate(old, cur interface{}) {
 		level.Debug(c.logger).Log("msg", "PrometheusRule updated")
 		c.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, "update").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
 
@@ -786,7 +801,7 @@ func (c *Operator) handleRuleDelete(obj interface{}) {
 		level.Debug(c.logger).Log("msg", "PrometheusRule deleted")
 		c.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, "delete").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
 
@@ -797,7 +812,7 @@ func (c *Operator) handleSecretDelete(obj interface{}) {
 		level.Debug(c.logger).Log("msg", "Secret deleted")
 		c.metrics.TriggerByCounter("Secret", "delete").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForPrometheusNamespace(o.GetNamespace())
 	}
 }
 
@@ -811,7 +826,7 @@ func (c *Operator) handleSecretUpdate(old, cur interface{}) {
 		level.Debug(c.logger).Log("msg", "Secret updated")
 		c.metrics.TriggerByCounter("Secret", "update").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForPrometheusNamespace(o.GetNamespace())
 	}
 }
 
@@ -821,7 +836,7 @@ func (c *Operator) handleSecretAdd(obj interface{}) {
 		level.Debug(c.logger).Log("msg", "Secret added")
 		c.metrics.TriggerByCounter("Secret", "add").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForPrometheusNamespace(o.GetNamespace())
 	}
 }
 
@@ -832,7 +847,7 @@ func (c *Operator) handleConfigMapAdd(obj interface{}) {
 		level.Debug(c.logger).Log("msg", "ConfigMap added")
 		c.metrics.TriggerByCounter("ConfigMap", "add").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForPrometheusNamespace(o.GetNamespace())
 	}
 }
 
@@ -842,7 +857,7 @@ func (c *Operator) handleConfigMapDelete(obj interface{}) {
 		level.Debug(c.logger).Log("msg", "ConfigMap deleted")
 		c.metrics.TriggerByCounter("ConfigMap", "delete").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForPrometheusNamespace(o.GetNamespace())
 	}
 }
 
@@ -856,7 +871,7 @@ func (c *Operator) handleConfigMapUpdate(old, cur interface{}) {
 		level.Debug(c.logger).Log("msg", "ConfigMap updated")
 		c.metrics.TriggerByCounter("ConfigMap", "update").Inc()
 
-		c.enqueueForNamespace(o.GetNamespace())
+		c.enqueueForPrometheusNamespace(o.GetNamespace())
 	}
 }
 
@@ -892,10 +907,18 @@ func (c *Operator) enqueue(obj interface{}) {
 	c.queue.Add(key)
 }
 
+func (c *Operator) enqueueForPrometheusNamespace(nsName string) {
+	c.enqueueForNamespace(c.nsPromInf.GetStore(), nsName)
+}
+
+func (c *Operator) enqueueForMonitorNamespace(nsName string) {
+	c.enqueueForNamespace(c.nsMonInf.GetStore(), nsName)
+}
+
 // enqueueForNamespace enqueues all Prometheus object keys that belong to the
 // given namespace or select objects in the given namespace.
-func (c *Operator) enqueueForNamespace(nsName string) {
-	nsObject, exists, err := c.nsInf.GetStore().GetByKey(nsName)
+func (c *Operator) enqueueForNamespace(store cache.Store, nsName string) {
+	nsObject, exists, err := store.GetByKey(nsName)
 	if err != nil {
 		level.Error(c.logger).Log(
 			"msg", "get namespace to enqueue Prometheus instances failed",
@@ -912,7 +935,7 @@ func (c *Operator) enqueueForNamespace(nsName string) {
 	ns := nsObject.(*v1.Namespace)
 
 	err = cache.ListAll(c.promInf.GetStore(), labels.Everything(), func(obj interface{}) {
-		// Check for Prometheus instances in the NS.
+		// Check for Prometheus instances in the namespace.
 		p := obj.(*monitoringv1.Prometheus)
 		if p.Namespace == nsName {
 			c.enqueue(p)
@@ -920,7 +943,7 @@ func (c *Operator) enqueueForNamespace(nsName string) {
 		}
 
 		// Check for Prometheus instances selecting ServiceMonitors in
-		// the NS.
+		// the namespace.
 		smNSSelector, err := metav1.LabelSelectorAsSelector(p.Spec.ServiceMonitorNamespaceSelector)
 		if err != nil {
 			level.Error(c.logger).Log(
@@ -1892,7 +1915,7 @@ func testForArbitraryFSAccess(e monitoringv1.Endpoint) error {
 // selector.
 func (c *Operator) listMatchingNamespaces(selector labels.Selector) ([]string, error) {
 	var ns []string
-	err := cache.ListAll(c.nsInf.GetStore(), selector, func(obj interface{}) {
+	err := cache.ListAll(c.nsMonInf.GetStore(), selector, func(obj interface{}) {
 		ns = append(ns, obj.(*v1.Namespace).Name)
 	})
 	if err != nil {

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -62,11 +62,12 @@ type Operator struct {
 	mclient monitoringclient.Interface
 	logger  log.Logger
 
-	thanosRulerInf cache.SharedIndexInformer
-	nsInf          cache.SharedIndexInformer
-	cmapInf        cache.SharedIndexInformer
-	ruleInf        cache.SharedIndexInformer
-	ssetInf        cache.SharedIndexInformer
+	thanosRulerInf   cache.SharedIndexInformer
+	nsThanosRulerInf cache.SharedIndexInformer
+	nsRuleInf        cache.SharedIndexInformer
+	cmapInf          cache.SharedIndexInformer
+	ruleInf          cache.SharedIndexInformer
+	ssetInf          cache.SharedIndexInformer
 
 	queue workqueue.RateLimitingInterface
 
@@ -196,21 +197,33 @@ func New(conf prometheusoperator.Config, logger log.Logger, r prometheus.Registe
 		&appsv1.StatefulSet{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 
-	// nsResyncPeriod is used to control how often the namespace informer
-	// should resync. If the unprivileged ListerWatcher is used, then the
-	// informer must resync more often because it cannot watch for
-	// namespace changes.
-	nsResyncPeriod := 15 * time.Second
-	// If the only namespace is v1.NamespaceAll, then the client must be
-	// privileged and a regular cache.ListWatch will be used. In this case
-	// watching works and we do not need to resync so frequently.
-	if listwatch.IsAllNamespaces(o.config.Namespaces.AllowList) {
-		nsResyncPeriod = resyncPeriod
+	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) cache.SharedIndexInformer {
+		// nsResyncPeriod is used to control how often the namespace informer
+		// should resync. If the unprivileged ListerWatcher is used, then the
+		// informer must resync more often because it cannot watch for
+		// namespace changes.
+		nsResyncPeriod := 15 * time.Second
+		// If the only namespace is v1.NamespaceAll, then the client must be
+		// privileged and a regular cache.ListWatch will be used. In this case
+		// watching works and we do not need to resync so frequently.
+		if listwatch.IsAllNamespaces(allowList) {
+			nsResyncPeriod = resyncPeriod
+		}
+		nsInf := cache.NewSharedIndexInformer(
+			o.metrics.NewInstrumentedListerWatcher(
+				listwatch.NewUnprivilegedNamespaceListWatchFromClient(o.logger, o.kclient.CoreV1().RESTClient(), allowList, o.config.Namespaces.DenyList, fields.Everything()),
+			),
+			&v1.Namespace{}, nsResyncPeriod, cache.Indexers{},
+		)
+
+		return nsInf
 	}
-	o.nsInf = cache.NewSharedIndexInformer(
-		listwatch.NewUnprivilegedNamespaceListWatchFromClient(o.logger, o.kclient.CoreV1().RESTClient(), o.config.Namespaces.AllowList, o.config.Namespaces.DenyList, fields.Everything()),
-		&v1.Namespace{}, nsResyncPeriod, cache.Indexers{},
-	)
+	o.nsRuleInf = newNamespaceInformer(o, o.config.Namespaces.AllowList)
+	if listwatch.IdenticalNamespaces(o.config.Namespaces.AllowList, o.config.Namespaces.ThanosRulerAllowList) {
+		o.nsThanosRulerInf = o.nsRuleInf
+	} else {
+		o.nsThanosRulerInf = newNamespaceInformer(o, o.config.Namespaces.ThanosRulerAllowList)
+	}
 
 	return o, nil
 }
@@ -223,7 +236,8 @@ func (o *Operator) waitForCacheSync(stopc <-chan struct{}) error {
 		informer cache.SharedIndexInformer
 	}{
 		{"ThanosRuler", o.thanosRulerInf},
-		{"Namespace", o.nsInf},
+		{"ThanosRulerNamespace", o.nsThanosRulerInf},
+		{"RuleNamespace", o.nsRuleInf},
 		{"ConfigMap", o.cmapInf},
 		{"PrometheusRule", o.ruleInf},
 		{"StatefulSet", o.ssetInf},
@@ -297,7 +311,10 @@ func (o *Operator) Run(stopc <-chan struct{}) error {
 	go o.thanosRulerInf.Run(stopc)
 	go o.cmapInf.Run(stopc)
 	go o.ruleInf.Run(stopc)
-	go o.nsInf.Run(stopc)
+	go o.nsRuleInf.Run(stopc)
+	if o.nsRuleInf != o.nsThanosRulerInf {
+		go o.nsThanosRulerInf.Run(stopc)
+	}
 	go o.ssetInf.Run(stopc)
 	if err := o.waitForCacheSync(stopc); err != nil {
 		return err
@@ -361,7 +378,7 @@ func (o *Operator) handleConfigMapAdd(obj interface{}) {
 		level.Debug(o.logger).Log("msg", "ConfigMap added")
 		o.metrics.TriggerByCounter("ConfigMap", "add").Inc()
 
-		o.enqueueForNamespace(meta.GetNamespace())
+		o.enqueueForThanosRulerNamespace(meta.GetNamespace())
 	}
 }
 
@@ -371,7 +388,7 @@ func (o *Operator) handleConfigMapDelete(obj interface{}) {
 		level.Debug(o.logger).Log("msg", "ConfigMap deleted")
 		o.metrics.TriggerByCounter("ConfigMap", "delete").Inc()
 
-		o.enqueueForNamespace(meta.GetNamespace())
+		o.enqueueForThanosRulerNamespace(meta.GetNamespace())
 	}
 }
 
@@ -385,7 +402,7 @@ func (o *Operator) handleConfigMapUpdate(old, cur interface{}) {
 		level.Debug(o.logger).Log("msg", "ConfigMap updated")
 		o.metrics.TriggerByCounter("ConfigMap", "update").Inc()
 
-		o.enqueueForNamespace(meta.GetNamespace())
+		o.enqueueForThanosRulerNamespace(meta.GetNamespace())
 	}
 }
 
@@ -396,7 +413,7 @@ func (o *Operator) handleRuleAdd(obj interface{}) {
 		level.Debug(o.logger).Log("msg", "PrometheusRule added")
 		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, "add").Inc()
 
-		o.enqueueForNamespace(meta.GetNamespace())
+		o.enqueueForRulesNamespace(meta.GetNamespace())
 	}
 }
 
@@ -411,7 +428,7 @@ func (o *Operator) handleRuleUpdate(old, cur interface{}) {
 		level.Debug(o.logger).Log("msg", "PrometheusRule updated")
 		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, "update").Inc()
 
-		o.enqueueForNamespace(meta.GetNamespace())
+		o.enqueueForRulesNamespace(meta.GetNamespace())
 	}
 }
 
@@ -422,7 +439,7 @@ func (o *Operator) handleRuleDelete(obj interface{}) {
 		level.Debug(o.logger).Log("msg", "PrometheusRule deleted")
 		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, "delete").Inc()
 
-		o.enqueueForNamespace(meta.GetNamespace())
+		o.enqueueForRulesNamespace(meta.GetNamespace())
 	}
 }
 
@@ -646,7 +663,7 @@ func (o *Operator) sync(key string) error {
 // selector.
 func (o *Operator) listMatchingNamespaces(selector labels.Selector) ([]string, error) {
 	var ns []string
-	err := cache.ListAll(o.nsInf.GetStore(), selector, func(obj interface{}) {
+	err := cache.ListAll(o.nsRuleInf.GetStore(), selector, func(obj interface{}) {
 		ns = append(ns, obj.(*v1.Namespace).Name)
 	})
 	if err != nil {
@@ -739,10 +756,18 @@ func needsUpdate(pod *v1.Pod, tmpl v1.PodTemplateSpec) bool {
 	return false
 }
 
+func (o *Operator) enqueueForThanosRulerNamespace(nsName string) {
+	o.enqueueForNamespace(o.nsThanosRulerInf.GetStore(), nsName)
+}
+
+func (o *Operator) enqueueForRulesNamespace(nsName string) {
+	o.enqueueForNamespace(o.nsRuleInf.GetStore(), nsName)
+}
+
 // enqueueForNamespace enqueues all ThanosRuler object keys that belong to the
 // given namespace or select objects in the given namespace.
-func (o *Operator) enqueueForNamespace(nsName string) {
-	nsObject, exists, err := o.nsInf.GetStore().GetByKey(nsName)
+func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
+	nsObject, exists, err := store.GetByKey(nsName)
 	if err != nil {
 		level.Error(o.logger).Log(
 			"msg", "get namespace to enqueue ThanosRuler instances failed",
@@ -759,7 +784,7 @@ func (o *Operator) enqueueForNamespace(nsName string) {
 	ns := nsObject.(*v1.Namespace)
 
 	err = cache.ListAll(o.thanosRulerInf.GetStore(), labels.Everything(), func(obj interface{}) {
-		// Check for ThanosRuler instances in the NS.
+		// Check for ThanosRuler instances in the namespace.
 		tr := obj.(*monitoringv1.ThanosRuler)
 		if tr.Namespace == nsName {
 			o.enqueue(tr)
@@ -767,7 +792,7 @@ func (o *Operator) enqueueForNamespace(nsName string) {
 		}
 
 		// Check for ThanosRuler instances selecting PrometheusRules in
-		// the NS.
+		// the namespace.
 		ruleNSSelector, err := metav1.LabelSelectorAsSelector(tr.Spec.RuleNamespaceSelector)
 		if err != nil {
 			level.Error(o.logger).Log(


### PR DESCRIPTION
Service/pod monitors and rules resources watched by the operator
can live in different namespaces than the configmaps and secrets
associated to the Prometheus custom resources.

Before this change, we had only one namespace informer scoped to the
monitor/rule namespaces. Whenever a change of configmap or secret was
detected, the operator couldn't retrieve the associated namespace
because it didn't exist in the monitor/rule namespaces and the
reconciliation wouldn't happen.

With this change, separate namespace informers are used when the
monitors/rules and prometheus namespaces aren't identical.

Closes #3181