### PR TITLE
Update exposing-prometheus-and-alertmanager.md for nginx ingress 0.22.0+

### DIFF
--- a/Documentation/user-guides/exposing-prometheus-and-alertmanager.md
+++ b/Documentation/user-guides/exposing-prometheus-and-alertmanager.md
@@ -214,7 +214,7 @@ metadata:
   name: monitoring
   annotations:
     ingress.kubernetes.io/whitelist-source-range: 10.0.0.0/16 # change this range to admin IPs
-    ingress.kubernetes.io/rewrite-target: "/"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
   - http:
@@ -222,11 +222,11 @@ spec:
       - backend:
           serviceName: prometheus-main
           servicePort: 9090
-        path: /prometheus
+        path: /prometheus(/|$)(.*)
       - backend:
           serviceName: alertmanager-main
           servicePort: 9093
-        path: /alertmanager
+        path: /alertmanager(/|$)(.*)
 ```
 
 Finally, the Prometheus and `Alertmanager` objects must be created, specifying the `externalUrl` at which they will be found.


### PR DESCRIPTION
Starting in Version 0.22.0, ingress definitions using the annotation nginx.ingress.kubernetes.io/rewrite-target are not backwards compatible with previous versions. In Version 0.22.0 and beyond, any substrings within the request URI that need to be passed to the rewritten path must explicitly be defined in a capture group.