### PR TITLE
test/framework: fix prometheus active targets polling

### DIFF
--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -160,7 +160,7 @@ func testDenyServiceMonitor(t *testing.T) {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 
-		if err := framework.WaitForTargets(allowed, svc.Name, 1); err != nil {
+		if err := framework.WaitForActiveTargets(allowed, svc.Name, 1); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -177,7 +177,7 @@ func testPrometheusInstanceNamespaces_DenyList(t *testing.T) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 
-	if err := framework.WaitForTargets(instanceNs, "prometheus-instance", 0); err != nil {
+	if err := framework.WaitForActiveTargets(instanceNs, "prometheus-instance", 0); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -292,7 +292,7 @@ func testPrometheusInstanceNamespaces_AllowList(t *testing.T) {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 
-		if err := framework.WaitForTargets(instanceNs, "prometheus-instance", 1); err != nil {
+		if err := framework.WaitForActiveTargets(instanceNs, "prometheus-instance", 1); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -2481,7 +2481,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 			},
 			endpoint: monitoringv1.Endpoint{
 				Port:            "web",
-				BearerTokenFile: "abc",
+				BearerTokenFile: "/etc/ca-certificates/bearer-token",
 			},
 			expectTargets: true,
 		},
@@ -2492,7 +2492,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 			},
 			endpoint: monitoringv1.Endpoint{
 				Port:            "web",
-				BearerTokenFile: "abc",
+				BearerTokenFile: "/etc/ca-certificates/bearer-token",
 			},
 			expectTargets: false,
 		},

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -2218,13 +2218,15 @@ func testPromGetAuthSecret(t *testing.T) {
 					},
 					Key: "bearertoken",
 				}
-				sm.Spec.Endpoints[0].Path = "/bearer-token"
+				sm.Spec.Endpoints[0].Path = "/bearer-metrics"
 				return sm
 			},
 		},
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := framework.NewTestCtx(t)

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -293,7 +293,7 @@ func createK8sAppMonitoring(t *testing.T, name, ns string, prwtc testFramework.P
 
 	// Check for proper scraping.
 
-	if err := framework.WaitForTargets(ns, promSVC.Name, 1); err != nil {
+	if err := framework.WaitForHealthyTargets(ns, promSVC.Name, 1); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1118,7 +1118,7 @@ scrape_configs:
 		ctx.AddFinalizerFn(finalizerFn)
 	}
 
-	if err := framework.WaitForTargets(ns, svc.Name, 1); err != nil {
+	if err := framework.WaitForActiveTargets(ns, svc.Name, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1150,7 +1150,7 @@ scrape_configs:
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForTargets(ns, svc.Name, 2); err != nil {
+	if err := framework.WaitForActiveTargets(ns, svc.Name, 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1208,7 +1208,7 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 	}
 
 	// Wait for ServiceMonitor target, as well as additional-config target
-	if err := framework.WaitForTargets(ns, svc.Name, 2); err != nil {
+	if err := framework.WaitForActiveTargets(ns, svc.Name, 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1267,7 +1267,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 	}
 
 	// Wait for ServiceMonitor target
-	if err := framework.WaitForTargets(ns, svc.Name, 1); err != nil {
+	if err := framework.WaitForActiveTargets(ns, svc.Name, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2298,7 +2298,7 @@ func testPromGetAuthSecret(t *testing.T) {
 				t.Fatal("Creating ServiceMonitor failed: ", err)
 			}
 
-			if err := framework.WaitForTargets(ns, "prometheus-operated", 1); err != nil {
+			if err := framework.WaitForHealthyTargets(ns, "prometheus-operated", 1); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -2778,7 +2778,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 			}
 
 			if test.expectTargets {
-				if err := framework.WaitForTargets(ns, svc.Name, 1); err != nil {
+				if err := framework.WaitForActiveTargets(ns, svc.Name, 1); err != nil {
 					t.Fatal(err)
 				}
 
@@ -2787,7 +2787,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 
 			// Make sure Prometheus has enough time to reload.
 			time.Sleep(2 * time.Minute)
-			if err := framework.WaitForTargets(ns, svc.Name, 0); err != nil {
+			if err := framework.WaitForActiveTargets(ns, svc.Name, 0); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -2969,7 +2969,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 	// Check for proper scraping.
 	//
 
-	if err := framework.WaitForTargets(ns, promSVC.Name, 1); err != nil {
+	if err := framework.WaitForHealthyTargets(ns, promSVC.Name, 1); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -324,7 +324,8 @@ func promImage(version string) string {
 	return fmt.Sprintf("quay.io/prometheus/prometheus:%s", version)
 }
 
-func (f *Framework) WaitForTargets(ns, svcName string, amount int) error {
+// WaitForActiveTargets waits for a number of targets to be configured.
+func (f *Framework) WaitForActiveTargets(ns, svcName string, amount int) error {
 	var targets []*Target
 
 	if err := wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
@@ -340,7 +341,31 @@ func (f *Framework) WaitForTargets(ns, svcName string, amount int) error {
 
 		return false, nil
 	}); err != nil {
-		return fmt.Errorf("waiting for targets timed out. %v of %v targets found. %v", len(targets), amount, err)
+		return fmt.Errorf("waiting for active targets timed out. %v of %v active targets found. %v", len(targets), amount, err)
+	}
+
+	return nil
+}
+
+// WaitForHealthyTargets waits for a number of targets to be configured and
+// healthy.
+func (f *Framework) WaitForHealthyTargets(ns, svcName string, amount int) error {
+	var targets []*Target
+
+	if err := wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
+		var err error
+		targets, err = f.GetHealthyTargets(ns, svcName)
+		if err != nil {
+			return false, err
+		}
+
+		if len(targets) == amount {
+			return true, nil
+		}
+
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("waiting for healthy targets timed out. %v of %v healthy targets found. %v", len(targets), amount, err)
 	}
 
 	return nil
@@ -443,12 +468,16 @@ func (f *Framework) GetActiveTargets(ns, svcName string) ([]*Target, error) {
 		return nil, err
 	}
 
-	return getHealthyTargets(rt.Data.ActiveTargets)
+	return rt.Data.ActiveTargets, nil
 }
 
-func getHealthyTargets(targets []*Target) ([]*Target, error) {
-	healthyTargets := make([]*Target, 0, len(targets))
+func (f *Framework) GetHealthyTargets(ns, svcName string) ([]*Target, error) {
+	targets, err := f.GetActiveTargets(ns, svcName)
+	if err != nil {
+		return nil, err
+	}
 
+	healthyTargets := make([]*Target, 0, len(targets))
 	for _, target := range targets {
 		switch target.Health {
 		case healthGood:


### PR DESCRIPTION
In order to check if prometheus is able to scrape a target, we are
querying the /api/v1/targets endpoint and checking if the number of
active targets is equal to the one we expect. However, active targets
displayed by the API can sometimes be unhealthy. For example, when the
scraped target responds 401 Unauthorized, the target is still considered
active but its health will be set to "down". Because of that,
unauthorized scrapes will be considered valid in the tests.

Thus, in order to verify that prometheus is allowed to scrape a target,
we also need to check if it is healthy.

Example of active target being down:
```json
{
    "status": "success",
    "data": {
        "activeTargets": [
            {
                "..."
                "lastError": "server returned HTTP status 401 Unauthorized",
                "lastScrape": "2020-07-24T09:54:42.018550304Z",
                "lastScrapeDuration": 0.001038429,
                "health": "down"
            }
        ],
    }
}

```
