### PR TITLE
pkg/prometheus: Ensure relabeling of container label in ServiceMonitors

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -998,6 +998,10 @@ func (cg *configGenerator) generateServiceMonitorConfig(
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_name"}},
 			{Key: "target_label", Value: "pod"},
 		},
+		{
+			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_container_name"}},
+			{Key: "target_label", Value: "container"},
+		},
 	}...)
 
 	// Relabel targetLabels from Service onto target.

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -1277,6 +1277,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
     - __meta_kubernetes_service_name
     target_label: job
     replacement: ${1}
@@ -1552,6 +1555,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
     - __meta_kubernetes_service_name
     target_label: job
     replacement: ${1}
@@ -1754,6 +1760,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
   - source_labels:
     - __meta_kubernetes_service_label_example
     target_label: example
@@ -1994,6 +2003,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
     - __meta_kubernetes_service_label_example
     target_label: example
     regex: (.+)
@@ -2118,6 +2130,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
   - source_labels:
     - __meta_kubernetes_service_label_example
     target_label: example
@@ -2244,6 +2259,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
     - __meta_kubernetes_service_label_example
     target_label: example
     regex: (.+)
@@ -2368,6 +2386,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
     - __meta_kubernetes_service_label_example
     target_label: example
     regex: (.+)
@@ -2491,6 +2512,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
   - source_labels:
     - __meta_kubernetes_pod_label_example
     target_label: example
@@ -2717,6 +2741,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
   - source_labels:
     - __meta_kubernetes_service_name
     target_label: job


### PR DESCRIPTION
PodMonitors already default to relabeling namespace, pod and container
into the target labels. ServiceMonitors should do the same to allow easy
correlation between signals.

@coreos/team-monitoring 