### PR TITLE
remove go module caching in travis CI for release-0.38 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ go:
 go_import_path: github.com/coreos/prometheus-operator
 env:
   - GO111MODULE=on
-cache:
-  directories:
-  - $GOCACHE
-  - $GOPATH/pkg/mod
 services:
 - docker
 before_install:


### PR DESCRIPTION
Fixes issue where the cache difference between branches was causing build failures.