### PR TITLE
Propagate Prometheus image version to statefulset

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -282,11 +282,10 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 	terminationGracePeriod := int64(600)
 
 	baseImage := operator.StringValOrDefault(p.Spec.BaseImage, operator.DefaultPrometheusBaseImage)
-	prometheusImagePath := operator.BuildImagePath(baseImage, p.Spec.Version, p.Spec.Tag, p.Spec.SHA)
-	// An image path specified in the custom resource overrides all other image path settings.
 	if p.Spec.Image != nil && strings.TrimSpace(*p.Spec.Image) != "" {
-		prometheusImagePath = *p.Spec.Image
+		baseImage = *p.Spec.Image
 	}
+	prometheusImagePath := operator.BuildImagePath(baseImage, p.Spec.Version, p.Spec.Tag, p.Spec.SHA)
 
 	promArgs := []string{
 		"-web.console.templates=/etc/prometheus/consoles",

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -579,7 +579,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 		image := "my-reg/prometheus"
 		sset, err := makeStatefulSet(monitoringv1.Prometheus{
 			Spec: monitoringv1.PrometheusSpec{
-				Image:   &image,
+				Image: &image,
 			},
 		}, defaultTestConfig, nil, "")
 		if err != nil {
@@ -596,8 +596,8 @@ func TestTagAndShaAndVersion(t *testing.T) {
 		image := "my-reg/prometheus"
 		sset, err := makeStatefulSet(monitoringv1.Prometheus{
 			Spec: monitoringv1.PrometheusSpec{
-				SHA:     "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
-				Image:   &image,
+				SHA:   "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
+				Image: &image,
 			},
 		}, defaultTestConfig, nil, "")
 		if err != nil {
@@ -614,8 +614,8 @@ func TestTagAndShaAndVersion(t *testing.T) {
 		image := "my-reg/prometheus"
 		sset, err := makeStatefulSet(monitoringv1.Prometheus{
 			Spec: monitoringv1.PrometheusSpec{
-				Tag:     "my-unrelated-tag",
-				Image:   &image,
+				Tag:   "my-unrelated-tag",
+				Image: &image,
 			},
 		}, defaultTestConfig, nil, "")
 		if err != nil {
@@ -632,9 +632,9 @@ func TestTagAndShaAndVersion(t *testing.T) {
 		image := "my-reg/prometheus"
 		sset, err := makeStatefulSet(monitoringv1.Prometheus{
 			Spec: monitoringv1.PrometheusSpec{
-				SHA:     "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
-				Tag:     "my-unrealted-tag",
-				Image:   &image,
+				SHA:   "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
+				Tag:   "my-unrealted-tag",
+				Image: &image,
 			},
 		}, defaultTestConfig, nil, "")
 		if err != nil {

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -499,6 +499,26 @@ func TestTagAndShaAndVersion(t *testing.T) {
 		}
 	}
 	{
+		image := "my-reg/prometheus"
+		sset, err := makeStatefulSet(monitoringv1.Prometheus{
+			Spec: monitoringv1.PrometheusSpec{
+				SHA:     "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
+				Tag:     "my-unrelated-tag",
+				Version: "v2.3.2",
+				Image:   &image,
+			},
+		}, defaultTestConfig, nil, "")
+		if err != nil {
+			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+		}
+
+		resultImage := sset.Spec.Template.Spec.Containers[0].Image
+		expected := "my-reg/prometheus@sha256:7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324"
+		if resultImage != expected {
+			t.Fatalf("Unexpected container image.\n\nExpected: %s\n\nGot: %s", expected, resultImage)
+		}
+	}
+	{
 		image := "my-reg/prometheus:latest"
 		sset, err := makeStatefulSet(monitoringv1.Prometheus{
 			Spec: monitoringv1.PrometheusSpec{
@@ -513,9 +533,118 @@ func TestTagAndShaAndVersion(t *testing.T) {
 		}
 
 		resultImage := sset.Spec.Template.Spec.Containers[0].Image
-		expected := "my-reg/prometheus:latest"
+		expected := "my-reg/prometheus:latest@sha256:7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324"
 		if resultImage != expected {
 			t.Fatalf("Explicit image should have precedence. Unexpected container image.\n\nExpected: %s\n\nGot: %s", expected, resultImage)
+		}
+	}
+	{
+		image := "my-reg/prometheus"
+		sset, err := makeStatefulSet(monitoringv1.Prometheus{
+			Spec: monitoringv1.PrometheusSpec{
+				Version: "v2.3.2",
+				Image:   &image,
+			},
+		}, defaultTestConfig, nil, "")
+		if err != nil {
+			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+		}
+
+		resultImage := sset.Spec.Template.Spec.Containers[0].Image
+		expected := "my-reg/prometheus:v2.3.2"
+		if resultImage != expected {
+			t.Fatalf("Unexpected container image.\n\nExpected: %s\n\nGot: %s", expected, resultImage)
+		}
+	}
+	{
+		image := "my-reg/prometheus"
+		sset, err := makeStatefulSet(monitoringv1.Prometheus{
+			Spec: monitoringv1.PrometheusSpec{
+				SHA:     "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
+				Version: "v2.3.2",
+				Image:   &image,
+			},
+		}, defaultTestConfig, nil, "")
+		if err != nil {
+			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+		}
+
+		resultImage := sset.Spec.Template.Spec.Containers[0].Image
+		expected := "my-reg/prometheus@sha256:7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324"
+		if resultImage != expected {
+			t.Fatalf("Unexpected container image.\n\nExpected: %s\n\nGot: %s", expected, resultImage)
+		}
+	}
+	{
+		image := "my-reg/prometheus"
+		sset, err := makeStatefulSet(monitoringv1.Prometheus{
+			Spec: monitoringv1.PrometheusSpec{
+				Image:   &image,
+			},
+		}, defaultTestConfig, nil, "")
+		if err != nil {
+			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+		}
+
+		resultImage := sset.Spec.Template.Spec.Containers[0].Image
+		expected := "my-reg/prometheus"
+		if resultImage != expected {
+			t.Fatalf("Unexpected container image.\n\nExpected: %s\n\nGot: %s", expected, resultImage)
+		}
+	}
+	{
+		image := "my-reg/prometheus"
+		sset, err := makeStatefulSet(monitoringv1.Prometheus{
+			Spec: monitoringv1.PrometheusSpec{
+				SHA:     "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
+				Image:   &image,
+			},
+		}, defaultTestConfig, nil, "")
+		if err != nil {
+			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+		}
+
+		resultImage := sset.Spec.Template.Spec.Containers[0].Image
+		expected := "my-reg/prometheus@sha256:7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324"
+		if resultImage != expected {
+			t.Fatalf("Unexpected container image.\n\nExpected: %s\n\nGot: %s", expected, resultImage)
+		}
+	}
+	{
+		image := "my-reg/prometheus"
+		sset, err := makeStatefulSet(monitoringv1.Prometheus{
+			Spec: monitoringv1.PrometheusSpec{
+				Tag:     "my-unrelated-tag",
+				Image:   &image,
+			},
+		}, defaultTestConfig, nil, "")
+		if err != nil {
+			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+		}
+
+		resultImage := sset.Spec.Template.Spec.Containers[0].Image
+		expected := "my-reg/prometheus:my-unrelated-tag"
+		if resultImage != expected {
+			t.Fatalf("Unexpected container image.\n\nExpected: %s\n\nGot: %s", expected, resultImage)
+		}
+	}
+	{
+		image := "my-reg/prometheus"
+		sset, err := makeStatefulSet(monitoringv1.Prometheus{
+			Spec: monitoringv1.PrometheusSpec{
+				SHA:     "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
+				Tag:     "my-unrealted-tag",
+				Image:   &image,
+			},
+		}, defaultTestConfig, nil, "")
+		if err != nil {
+			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+		}
+
+		resultImage := sset.Spec.Template.Spec.Containers[0].Image
+		expected := "my-reg/prometheus@sha256:7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324"
+		if resultImage != expected {
+			t.Fatalf("Unexpected container image.\n\nExpected: %s\n\nGot: %s", expected, resultImage)
 		}
 	}
 }


### PR DESCRIPTION

Since `0.35.0` release, some fields have been deprecated:

- `spec.baseImage`
- `spec.tag`
- `spec.sha`

In code, pkg/prometheus/statefulset.go line 284 and later, operator build prometheusImagePath using deprecated fields and spec.Version. At line 287, if spec.Image is defined, operator will simply replace prometheusImagePath value with spec.Image value.

This skip the version, which is not propagated anymore to statefulset definition.
This patch intends to be able to use either version or tag information to set Prometheus version for statefulset.
This brings back the old behaviour while keeping the deprecation mechanism