### PR TITLE
Bump Prometheus and Thanos versions

### DIFF
--- a/Documentation/compatibility.md
+++ b/Documentation/compatibility.md
@@ -61,6 +61,7 @@ The versions of Prometheus compatible to be run with the Prometheus Operator are
 * v2.19.0
 * v2.19.1
 * v2.19.2
+* v2.20.0
 
 ## Alertmanager
 

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -22,7 +22,7 @@ const (
 	DefaultAlertmanagerVersion    = "v0.21.0"
 	DefaultAlertmanagerBaseImage  = "quay.io/prometheus/alertmanager"
 	DefaultAlertmanagerImage      = DefaultAlertmanagerBaseImage + ":" + DefaultAlertmanagerVersion
-	DefaultThanosVersion          = "v0.12.2"
+	DefaultThanosVersion          = "v0.14.0"
 	DefaultThanosBaseImage        = "quay.io/thanos/thanos"
 	DefaultThanosImage            = DefaultThanosBaseImage + ":" + DefaultThanosVersion
 	DefaultConfigMapReloaderImage = "jimmidyson/configmap-reload:v0.4.0"
@@ -74,6 +74,7 @@ var (
 		"v2.19.0",
 		"v2.19.1",
 		"v2.19.2",
+		"v2.20.0",
 	}
 	DefaultPrometheusVersion   = PrometheusCompatibilityMatrix[len(PrometheusCompatibilityMatrix)-1]
 	DefaultPrometheusBaseImage = "quay.io/prometheus/prometheus"


### PR DESCRIPTION
Prometheus v0.20.0 has been released yesterday. Thanos hadn't been updated in a while so setting it to the latest stable (v0.14.0).