### PR TITLE
fix probe promcfg

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1293,8 +1293,8 @@ func checkPrometheusSpecDeprecation(key string, p *monitoringv1.Prometheus, logg
 		}
 	}
 
-	if p.Spec.ServiceMonitorSelector == nil && p.Spec.PodMonitorSelector == nil {
-		level.Warn(logger).Log("msg", "neither serviceMonitorSelector nor podMonitorSelector specified. Custom configuration is deprecated, use additionalScrapeConfigs instead")
+	if p.Spec.ServiceMonitorSelector == nil && p.Spec.PodMonitorSelector == nil && p.Spec.ProbeSelector == nil {
+		level.Warn(logger).Log("msg", "neither serviceMonitorSelector nor podMonitorSelector, nor probeSelector specified. Custom configuration is deprecated, use additionalScrapeConfigs instead")
 	}
 }
 
@@ -1678,8 +1678,9 @@ func (c *Operator) createOrUpdateConfigurationSecret(p *monitoringv1.Prometheus,
 	// If no service or pod monitor selectors are configured, the user wants to
 	// manage configuration themselves. Do create an empty Secret if it doesn't
 	// exist.
-	if p.Spec.ServiceMonitorSelector == nil && p.Spec.PodMonitorSelector == nil {
-		level.Debug(c.logger).Log("msg", "neither ServiceMonitor not PodMonitor selector specified, leaving configuration unmanaged", "prometheus", p.Name, "namespace", p.Namespace)
+	if p.Spec.ServiceMonitorSelector == nil && p.Spec.PodMonitorSelector == nil &&
+		p.Spec.ProbeSelector == nil {
+		level.Debug(c.logger).Log("msg", "neither ServiceMonitor nor PodMonitor, nor Probe selector specified, leaving configuration unmanaged", "prometheus", p.Name, "namespace", p.Namespace)
 
 		s, err := makeEmptyConfigurationSecret(p, c.config)
 		if err != nil {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -451,7 +451,15 @@ scrape_configs:
     - promcon.io
     labels:
       static: label
-  relabel_configs: []
+  relabel_configs:
+  - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
 alerting:
   alert_relabel_configs:
   - action: labeldrop
@@ -549,6 +557,14 @@ scrape_configs:
     labels:
       static: label
   relabel_configs:
+  - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
   - target_label: namespace
     replacement: default
 alerting:
@@ -655,13 +671,18 @@ scrape_configs:
     source_labels:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
     regex: "true"
-  - source_labels: '[__address__]'
+  - source_labels:
+    - __address__
     target_label: __param_target
-  - source_labels: '[__param_target]'
+  - source_labels:
+    - __param_target
     target_label: instance
   - target_label: __address__
     replacement: blackbox.exporter.io
-  - source_labels: '[__meta_kubernetes_ingress_scheme, __address__, __meta_kubernetes_ingress_path]'
+  - source_labels:
+    - __meta_kubernetes_ingress_scheme
+    - __address__
+    - __meta_kubernetes_ingress_path
     separator: ;
     regex: (.+);(.+);(.+)
     target_label: __param_target
@@ -781,13 +802,18 @@ scrape_configs:
     source_labels:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
     regex: "true"
-  - source_labels: '[__address__]'
+  - source_labels:
+    - __address__
     target_label: __param_target
-  - source_labels: '[__param_target]'
+  - source_labels:
+    - __param_target
     target_label: instance
   - target_label: __address__
     replacement: blackbox.exporter.io
-  - source_labels: '[__meta_kubernetes_ingress_scheme, __address__, __meta_kubernetes_ingress_path]'
+  - source_labels:
+    - __meta_kubernetes_ingress_scheme
+    - __address__
+    - __meta_kubernetes_ingress_path
     separator: ;
     regex: (.+);(.+);(.+)
     target_label: __param_target


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Fixes prometheus config for Probe.

1. If only ProbeSelector is set, PodMonitorSelector and ServiceMonitorSelector not set, it will do nothing.
2. Relabelings are not added for Probe.