### PR TITLE
Update compatibility matrix

### DIFF
--- a/Documentation/compatibility.md
+++ b/Documentation/compatibility.md
@@ -52,6 +52,7 @@ The versions of Prometheus compatible to be run with the Prometheus Operator are
 * v2.14.0
 * v2.15.2
 * v2.16.0
+* v2.17.2
 
 ## Alertmanager
 

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -67,6 +67,7 @@ var (
 		"v2.14.0",
 		"v2.15.2",
 		"v2.16.0",
+		"v2.17.2",
 	}
 	DefaultPrometheusVersion   = PrometheusCompatibilityMatrix[len(PrometheusCompatibilityMatrix)-1]
 	DefaultPrometheusBaseImage = "quay.io/prometheus/prometheus"


### PR DESCRIPTION
Add prometheus v2.17.2 to compatibility matrix

Signed-off-by: Benjamin <benjamin@yunify.com>