### PR TITLE
add SecretListWatchSelector to reduce memory and CPU footprint

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -185,6 +185,7 @@ func init() {
 	flagset.StringVar(&cfg.PromSelector, "prometheus-instance-selector", "", "Label selector to filter Prometheus Custom Resources to watch.")
 	flagset.StringVar(&cfg.AlertManagerSelector, "alertmanager-instance-selector", "", "Label selector to filter AlertManager Custom Resources to watch.")
 	flagset.StringVar(&cfg.ThanosRulerSelector, "thanos-ruler-instance-selector", "", "Label selector to filter ThanosRuler Custom Resources to watch.")
+	flagset.StringVar(&cfg.SecretListWatchSelector, "secret-selector", "", "Field selector to filter Secrets to watch")
 }
 
 func Main() int {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -185,7 +185,7 @@ func init() {
 	flagset.StringVar(&cfg.PromSelector, "prometheus-instance-selector", "", "Label selector to filter Prometheus Custom Resources to watch.")
 	flagset.StringVar(&cfg.AlertManagerSelector, "alertmanager-instance-selector", "", "Label selector to filter AlertManager Custom Resources to watch.")
 	flagset.StringVar(&cfg.ThanosRulerSelector, "thanos-ruler-instance-selector", "", "Label selector to filter ThanosRuler Custom Resources to watch.")
-	flagset.StringVar(&cfg.SecretListWatchSelector, "secret-selector", "", "Field selector to filter Secrets to watch")
+	flagset.StringVar(&cfg.SecretListWatchSelector, "secret-field-selector", "", "Field selector to filter Secrets to watch")
 }
 
 func Main() int {


### PR DESCRIPTION
Fixes #3298 

Supersedes #3299 

This PR allows us to set a field selector. This follows the discussion about not wanting an opinionated selector in the code. With this option we can both exclude:
```
--secret-field-selector='type!=helm.sh/release.v1'
```
and select:
```
--secret-field-selector='type=prometheus.io/whatever-we-want'
```

Because this is a field selector, we can chain the selectors using `,`.
The only restriction is that you can't use an OR operator here.

Moreover, the default value (empty string) is equivalent to `fields.Everything` so this is not a breaking change !

⚠️ Note, some errors may come from the WatchList if the Field Selector is valid but refused by the Kube API (for instance: field label <xxx> is not supported)
While they are properly reported, it seems that the Prometheus Operator is still considered "healthy".