### PR TITLE
Fix probe ingress configs

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -702,9 +702,7 @@ func (cg *configGenerator) generateProbeConfig(
 
 	// Generate kubernetes_sd_config section for ingress resources.
 	if m.Spec.Targets.StaticConfig == nil {
-		var (
-			labelKeys []string
-		)
+		labelKeys := make([]string, 0, len(m.Spec.Targets.Ingress.Selector.MatchLabels))
 
 		// Filter targets by ingresses selected by the monitor.
 		// Exact label matches.
@@ -762,22 +760,6 @@ func (cg *configGenerator) generateProbeConfig(
 			cfg = append(cfg, cg.generateK8SSDConfig(selectedNamespaces, apiserverConfig, basicAuthSecrets, kubernetesSDRoleIngress))
 		}
 
-		// Relabelings for prober.
-		relabelings = append(relabelings, []yaml.MapSlice{
-			{
-				{Key: "source_labels", Value: []string{"__address__"}},
-				{Key: "target_label", Value: "__param_target"},
-			},
-			{
-				{Key: "source_labels", Value: []string{"__param_target"}},
-				{Key: "target_label", Value: "instance"},
-			},
-			{
-				{Key: "target_label", Value: "__address__"},
-				{Key: "replacement", Value: m.Spec.ProberSpec.URL},
-			},
-		}...)
-
 		// Relabelings for ingress SD.
 		relabelings = append(relabelings, []yaml.MapSlice{
 			{
@@ -795,6 +777,22 @@ func (cg *configGenerator) generateProbeConfig(
 			{
 				{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_name"}},
 				{Key: "target_label", Value: "ingress"},
+			},
+		}...)
+
+		// Relabelings for prober.
+		relabelings = append(relabelings, []yaml.MapSlice{
+			{
+				{Key: "source_labels", Value: []string{"__address__"}},
+				{Key: "target_label", Value: "__param_target"},
+			},
+			{
+				{Key: "source_labels", Value: []string{"__param_target"}},
+				{Key: "target_label", Value: "instance"},
+			},
+			{
+				{Key: "target_label", Value: "__address__"},
+				{Key: "replacement", Value: m.Spec.ProberSpec.URL},
 			},
 		}...)
 

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -672,14 +672,6 @@ scrape_configs:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
     regex: "true"
   - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
-  - source_labels:
     - __meta_kubernetes_ingress_scheme
     - __address__
     - __meta_kubernetes_ingress_path
@@ -694,6 +686,14 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_ingress_name
     target_label: ingress
+  - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
   - target_label: foo
     replacement: bar
     action: replace
@@ -803,14 +803,6 @@ scrape_configs:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
     regex: "true"
   - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
-  - source_labels:
     - __meta_kubernetes_ingress_scheme
     - __address__
     - __meta_kubernetes_ingress_path
@@ -825,6 +817,14 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_ingress_name
     target_label: ingress
+  - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
   - target_label: foo
     replacement: bar
     action: replace


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Tried probe with ingress locally and found this problem. The point is that we should put relabeling configs for Blackbox exporter after relabeling configs for Ingress SD, otherwise `__address__` will be changed to proberURL, so it would go wrong here https://github.com/coreos/prometheus-operator/blob/master/pkg/prometheus/promcfg.go#L788.

Verification.

![Screenshot from 2020-07-02 23-13-20](https://user-images.githubusercontent.com/25150124/86427986-a61b4c80-bcb9-11ea-8918-c0c9c6db4678.png)

probe

``` yaml
apiVersion: monitoring.coreos.com/v1
kind: Probe
metadata:
  name: ingress
  namespace: default
  labels:
    probe: test
spec:
  jobName: test
  prober:
    url: blackbox-prometheus-blackbox-exporter:9115
  targets:
    ingress:
      selector:
        matchLabels:
          probe: test
      namespaceSelector:
        matchNames:
        - default
  module: http_2xx
  interval: 15s
```

Ingress

``` yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: test
  namespace: default
  labels:
    probe: test
spec:
  rules:
  - host: example.com
    http:
      paths:
      - path: /
        backend:
          serviceName: prometheus-self
          servicePort: web
```


