### PR TITLE
Automaticly disable high availability mode for 1 replica alertmanager

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -240,9 +240,14 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 
 	amArgs := []string{
 		fmt.Sprintf("--config.file=%s", alertmanagerConfFile),
-		fmt.Sprintf("--cluster.listen-address=[$(POD_IP)]:%d", 9094),
 		fmt.Sprintf("--storage.path=%s", alertmanagerStorageDir),
 		fmt.Sprintf("--data.retention=%s", a.Spec.Retention),
+	}
+
+	if *a.Spec.Replicas == 1 {
+		amArgs = append(amArgs, "--cluster.listen-address=")
+	} else {
+		amArgs = append(amArgs, "--cluster.listen-address=[$(POD_IP)]:9094")
 	}
 
 	if a.Spec.ListenLocal {

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -625,3 +625,55 @@ func TestTerminationPolicy(t *testing.T) {
 		}
 	}
 }
+
+func TestClusterListenAddressForSingleReplica(t *testing.T) {
+	a := monitoringv1.Alertmanager{}
+	replicas := int32(1)
+	a.Spec.Version = operator.DefaultAlertmanagerVersion
+	a.Spec.Replicas = &replicas
+
+	statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	amArgs := statefulSet.Template.Spec.Containers[0].Args
+
+	containsEmptyClusterListenAddress := false
+
+	for _, arg := range amArgs {
+		if arg == "--cluster.listen-address=" {
+			containsEmptyClusterListenAddress = true
+		}
+	}
+
+	if !containsEmptyClusterListenAddress {
+		t.Fatal("expected stateful set to contain arg '--cluster.listen-address='")
+	}
+}
+
+func TestClusterListenAddressForMultiReplica(t *testing.T) {
+	a := monitoringv1.Alertmanager{}
+	replicas := int32(3)
+	a.Spec.Version = operator.DefaultAlertmanagerVersion
+	a.Spec.Replicas = &replicas
+
+	statefulSet, err := makeStatefulSetSpec(&a, defaultTestConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	amArgs := statefulSet.Template.Spec.Containers[0].Args
+
+	containsClusterListenAddress := false
+
+	for _, arg := range amArgs {
+		if arg == "--cluster.listen-address=[$(POD_IP)]:9094" {
+			containsClusterListenAddress = true
+		}
+	}
+
+	if !containsClusterListenAddress {
+		t.Fatal("expected stateful set to contain arg '--cluster.listen-address=[$(POD_IP)]:9094'")
+	}
+}

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -240,7 +240,7 @@ func testAMClusterInitialization(t *testing.T) {
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitializedCluster(ns, name, amClusterSize); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(ns, name, amClusterSize); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -268,7 +268,7 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitializedCluster(ns, name, amClusterSize); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(ns, name, amClusterSize); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -283,7 +283,7 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitializedCluster(ns, name, amClusterSize); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(ns, name, amClusterSize); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -306,7 +306,7 @@ func testAMClusterGossipSilences(t *testing.T) {
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitializedCluster(ns, name, amClusterSize); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(ns, name, amClusterSize); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -531,7 +531,7 @@ inhibit_rules:
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerClusterReady(ns, alertmanager.Name, int(*alertmanager.Spec.Replicas)); err != nil {
+	if err := framework.WaitForAlertmanagerReady(ns, alertmanager.Name, int(*alertmanager.Spec.Replicas)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -620,7 +620,7 @@ inhibit_rules:
 	// Wait for the change above to take effect.
 	time.Sleep(time.Minute)
 
-	if err := framework.WaitForAlertmanagerClusterReady(ns, alertmanager.Name, int(*alertmanager.Spec.Replicas)); err != nil {
+	if err := framework.WaitForAlertmanagerReady(ns, alertmanager.Name, int(*alertmanager.Spec.Replicas)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -128,12 +128,12 @@ func (f *Framework) CreateAlertmanagerAndWaitUntilReady(ns string, a *monitoring
 		return nil, errors.Wrap(err, fmt.Sprintf("creating alertmanager %v failed", a.Name))
 	}
 
-	return a, f.WaitForAlertmanagerClusterReady(ns, a.Name, int(*a.Spec.Replicas))
+	return a, f.WaitForAlertmanagerReady(ns, a.Name, int(*a.Spec.Replicas))
 }
 
-// WaitForAlertmanagerClusterReady waits for each individual pod as well as the
+// WaitForAlertmanagerReady waits for each individual pod as well as the
 // cluster as a whole to be ready.
-func (f *Framework) WaitForAlertmanagerClusterReady(ns, name string, replicas int) error {
+func (f *Framework) WaitForAlertmanagerReady(ns, name string, replicas int) error {
 	if err := WaitForPodsReady(
 		f.KubeClient,
 		ns,
@@ -150,7 +150,7 @@ func (f *Framework) WaitForAlertmanagerClusterReady(ns, name string, replicas in
 
 	for i := 0; i < replicas; i++ {
 		name := fmt.Sprintf("alertmanager-%v-%v", name, strconv.Itoa(i))
-		if err := f.WaitForAlertmanagerInitializedCluster(ns, name, replicas); err != nil {
+		if err := f.WaitForAlertmanagerInitialized(ns, name, replicas); err != nil {
 			return errors.Wrap(err,
 				fmt.Sprintf(
 					"failed to wait for an Alertmanager cluster (%s) with %d instances to become ready",
@@ -210,12 +210,17 @@ func amImage(version string) string {
 	return fmt.Sprintf("quay.io/prometheus/alertmanager:%s", version)
 }
 
-func (f *Framework) WaitForAlertmanagerInitializedCluster(ns, name string, amountPeers int) error {
+func (f *Framework) WaitForAlertmanagerInitialized(ns, name string, amountPeers int) error {
 	var pollError error
 	err := wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		amStatus, err := f.GetAlertmanagerStatus(ns, name)
 		if err != nil {
 			return false, err
+		}
+
+		isAlertmanagerInClusterMode := amountPeers > 1
+		if !isAlertmanagerInClusterMode && amStatus.Status == "success" {
+			return true, nil
 		}
 
 		if amStatus.Data.ClusterStatus == nil {
@@ -409,7 +414,8 @@ type amAPISil struct {
 }
 
 type amAPIStatusResp struct {
-	Data amAPIStatusData `json:"data"`
+	Status string          `json:"status"`
+	Data   amAPIStatusData `json:"data"`
 }
 
 type amAPIStatusData struct {


### PR DESCRIPTION
AlertManager in a single-node setup will try to broadcast silences and notification logs to itself. The messages are queued forever, leading to the error message when it reaches the max queue size.

More info

- https://github.com/prometheus/alertmanager#high-availability
- https://github.com/prometheus/alertmanager/issues/1814

Fixes #3196