### PR TITLE
Normalize default durations

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -174,12 +174,12 @@ func (cg *configGenerator) generateConfig(
 
 	cfg := yaml.MapSlice{}
 
-	scrapeInterval := "30s"
+	scrapeInterval := "1m"
 	if p.Spec.ScrapeInterval != "" {
 		scrapeInterval = p.Spec.ScrapeInterval
 	}
 
-	evaluationInterval := "30s"
+	evaluationInterval := "1m"
 	if p.Spec.EvaluationInterval != "" {
 		evaluationInterval = p.Spec.EvaluationInterval
 	}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -67,8 +67,8 @@ func TestGlobalSettings(t *testing.T) {
 		{
 			Version: "v2.15.2",
 			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
@@ -83,10 +83,10 @@ alerting:
 		},
 		{
 			Version:            "v2.15.2",
-			EvaluationInterval: "60s",
+			EvaluationInterval: "1m",
 			Expected: `global:
-  evaluation_interval: 60s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
@@ -121,8 +121,8 @@ alerting:
 			Version:       "v2.15.2",
 			ScrapeTimeout: "30s",
 			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
@@ -143,8 +143,8 @@ alerting:
 				"key2": "value2",
 			},
 			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     key1: value1
     key2: value2
@@ -163,8 +163,8 @@ alerting:
 			Version:      "v2.16.0",
 			QueryLogFile: "test.log",
 			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -101,10 +101,10 @@ alerting:
 		},
 		{
 			Version:        "v2.15.2",
-			ScrapeInterval: "60s",
+			ScrapeInterval: "1m",
 			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 60s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
@@ -431,8 +431,8 @@ func TestProbeStaticTargetsConfigGeneration(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -528,8 +528,8 @@ func TestProbeStaticTargetsConfigGenerationWithLabelEnforce(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -634,8 +634,8 @@ func TestProbeIngressSDConfigGeneration(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -760,8 +760,8 @@ func TestProbeIngressSDConfigGenerationWithLabelEnforce(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -937,8 +937,8 @@ func TestAlertmanagerBearerToken(t *testing.T) {
 	// change this to check that just the `bearer_token_file` is set with
 	// something like json-path.
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -1016,8 +1016,8 @@ func TestAlertmanagerAPIVersion(t *testing.T) {
 	// change this to check that just the `api_version` is set with
 	// something like json-path.
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -1094,8 +1094,8 @@ func TestAdditionalAlertRelabelConfigs(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -1203,8 +1203,8 @@ func TestNoEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: ns-value/test
     prometheus_replica: $(POD_NAME)
@@ -1345,8 +1345,8 @@ func TestEnforcedNamespaceLabelPodMonitor(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: ns-value/test
     prometheus_replica: $(POD_NAME)
@@ -1478,8 +1478,8 @@ func TestEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: ns-value/test
     prometheus_replica: $(POD_NAME)
@@ -1591,8 +1591,8 @@ func TestAdditionalAlertmanagers(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -1684,8 +1684,8 @@ func TestSettingHonorTimestampsInServiceMonitor(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -1811,8 +1811,8 @@ func TestSettingHonorTimestampsInPodMonitor(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -1923,8 +1923,8 @@ func TestHonorTimestampsOverriding(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -2049,8 +2049,8 @@ func TestSettingHonorLabels(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -2174,8 +2174,8 @@ func TestHonorLabelsOverriding(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -2298,8 +2298,8 @@ func TestTargetLabels(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -2422,8 +2422,8 @@ func TestPodTargetLabels(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -2546,8 +2546,8 @@ func TestPodTargetLabelsFromPodMonitor(t *testing.T) {
 	}
 
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
@@ -2649,8 +2649,8 @@ func TestEmptyEndointPorts(t *testing.T) {
 	// change this to check that just the `bearer_token_file` is set with
 	// something like json-path.
 	expected := `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 1m
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)


### PR DESCRIPTION
Both scrapeInterval and evaluationInterval are on 30s. This commit changes this to 1m and updates the tests included with it.

Reason:

- These defaults are not documented for the Prometheus Operator
- These defaults differ from official Prometheus documentation. See: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration