### PR TITLE
🐛 Don't overwrite __param_target

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -787,10 +787,6 @@ func (cg *configGenerator) generateProbeConfig(
 		// Relabelings for prober.
 		relabelings = append(relabelings, []yaml.MapSlice{
 			{
-				{Key: "source_labels", Value: []string{"__address__"}},
-				{Key: "target_label", Value: "__param_target"},
-			},
-			{
 				{Key: "source_labels", Value: []string{"__param_target"}},
 				{Key: "target_label", Value: "instance"},
 			},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -788,9 +788,6 @@ scrape_configs:
     - __meta_kubernetes_ingress_name
     target_label: ingress
   - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
     - __param_target
     target_label: instance
   - target_label: __address__
@@ -917,9 +914,6 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_ingress_name
     target_label: ingress
-  - source_labels:
-    - __address__
-    target_label: __param_target
   - source_labels:
     - __param_target
     target_label: instance


### PR DESCRIPTION
It is already set above using the sd metadata, no need to overwrite it back to __address__.