### PR TITLE
travis.yml: remove caching of go directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ go:
 go_import_path: github.com/coreos/prometheus-operator
 env:
   - GO111MODULE=on
-cache:
-  directories:
-  - $GOCACHE
-  - $GOPATH/pkg/mod
 services:
 - docker
 before_install:


### PR DESCRIPTION
Caching of the go modules directory can cause build problems if the
cache is shared between multiple branches.

Related to #3209 