### PR TITLE
Add nodes/metrics to allowable resources

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -124,6 +124,7 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes
+  - nodes/metrics
   - services
   - endpoints
   - pods

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -116,6 +116,7 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes
+  - nodes/metrics
   - services
   - endpoints
   - pods

--- a/example/rbac/prometheus/prometheus-cluster-role.yaml
+++ b/example/rbac/prometheus/prometheus-cluster-role.yaml
@@ -6,6 +6,7 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes
+  - nodes/metrics
   - services
   - endpoints
   - pods


### PR DESCRIPTION
Pulled in the `RBAC` yaml for the prometheus-operator and saw that it couldn't target our kube state / node exporter metrics, complaining about a 403.