### PR TITLE
test/e2e: fix scraping path in bearer-token test

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -2218,13 +2218,15 @@ func testPromGetAuthSecret(t *testing.T) {
 					},
 					Key: "bearertoken",
 				}
-				sm.Spec.Endpoints[0].Path = "/bearer-token"
+				sm.Spec.Endpoints[0].Path = "/bearer-metrics"
 				return sm
 			},
 		},
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := framework.NewTestCtx(t)


### PR DESCRIPTION
Fix the metrics scraping path of the bearer token e2e test to match the [endpoint](https://github.com/coreos/prometheus-operator/blob/master/test/instrumented-sample-app/main.go#L59-L68) of the sample app.