### PR TITLE
pkg/namespace-labeler: fix whitespace

### DIFF
--- a/pkg/namespace-labeler/labeler.go
+++ b/pkg/namespace-labeler/labeler.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package namespacelabeler
 
 import (


### PR DESCRIPTION
There should be an empty line between license header and package
declaration otherwise the license gets interpreted as package
documentation by godoc.