### PR TITLE
pkg: instrument resources being tracked by the operator

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -135,6 +135,8 @@ func New(c prometheusoperator.Config, logger log.Logger, r prometheus.Registerer
 		&monitoringv1.Alertmanager{}, resyncPeriod, cache.Indexers{},
 	)
 	o.metrics.MustRegister(NewAlertmanagerCollector(o.alrtInf.GetStore()))
+	o.metrics.MustRegister(operator.NewStoreCollector("alertmanager", o.alrtInf.GetStore()))
+
 	o.ssetInf = cache.NewSharedIndexInformer(
 		o.metrics.NewInstrumentedListerWatcher(
 			listwatch.MultiNamespaceListerWatcher(o.logger, o.config.Namespaces.AlertmanagerAllowList, o.config.Namespaces.DenyList, func(namespace string) cache.ListerWatcher {

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -267,6 +267,7 @@ func New(conf Config, logger log.Logger, r prometheus.Registerer) (*Operator, er
 		&monitoringv1.Prometheus{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	c.metrics.MustRegister(NewPrometheusCollector(c.promInf.GetStore()))
+	c.metrics.MustRegister(operator.NewStoreCollector("prometheus", c.promInf.GetStore()))
 
 	c.smonInf = cache.NewSharedIndexInformer(
 		c.metrics.NewInstrumentedListerWatcher(
@@ -283,6 +284,7 @@ func New(conf Config, logger log.Logger, r prometheus.Registerer) (*Operator, er
 		),
 		&monitoringv1.ServiceMonitor{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
+	c.metrics.MustRegister(operator.NewStoreCollector("servicemonitor", c.smonInf.GetStore()))
 
 	c.pmonInf = cache.NewSharedIndexInformer(
 		c.metrics.NewInstrumentedListerWatcher(
@@ -299,6 +301,7 @@ func New(conf Config, logger log.Logger, r prometheus.Registerer) (*Operator, er
 		),
 		&monitoringv1.PodMonitor{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
+	c.metrics.MustRegister(operator.NewStoreCollector("podmonitor", c.pmonInf.GetStore()))
 
 	c.probeInf = cache.NewSharedIndexInformer(
 		c.metrics.NewInstrumentedListerWatcher(
@@ -315,6 +318,7 @@ func New(conf Config, logger log.Logger, r prometheus.Registerer) (*Operator, er
 		),
 		&monitoringv1.Probe{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
+	c.metrics.MustRegister(operator.NewStoreCollector("probe", c.probeInf.GetStore()))
 
 	c.ruleInf = cache.NewSharedIndexInformer(
 		c.metrics.NewInstrumentedListerWatcher(
@@ -331,6 +335,7 @@ func New(conf Config, logger log.Logger, r prometheus.Registerer) (*Operator, er
 		),
 		&monitoringv1.PrometheusRule{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
+	c.metrics.MustRegister(operator.NewStoreCollector("prometheurule", c.ruleInf.GetStore()))
 
 	c.cmapInf = cache.NewSharedIndexInformer(
 		c.metrics.NewInstrumentedListerWatcher(

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -174,6 +174,8 @@ func New(conf prometheusoperator.Config, logger log.Logger, r prometheus.Registe
 	)
 
 	o.metrics.MustRegister(NewThanosRulerCollector(o.thanosRulerInf.GetStore()))
+	o.metrics.MustRegister(operator.NewStoreCollector("thanosruler", o.thanosRulerInf.GetStore()))
+
 	o.ruleInf = cache.NewSharedIndexInformer(
 		o.metrics.NewInstrumentedListerWatcher(
 			listwatch.MultiNamespaceListerWatcher(o.logger, o.config.Namespaces.AllowList, o.config.Namespaces.DenyList, func(namespace string) cache.ListerWatcher {
@@ -189,6 +191,7 @@ func New(conf prometheusoperator.Config, logger log.Logger, r prometheus.Registe
 		),
 		&monitoringv1.PrometheusRule{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
+	o.metrics.MustRegister(operator.NewStoreCollector("prometheusrule", o.thanosRulerInf.GetStore()))
 
 	o.ssetInf = cache.NewSharedIndexInformer(
 		listwatch.MultiNamespaceListerWatcher(o.logger, o.config.Namespaces.ThanosRulerAllowList, o.config.Namespaces.DenyList, func(namespace string) cache.ListerWatcher {


### PR DESCRIPTION
This change adds a new `prometheus_operator_resources` metric that keeps
track of the number of resources currently managed by the operator. The
metric is broken down by controller and type of resource.