### PR TITLE
Update prometheus compatibility matrix to v2.19.2

### DIFF
--- a/Documentation/compatibility.md
+++ b/Documentation/compatibility.md
@@ -59,6 +59,8 @@ The versions of Prometheus compatible to be run with the Prometheus Operator are
 * v2.18.1
 * v2.18.2
 * v2.19.0
+* v2.19.1
+* v2.19.2
 
 ## Alertmanager
 

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -72,6 +72,8 @@ var (
 		"v2.18.1",
 		"v2.18.2",
 		"v2.19.0",
+		"v2.19.1",
+		"v2.19.2",
 	}
 	DefaultPrometheusVersion   = PrometheusCompatibilityMatrix[len(PrometheusCompatibilityMatrix)-1]
 	DefaultPrometheusBaseImage = "quay.io/prometheus/prometheus"


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Bump to latest release. v2.19.2 contains some bug fixes.