### PR TITLE
reload alertmanager on configmap/secret change

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -435,6 +435,15 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 		},
 	}
 
+	reloadWatchDirs := []string{alertmanagerConfDir}
+	configReloaderVolumeMounts := []v1.VolumeMount{
+		{
+			Name:      "config-volume",
+			MountPath: alertmanagerConfDir,
+			ReadOnly:  true,
+		},
+	}
+
 	for _, s := range a.Spec.Secrets {
 		volumes = append(volumes, v1.Volume{
 			Name: k8sutil.SanitizeVolumeName("secret-" + s),
@@ -444,11 +453,15 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 				},
 			},
 		})
-		amVolumeMounts = append(amVolumeMounts, v1.VolumeMount{
+		mountPath := secretsDir + s
+		mount := v1.VolumeMount{
 			Name:      k8sutil.SanitizeVolumeName("secret-" + s),
 			ReadOnly:  true,
-			MountPath: secretsDir + s,
-		})
+			MountPath: mountPath,
+		}
+		amVolumeMounts = append(amVolumeMounts, mount)
+		configReloaderVolumeMounts = append(configReloaderVolumeMounts, mount)
+		reloadWatchDirs = append(reloadWatchDirs, mountPath)
 	}
 
 	for _, c := range a.Spec.ConfigMaps {
@@ -462,11 +475,15 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 				},
 			},
 		})
-		amVolumeMounts = append(amVolumeMounts, v1.VolumeMount{
+		mountPath := configmapsDir + c
+		mount := v1.VolumeMount{
 			Name:      k8sutil.SanitizeVolumeName("configmap-" + c),
 			ReadOnly:  true,
-			MountPath: configmapsDir + c,
-		})
+			MountPath: mountPath,
+		}
+		amVolumeMounts = append(amVolumeMounts, mount)
+		configReloaderVolumeMounts = append(configReloaderVolumeMounts, mount)
+		reloadWatchDirs = append(reloadWatchDirs, mountPath)
 	}
 
 	amVolumeMounts = append(amVolumeMounts, a.Spec.VolumeMounts...)
@@ -482,6 +499,12 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	terminationGracePeriod := int64(120)
 	finalLabels := config.Labels.Merge(podLabels)
 
+	configReloaderArgs := []string{
+		fmt.Sprintf("-webhook-url=%s", localReloadURL),
+	}
+	for _, reloadWatchDir := range reloadWatchDirs {
+		configReloaderArgs = append(configReloaderArgs, fmt.Sprintf("-volume-dir=%s", reloadWatchDir))
+	}
 	defaultContainers := []v1.Container{
 		{
 			Args:           amArgs,
@@ -505,19 +528,10 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 			},
 			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 		}, {
-			Name:  "config-reloader",
-			Image: config.ConfigReloaderImage,
-			Args: []string{
-				fmt.Sprintf("-webhook-url=%s", localReloadURL),
-				fmt.Sprintf("-volume-dir=%s", alertmanagerConfDir),
-			},
-			VolumeMounts: []v1.VolumeMount{
-				{
-					Name:      "config-volume",
-					ReadOnly:  true,
-					MountPath: alertmanagerConfDir,
-				},
-			},
+			Name:                     "config-reloader",
+			Image:                    config.ConfigReloaderImage,
+			Args:                     configReloaderArgs,
+			VolumeMounts:             configReloaderVolumeMounts,
 			Resources:                resources,
 			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 		},

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -265,6 +265,15 @@ func (f *Framework) GetAlertmanagerStatus(ns, n string) (amAPIStatusResp, error)
 	return amStatus, nil
 }
 
+func (f *Framework) GetAlertmanagerMetrics(ns, n string) ([]string, error) {
+	request := ProxyGetPod(f.KubeClient, ns, n, "/metrics")
+	resp, err := request.DoRaw(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(resp), "\n"), nil
+}
+
 func (f *Framework) CreateSilence(ns, n string) (string, error) {
 	var createSilenceResponse amAPICreateSilResp
 
@@ -385,6 +394,37 @@ func (f *Framework) WaitForAlertmanagerConfigToContainString(ns, amName, expecte
 
 	if err != nil {
 		return fmt.Errorf("failed to wait for alertmanager config to contain %q: %v", expectedString, err)
+	}
+
+	return nil
+}
+
+func (f *Framework) WaitForAlertmanagerConfigToBeReloaded(ns, amName string, previousReloadTimestamp time.Time) error {
+	const configReloadMetricName = "alertmanager_config_last_reload_success_timestamp_seconds"
+	err := wait.Poll(10*time.Second, time.Minute*5, func() (bool, error) {
+		metrics, err := f.GetAlertmanagerMetrics(ns, "alertmanager-"+amName+"-0")
+		if err != nil {
+			return false, err
+		}
+
+		for _, metricLine := range metrics {
+			if !strings.HasPrefix(metricLine, configReloadMetricName) {
+				continue
+			}
+			components := strings.Split(metricLine, " ")
+			timestampSec, err := strconv.ParseFloat(components[1], 64)
+			if err != nil {
+				return false, err
+			}
+			timestamp := time.Unix(int64(timestampSec), 0)
+			return timestamp.After(previousReloadTimestamp), nil
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to wait for alertmanager config to have been reloaded after %v: %v", previousReloadTimestamp, err)
 	}
 
 	return nil


### PR DESCRIPTION
Via the configMaps and secrets fields we can add additional
files that should be mounted into the /etc/alertmanager directory.
These can then be used for templates (e.g. e-mail templates).

If those change we want to reload the alertmanager in order
to urge it to take the changed files into account.

closes #3309

----

I was thinking about how to potentially refine the `testAMReloadConfig` e2e test, but since the reload would not change the config that is exposed in via the API endpoint we could not check against anything. Ultimately the only component we could test against would be a metric, e.g. the Alertmanager config reload timestamp metric (`alertmanager_config_last_reload_success_timestamp_seconds`). I was not really certain whether this is something you would like to have in the test suite. Let me know whether i should aim to add a test for that.