### PR TITLE
set scrapeInterval and evaluationInterval to 1m

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -174,12 +174,12 @@ func (cg *configGenerator) generateConfig(
 
 	cfg := yaml.MapSlice{}
 
-	scrapeInterval := "30s"
+	scrapeInterval := "1m"
 	if p.Spec.ScrapeInterval != "" {
 		scrapeInterval = p.Spec.ScrapeInterval
 	}
 
-	evaluationInterval := "30s"
+	evaluationInterval := "1m"
 	if p.Spec.EvaluationInterval != "" {
 		evaluationInterval = p.Spec.EvaluationInterval
 	}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -67,8 +67,8 @@ func TestGlobalSettings(t *testing.T) {
 		{
 			Version: "v2.15.2",
 			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
@@ -83,10 +83,10 @@ alerting:
 		},
 		{
 			Version:            "v2.15.2",
-			EvaluationInterval: "60s",
+			EvaluationInterval: "1m",
 			Expected: `global:
-  evaluation_interval: 60s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
@@ -121,8 +121,8 @@ alerting:
 			Version:       "v2.15.2",
 			ScrapeTimeout: "30s",
 			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
@@ -143,8 +143,8 @@ alerting:
 				"key2": "value2",
 			},
 			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     key1: value1
     key2: value2
@@ -163,8 +163,8 @@ alerting:
 			Version:      "v2.16.0",
 			QueryLogFile: "test.log",
 			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)


### PR DESCRIPTION
Both scrapeInterval and evaluationInterval are on 30s. This commit changes this to 1m and updates the tests included with it.

Reason: 

- These defaults are not documented for the Prometheus Operator
- These defaults differ from official Prometheus documentation: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration

