### PR TITLE
listwatch: do not duplicate resource versions

### DIFF
--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
@@ -137,7 +138,7 @@ type multiListerWatcher []cache.ListerWatcher
 // a single result.
 func (mlw multiListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
 	l := metav1.List{}
-	var resourceVersions []string
+	resourceVersions := sets.NewString()
 	for _, lw := range mlw {
 		list, err := lw.List(options)
 		if err != nil {
@@ -154,11 +155,13 @@ func (mlw multiListerWatcher) List(options metav1.ListOptions) (runtime.Object, 
 		for _, item := range items {
 			l.Items = append(l.Items, runtime.RawExtension{Object: item.DeepCopyObject()})
 		}
-		resourceVersions = append(resourceVersions, metaObj.GetResourceVersion())
+		if !resourceVersions.Has(metaObj.GetResourceVersion()) {
+			resourceVersions.Insert(metaObj.GetResourceVersion())
+		}
 	}
 	// Combine the resource versions so that the composite Watch method can
 	// distribute appropriate versions to each underlying Watch func.
-	l.ListMeta.ResourceVersion = strings.Join(resourceVersions, "/")
+	l.ListMeta.ResourceVersion = strings.Join(resourceVersions.List(), "/")
 	return &l, nil
 }
 
@@ -170,8 +173,8 @@ func (mlw multiListerWatcher) Watch(options metav1.ListOptions) (watch.Interface
 	// Allow resource versions to be "".
 	if options.ResourceVersion != "" {
 		rvs := strings.Split(options.ResourceVersion, "/")
-		if len(rvs) != len(mlw) {
-			return nil, fmt.Errorf("expected resource version to have %d parts to match the number of ListerWatchers", len(mlw))
+		if len(rvs) != 1 {
+			return nil, fmt.Errorf("expected resource version to have 1 parts to match the number of ListerWatchers, got %d", len(rvs))
 		}
 		resourceVersions = rvs
 	}
@@ -199,9 +202,9 @@ func newMultiWatch(lws []cache.ListerWatcher, resourceVersions []string, options
 
 	wg.Add(len(lws))
 
-	for i, lw := range lws {
+	for _, lw := range lws {
 		o := options.DeepCopy()
-		o.ResourceVersion = resourceVersions[i]
+		o.ResourceVersion = resourceVersions[0]
 		w, err := lw.Watch(*o)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This fixes a known bug https://github.com/coreos/prometheus-operator/issues/3218 as well as an unknown until the 0.39 release where List and Watch were producing a large amount of errors most likely due to a combination of bumping client-go, using multi namespace watcher and removing the CRD management done by operator. This left the option of the multi list watcher to create a wrong set of resourceVersions because of duplicates, most likely due to large amount of resources filling the cache at startup. As all of these things combined is very rare, even hard to reproduce, which is why this was most likely not experienced by a lot of users, hence lack of bug reports. 

Note: I really want to move away from using a custom multi namespace watcher very soon so did not spend too much time on refactor. https://github.com/coreos/prometheus-operator/issues/3339

This was tested on both vanilla k8s 1.18.3 and more complex setup of OpenShift monitoring where we make heavy use of this feature.

cc @coreos/team-monitoring 

Thanks @mfojtik for the initial fix.

Fixes https://github.com/coreos/prometheus-operator/issues/3218